### PR TITLE
docs: clarify explore market title invariant

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The API gives you programmatic access to the same intelligence powering the [0xi
 - **Trader** — grades (S through F), P&L, win rate, strategy detection
 - **Leaderboard** — top traders ranked by score with cursor pagination
 - **Whale Trades** — large trades with signal scoring, filterable by grade and category
-- **Explore Markets** — browse whale-active markets by category, platform, status, and sort order
+- **Explore Markets** — browse whale-active titled markets by category, platform, status, and sort order
 - **Market Intel** — smart money flow direction, buy/sell volumes, top positions
 - **Search Markets** — find markets by keyword with category and status filters
 - **Insider Radar** — suspicious trading patterns and pre-resolution accumulation

--- a/api-reference/endpoint/explore-markets.mdx
+++ b/api-reference/endpoint/explore-markets.mdx
@@ -2,3 +2,5 @@
 title: "Explore Markets"
 openapi: "GET /api/v1/markets/explore"
 ---
+
+Returns whale-active markets with non-empty titles, grouped into standalone entries or event-level clusters for discovery surfaces.

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -250,7 +250,7 @@
       "get": {
         "operationId": "explore_markets",
         "summary": "Explore markets",
-        "description": "Browse whale-active markets with category, platform, status, and keyword filters. Returns a grouped discovery feed where entries are either standalone markets or event groups.",
+        "description": "Browse whale-active titled markets with category, platform, status, and keyword filters. Returns a grouped discovery feed where entries are either standalone markets or event groups.",
         "tags": ["Markets"],
         "parameters": [
           {
@@ -619,7 +619,7 @@
         "properties": {
           "id": { "type": "string" },
           "condition_id": { "type": "string" },
-          "title": { "type": "string" },
+          "title": { "type": "string", "minLength": 1, "description": "Non-empty market title." },
           "slug": { "type": "string", "nullable": true, "description": "Provider-native market slug." },
           "url_slug": { "type": "string", "nullable": true, "description": "First-party market page slug used for internal links." },
           "image": { "type": "string", "nullable": true },

--- a/index.mdx
+++ b/index.mdx
@@ -23,7 +23,7 @@ The 0xinsider API gives you programmatic access to the same intelligence powerin
     Large trades with signal scoring, filterable by grade and category
   </Card>
   <Card title="Explore Markets" icon="compass" href="/api-reference/endpoint/explore-markets">
-    Browse whale-active markets by category, platform, status, and sort order
+    Browse whale-active titled markets by category, platform, status, and sort order
   </Card>
   <Card title="Market Intel" icon="chart-mixed" href="/api-reference/endpoint/get-market-intel">
     Smart money flow direction, buy/sell volumes, top positions


### PR DESCRIPTION
## Summary
- sync the public OpenAPI file from the main repo after `bf9a23ae`
- clarify that Explore Markets returns whale-active titled markets
- document the non-empty title invariant on the endpoint page and landing copy

## Verify
- `jq empty api-reference/openapi.json`
- `mint openapi-check api-reference/openapi.json`
- `mint broken-links`