### PR TITLE
fix: align API docs examples with live auth contract

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -12,10 +12,10 @@ https://api.0xinsider.com/api/v1/
 
 ## Authentication
 
-All endpoints (except `/health`) require a Bearer token:
+All endpoints (except `/api/v1/health`) require a Bearer token:
 
 ```bash
-Authorization: Bearer oxi_sk_test_...
+Authorization: Bearer oxi_sk_live_...
 ```
 
 Generate your key at [0xinsider.com/developers](https://0xinsider.com/developers).

--- a/authentication.mdx
+++ b/authentication.mdx
@@ -8,7 +8,7 @@ description: "API key management and security."
 All authenticated endpoints require a Bearer token in the `Authorization` header:
 
 ```bash
-Authorization: Bearer oxi_sk_test_...
+Authorization: Bearer oxi_sk_live_...
 ```
 
 ### Key format
@@ -54,7 +54,7 @@ API access is bundled with the **Insider** subscription ($89/mo). Requests with 
   "error": {
     "code": "subscription_required",
     "message": "Active Insider subscription required.",
-    "doc_url": "https://0xinsider.com/docs/api#authentication"
+    "doc_url": "https://docs.0xinsider.com/api-reference/introduction#authentication"
   }
 }
 ```

--- a/concepts/grades.mdx
+++ b/concepts/grades.mdx
@@ -33,7 +33,7 @@ The leaderboard only includes traders with grades S, A, or B.
 ### Filter whale trades by grade
 
 ```bash
-curl -H "Authorization: Bearer oxi_sk_test_..." \
+curl -H "Authorization: Bearer oxi_sk_live_..." \
   "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&limit=10"
 ```
 
@@ -42,6 +42,6 @@ This returns only trades from traders with grade A or better (S and A).
 ### Filter leaderboard by strategy
 
 ```bash
-curl -H "Authorization: Bearer oxi_sk_test_..." \
+curl -H "Authorization: Bearer oxi_sk_live_..." \
   "https://api.0xinsider.com/api/v1/leaderboard?strategy=swing_trader"
 ```

--- a/concepts/pagination.mdx
+++ b/concepts/pagination.mdx
@@ -10,7 +10,7 @@ All list endpoints use **cursor-based pagination**. This is more reliable than o
 1. Make your first request with a `limit`:
 
 ```bash
-curl -H "Authorization: Bearer oxi_sk_test_..." \
+curl -H "Authorization: Bearer oxi_sk_live_..." \
   "https://api.0xinsider.com/api/v1/leaderboard?limit=20"
 ```
 
@@ -28,7 +28,7 @@ curl -H "Authorization: Bearer oxi_sk_test_..." \
 3. Pass `next_cursor` as the `cursor` param for the next page:
 
 ```bash
-curl -H "Authorization: Bearer oxi_sk_test_..." \
+curl -H "Authorization: Bearer oxi_sk_live_..." \
   "https://api.0xinsider.com/api/v1/leaderboard?limit=20&cursor=95.85_0x885..."
 ```
 

--- a/errors.mdx
+++ b/errors.mdx
@@ -13,7 +13,7 @@ All errors follow a consistent envelope (RFC 7807-inspired):
   "error": {
     "code": "invalid_api_key",
     "message": "Invalid or missing API key.",
-    "doc_url": "https://0xinsider.com/docs/api#authentication",
+    "doc_url": "https://docs.0xinsider.com/api-reference/introduction#authentication",
     "param": null
   },
   "meta": {
@@ -39,7 +39,7 @@ All errors follow a consistent envelope (RFC 7807-inspired):
 
 ### "Invalid or missing API key"
 
-- Verify the `Authorization` header format: `Bearer oxi_sk_test_...`
+- Verify the `Authorization` header format: `Bearer oxi_sk_live_...`
 - Check that the key hasn't been revoked at [0xinsider.com/developers](https://0xinsider.com/developers)
 - Keys are 76 characters total — ensure you copied the full key
 

--- a/index.mdx
+++ b/index.mdx
@@ -42,7 +42,7 @@ The 0xinsider API gives you programmatic access to the same intelligence powerin
 ## Quick example
 
 ```bash
-curl -H "Authorization: Bearer oxi_sk_test_..." \
+curl -H "Authorization: Bearer oxi_sk_live_..." \
   https://api.0xinsider.com/api/v1/leaderboard?limit=3
 ```
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -22,7 +22,7 @@ API access requires an active [Insider subscription](https://0xinsider.com/prici
 ## 2. Make your first request
 
 ```bash
-curl -H "Authorization: Bearer oxi_sk_test_YOUR_KEY" \
+curl -H "Authorization: Bearer oxi_sk_live_YOUR_KEY" \
   https://api.0xinsider.com/api/v1/health
 ```
 
@@ -37,21 +37,21 @@ curl -H "Authorization: Bearer oxi_sk_test_YOUR_KEY" \
 ## 3. Fetch the leaderboard
 
 ```bash
-curl -H "Authorization: Bearer oxi_sk_test_YOUR_KEY" \
+curl -H "Authorization: Bearer oxi_sk_live_YOUR_KEY" \
   "https://api.0xinsider.com/api/v1/leaderboard?limit=5"
 ```
 
 ## 4. Look up a trader
 
 ```bash
-curl -H "Authorization: Bearer oxi_sk_test_YOUR_KEY" \
+curl -H "Authorization: Bearer oxi_sk_live_YOUR_KEY" \
   https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53
 ```
 
 ## 5. Get whale trades
 
 ```bash
-curl -H "Authorization: Bearer oxi_sk_test_YOUR_KEY" \
+curl -H "Authorization: Bearer oxi_sk_live_YOUR_KEY" \
   "https://api.0xinsider.com/api/v1/whale-trades?limit=10&min_grade=A"
 ```
 

--- a/rate-limits.mdx
+++ b/rate-limits.mdx
@@ -39,7 +39,7 @@ When you exceed the limit, you'll receive a `429` response:
   "error": {
     "code": "rate_limited",
     "message": "Rate limit exceeded. Retry after 12s.",
-    "doc_url": "https://0xinsider.com/docs/api#rate-limits"
+    "doc_url": "https://docs.0xinsider.com/api-reference/introduction#rate-limits"
   }
 }
 ```


### PR DESCRIPTION
## Summary
- replace stale `oxi_sk_test_...` examples with the live `oxi_sk_live_...` key prefix across the public API docs
- fix authentication and rate-limit `doc_url` examples so they point at the current Mintlify reference instead of the dead `0xinsider.com/docs/api` path
- keep the introduction copy aligned with the shipped API contract by naming `/api/v1/health` as the only unauthenticated endpoint

## Why
The live app/API PR now points client-facing errors at `docs.0xinsider.com`, but the Mintlify repo still showed the retired key prefix and dead docs URLs. That mismatch would keep sending external users to stale examples even after the app-side PR ships.

## Affected surfaces
- homepage quick example
- API introduction and authentication pages
- quickstart, errors, rate limits, pagination, and grades concept pages

## Verification
- `rg -n 'oxi_sk_test_|0xinsider.com/docs/api#authentication|0xinsider.com/docs/api#rate-limits' /Users/trevor.lasn/Work/docs -S` => no matches
- `cd /Users/trevor.lasn/Work/docs && mint broken-links` => `success no broken links found`

## Commit Log
### 4412d80 - fix: align api docs examples with live auth contract
- changed: `index.mdx`, `api-reference/introduction.mdx`, `authentication.mdx`, `quickstart.mdx`, `errors.mdx`, `rate-limits.mdx`, `concepts/pagination.mdx`, and `concepts/grades.mdx`.
- why: the public docs site still showed the retired test-key prefix and dead docs URLs even though the shipped API contract now uses `oxi_sk_live_...` and points error docs at the Mintlify reference.
- affects: external users reading `docs.0xinsider.com` for auth, quickstart, pagination, error handling, and rate-limit guidance.
- how to test:
  - run `rg -n 'oxi_sk_test_|0xinsider.com/docs/api#authentication|0xinsider.com/docs/api#rate-limits' /Users/trevor.lasn/Work/docs -S`
  - run `cd /Users/trevor.lasn/Work/docs && mint broken-links`
