### PR TITLE
Add API changelog to the Mintlify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Open `http://localhost:3000`.
 ## Links
 
 - [API docs](https://docs.0xinsider.com)
+- [API changelog](https://docs.0xinsider.com/changelog)
 - [Terminal](https://0xinsider.com)
-- [Changelog](https://0xinsider.com/changelog)
+- [Product changelog](https://0xinsider.com/changelog)
 - [Support](mailto:support@0xinsider.com)

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -1,0 +1,52 @@
+---
+title: "API changelog"
+sidebarTitle: "API changelog"
+description: "Externally visible changes to the 0xinsider REST API."
+rss: true
+---
+
+This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
+
+<Update label="April 2, 2026" description="Leaderboard strategy fields can be null">
+  [`GET /api/v1/leaderboard`](/api-reference/endpoint/get-leaderboard) now safely returns traders without a classified strategy.
+
+  Clients should treat `strategy_type` as nullable for ranked traders without a strategy classification.
+</Update>
+
+<Update label="April 1, 2026" description="Explore Markets excludes untitled rows">
+  [`GET /api/v1/markets/explore`](/api-reference/endpoint/explore-markets) no longer returns untitled markets.
+
+  This tightens the response set to titled, user-facing markets only.
+</Update>
+
+<Update label="March 28, 2026" description="Trader realized P&L corrected">
+  [`GET /api/v1/trader/{address}`](/api-reference/endpoint/get-trader) now returns the canonical realized P&L from the `realized_pnl` source-of-truth field.
+
+  The `pnl.realized` field stopped deriving realized P&L from an inconsistent approximation.
+</Update>
+
+<Update label="March 26, 2026" description="Explore Markets endpoint launched">
+  Added [`GET /api/v1/markets/explore`](/api-reference/endpoint/explore-markets) for cursor-paginated market discovery.
+
+  The endpoint supports category, status, platform, and text filters, plus primary-market injection so grouped events include a main market when one exists.
+</Update>
+
+<Update label="March 25, 2026" description="Initial V1 launch">
+  Launched the first public developer API:
+
+  - [`GET /api/v1/trader/{address}`](/api-reference/endpoint/get-trader)
+  - [`GET /api/v1/whale-trades`](/api-reference/endpoint/get-whale-trades)
+  - [`GET /api/v1/leaderboard`](/api-reference/endpoint/get-leaderboard)
+  - [`GET /api/v1/markets/search`](/api-reference/endpoint/search-markets)
+  - [`GET /api/v1/market/{condition_id}/intel`](/api-reference/endpoint/get-market-intel)
+  - [`GET /api/v1/insider-radar`](/api-reference/endpoint/get-insider-radar)
+  - [`GET /api/v1/health`](/api-reference/endpoint/health)
+
+  The initial contract shipped with Bearer auth, `expand[]`, cursor pagination, prefixed IDs, and rate-limit headers.
+</Update>
+
+<Update label="March 25, 2026" description="Numeric precision standardized">
+  Money values and scores are truncated to 2 decimal places across V1 responses.
+
+  Prices and rates are truncated to 4 decimal places.
+</Update>

--- a/docs.json
+++ b/docs.json
@@ -82,6 +82,17 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "Changelog",
+        "groups": [
+          {
+            "group": "API updates",
+            "pages": [
+              "changelog"
+            ]
+          }
+        ]
       }
     ],
     "global": {
@@ -92,7 +103,7 @@
           "icon": "chart-line"
         },
         {
-          "anchor": "Changelog",
+          "anchor": "Product Changelog",
           "href": "https://0xinsider.com/changelog",
           "icon": "list"
         }


### PR DESCRIPTION
## Summary
- add a dedicated `Changelog` tab to the Mintlify docs navigation
- add `changelog.mdx` with API-only entries seeded from verified `/api/v1/*` changes
- rename the existing external header anchor to `Product Changelog` so the API changelog is unambiguous

## Why
The docs site had Guides and API Reference, but no API-specific changelog. Developers had no single place to track externally visible REST API changes separate from the broader product changelog on 0xinsider.com.

## Source Of Truth
- Mintlify navigation config in `docs.json`
- Mintlify changelog page pattern with RSS-enabled `Update` entries
- Verified 0xinsider app repo commits for public API behavior: `5517e7c9`, `c1e2708e`, `245738be`, `0146957a`, `578f7992`, `bf9a23ae`, `a7e42e00`

## User Impact
- API consumers can browse a dedicated API release history at `docs.0xinsider.com/changelog`
- the changelog excludes docs-only edits and focuses on contract and endpoint changes
- the broader product changelog remains available from the header as `Product Changelog`

## Verification
- `mint broken-links`

## Issue
Closes #4

## Commit Log
- `09a7419` docs: add API changelog page
  - What changed: added `changelog.mdx`, exposed a `Changelog` tab in `docs.json`, renamed the external header anchor to `Product Changelog`, and linked the new page from `README.md`
  - Why it changed: the docs site needed an API-specific changelog instead of pointing developers only at the broader product changelog
  - Affected files, systems, users, or operators: `docs.json`, `changelog.mdx`, `README.md`; affects docs.0xinsider.com navigation and changelog discovery for API consumers
  - How to test and verify: run `mint broken-links`, confirm the docs nav includes `Changelog`, and confirm the changelog page only lists API changes with exact dates
