### PR TITLE
docs: sync explore markets in public api reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The API gives you programmatic access to the same intelligence powering the [0xi
 - **Trader** — grades (S through F), P&L, win rate, strategy detection
 - **Leaderboard** — top traders ranked by score with cursor pagination
 - **Whale Trades** — large trades with signal scoring, filterable by grade and category
+- **Explore Markets** — browse whale-active markets by category, platform, status, and sort order
 - **Market Intel** — smart money flow direction, buy/sell volumes, top positions
 - **Search Markets** — find markets by keyword with category and status filters
 - **Insider Radar** — suspicious trading patterns and pre-resolution accumulation

--- a/api-reference/endpoint/explore-markets.mdx
+++ b/api-reference/endpoint/explore-markets.mdx
@@ -1,0 +1,4 @@
+---
+title: "Explore Markets"
+openapi: "GET /api/v1/markets/explore"
+---

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -246,6 +246,83 @@
         }
       }
     },
+    "/api/v1/markets/explore": {
+      "get": {
+        "operationId": "explore_markets",
+        "summary": "Explore markets",
+        "description": "Browse whale-active markets with category, platform, status, and keyword filters. Returns a grouped discovery feed where entries are either standalone markets or event groups.",
+        "tags": ["Markets"],
+        "parameters": [
+          {
+            "name": "category",
+            "in": "query",
+            "description": "Filter by inferred market category.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by market status.",
+            "schema": { "type": "string", "enum": ["active", "closed", "all"], "default": "all" }
+          },
+          {
+            "name": "platform",
+            "in": "query",
+            "description": "Filter by source platform.",
+            "schema": { "type": "string", "enum": ["polymarket", "kalshi", "all"], "default": "all" }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sort order for the discovery feed.",
+            "schema": { "type": "string", "enum": ["trending", "whales", "volume", "newest"], "default": "trending" }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque pagination cursor from the previous response.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Page size.",
+            "schema": { "type": "integer", "minimum": 1, "maximum": 48, "default": 24 }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Keyword search against market titles.",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Grouped market discovery results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["object", "data", "has_more", "meta"],
+                  "properties": {
+                    "object": { "type": "string", "const": "list" },
+                    "data": { "type": "array", "items": { "$ref": "#/components/schemas/ExploreEntry" } },
+                    "has_more": { "type": "boolean" },
+                    "next_cursor": { "type": "string", "nullable": true },
+                    "total": { "type": "integer", "nullable": true },
+                    "meta": { "$ref": "#/components/schemas/ResponseMeta" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "402": { "$ref": "#/components/responses/SubscriptionRequired" },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      }
+    },
     "/api/v1/market/{condition_id}/intel": {
       "get": {
         "operationId": "get_market_intel",
@@ -388,7 +465,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "API key: Authorization: Bearer oxi_sk_test_..."
+        "description": "API key: Authorization: Bearer oxi_sk_live_..."
       }
     },
     "schemas": {
@@ -439,8 +516,34 @@
               "confidence": { "type": "number", "nullable": true }
             }
           },
-          "category_strengths": { "nullable": true, "description": "Category performance breakdown (expand[]=categories)." },
-          "quant_metrics": { "nullable": true, "description": "Advanced metrics — Sharpe, Sortino, max drawdown (expand[]=quant_metrics)." },
+          "category_strengths": {
+            "type": "array",
+            "nullable": true,
+            "description": "Category performance breakdown (expand[]=categories). Null unless expanded.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "category": { "type": "string" },
+                "grade": { "type": "string", "nullable": true },
+                "rank": { "type": "integer", "nullable": true },
+                "markets": { "type": "integer", "nullable": true },
+                "pnl": { "type": "number", "nullable": true }
+              }
+            }
+          },
+          "quant_metrics": {
+            "type": "object",
+            "nullable": true,
+            "description": "Advanced risk/performance metrics (expand[]=quant_metrics). Null unless expanded.",
+            "properties": {
+              "sharpe_ratio": { "type": "number", "nullable": true, "description": "Risk-adjusted return (annualized)" },
+              "sortino_ratio": { "type": "number", "nullable": true, "description": "Downside risk-adjusted return" },
+              "max_drawdown": { "type": "number", "nullable": true, "description": "Largest peak-to-trough decline (0.0-1.0)" },
+              "profit_factor": { "type": "number", "nullable": true, "description": "Gross profit / gross loss" },
+              "kelly_fraction": { "type": "number", "nullable": true, "description": "Optimal bet size (Kelly criterion)" },
+              "sharpe_percentile": { "type": "number", "nullable": true, "description": "Percentile rank among all traders" }
+            }
+          },
           "last_active": { "type": "string", "format": "date-time", "nullable": true },
           "synced_at": { "type": "string", "format": "date-time", "nullable": true },
           "sync_status": { "type": "string", "nullable": true, "description": "synced, unknown, or pending." }
@@ -508,6 +611,85 @@
           "category": { "type": "string", "nullable": true },
           "platform": { "type": "string", "nullable": true },
           "status": { "type": "string", "enum": ["active", "resolved"] }
+        }
+      },
+      "ExploreMarket": {
+        "type": "object",
+        "required": ["id", "condition_id", "title", "status"],
+        "properties": {
+          "id": { "type": "string" },
+          "condition_id": { "type": "string" },
+          "title": { "type": "string" },
+          "slug": { "type": "string", "nullable": true, "description": "Provider-native market slug." },
+          "url_slug": { "type": "string", "nullable": true, "description": "First-party market page slug used for internal links." },
+          "image": { "type": "string", "nullable": true },
+          "icon": { "type": "string", "nullable": true },
+          "category": { "type": "string", "nullable": true },
+          "platform": { "type": "string", "nullable": true },
+          "status": { "type": "string", "enum": ["active", "resolved"] },
+          "volume": { "type": "number", "nullable": true },
+          "liquidity": { "type": "number", "nullable": true },
+          "whale_trade_count": { "type": "integer", "nullable": true },
+          "whale_distinct_wallets": { "type": "integer", "nullable": true },
+          "whale_total_usd": { "type": "number", "nullable": true },
+          "whale_last_trade_at": { "type": "string", "format": "date-time", "nullable": true },
+          "end_date": { "type": "string", "format": "date-time", "nullable": true },
+          "created_at": { "type": "string", "format": "date-time", "nullable": true },
+          "outcome_yes": { "type": "string", "nullable": true },
+          "outcome_no": { "type": "string", "nullable": true },
+          "event_slug": { "type": "string", "nullable": true },
+          "kalshi_series_slug": { "type": "string", "nullable": true },
+          "smart_score": { "type": "number", "nullable": true },
+          "smart_count": { "type": "integer", "nullable": true },
+          "smart_label": { "type": "string", "nullable": true },
+          "open_interest": { "type": "number", "nullable": true },
+          "oi_change_pct": { "type": "number", "nullable": true },
+          "price_points": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "items": { "type": "number" }
+            }
+          }
+        }
+      },
+      "ExploreGroup": {
+        "type": "object",
+        "required": ["type", "event_slug", "parent_title", "markets"],
+        "properties": {
+          "type": { "type": "string", "const": "group" },
+          "event_slug": { "type": "string" },
+          "parent_title": { "type": "string" },
+          "image": { "type": "string", "nullable": true },
+          "platform": { "type": "string", "nullable": true },
+          "category": { "type": "string", "nullable": true },
+          "markets": { "type": "array", "items": { "$ref": "#/components/schemas/ExploreMarket" } },
+          "rep_volume": { "type": "number", "nullable": true },
+          "rep_whales": { "type": "integer", "nullable": true }
+        }
+      },
+      "ExploreStandalone": {
+        "type": "object",
+        "required": ["type", "market"],
+        "properties": {
+          "type": { "type": "string", "const": "standalone" },
+          "market": { "$ref": "#/components/schemas/ExploreMarket" }
+        }
+      },
+      "ExploreEntry": {
+        "oneOf": [
+          { "$ref": "#/components/schemas/ExploreGroup" },
+          { "$ref": "#/components/schemas/ExploreStandalone" }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "group": "#/components/schemas/ExploreGroup",
+            "standalone": "#/components/schemas/ExploreStandalone"
+          }
         }
       },
       "MarketIntel": {

--- a/docs.json
+++ b/docs.json
@@ -59,6 +59,7 @@
             "group": "Markets",
             "pages": [
               "api-reference/endpoint/search-markets",
+              "api-reference/endpoint/explore-markets",
               "api-reference/endpoint/get-market-intel"
             ]
           },
@@ -119,9 +120,9 @@
     "baseUrl": "https://api.0xinsider.com",
     "auth": {
       "method": "bearer"
-    }
+    },
+    "openapi": "api-reference/openapi.json"
   },
-  "openapi": "/api-reference/openapi.json",
   "chat": {
     "enabled": false
   },

--- a/index.mdx
+++ b/index.mdx
@@ -22,6 +22,9 @@ The 0xinsider API gives you programmatic access to the same intelligence powerin
   <Card title="Whale Trades" icon="whale" href="/api-reference/endpoint/get-whale-trades">
     Large trades with signal scoring, filterable by grade and category
   </Card>
+  <Card title="Explore Markets" icon="compass" href="/api-reference/endpoint/explore-markets">
+    Browse whale-active markets by category, platform, status, and sort order
+  </Card>
   <Card title="Market Intel" icon="chart-mixed" href="/api-reference/endpoint/get-market-intel">
     Smart money flow direction, buy/sell volumes, top positions
   </Card>


### PR DESCRIPTION
## Summary
- add `Explore Markets` to the public API docs navigation and landing page
- add a dedicated Mintlify endpoint page for `GET /api/v1/markets/explore`
- sync `api-reference/openapi.json` from the current app `origin/dev` spec
- move OpenAPI config to `api.openapi` in `docs.json` so Mint CLI validates the spec cleanly
- update the docs repo README endpoint list to include Explore Markets

## Why
`GET /api/v1/markets/explore` was already shipped in the app repo and exposed in the hosted OpenAPI spec there, but the separate Mintlify docs repo still omitted the endpoint and still used an outdated OpenAPI config shape in `docs.json`.

## Verification
- `jq '.openapi, (.paths["/api/v1/markets/explore"] != null), (.components.schemas.ExploreEntry != null)' api-reference/openapi.json`
- `mint openapi-check api-reference/openapi.json`
- `mint broken-links`
