### PR TITLE
Sync API search and MCP docs with live contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,14 @@ The API gives you programmatic access to the same intelligence powering the [0xi
 - **Whale Trades** — large trades with signal scoring, filterable by grade and category
 - **Explore Markets** — browse whale-active titled markets by category, platform, status, and sort order
 - **Market Intel** — smart money flow direction, buy/sell volumes, top positions
-- **Search Markets** — find markets by keyword with category and status filters
+- **Search Markets** — find markets by keyword with category/status filters and real cursor pagination
 - **Insider Radar** — suspicious trading patterns and pre-resolution accumulation
 
 ## MCP Server
 
 Connect AI agents (Claude, Cursor, etc.) to 0xinsider via the Model Context Protocol:
 
-```bash
-npx @0xinsider/mcp init
-```
+Clone the main repo and run the MCP server from `mcp/dist/index.js`. The npm package is not published yet.
 
 See the [MCP docs](https://docs.0xinsider.com/mcp) for setup details.
 

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -65,6 +65,8 @@
           },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "402": { "$ref": "#/components/responses/SubscriptionRequired" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "423": { "$ref": "#/components/responses/Locked" },
           "429": { "$ref": "#/components/responses/RateLimited" },
           "500": { "$ref": "#/components/responses/InternalError" }
         }
@@ -74,7 +76,7 @@
       "get": {
         "operationId": "get_whale_trades",
         "summary": "List whale trades",
-        "description": "Returns recent large trades with signal scoring. Filter by size, category, or trader grade. Cursor-paginated, newest first.",
+        "description": "Returns recent large trades with signal scoring. Filter by size, category, or trader grade. Cursor-paginated, newest first. Market categories use the effective market category fallback derived from stored market metadata when inferred_category is still null.",
         "tags": ["Whale Trades"],
         "parameters": [
           {
@@ -97,7 +99,7 @@
           {
             "name": "category",
             "in": "query",
-            "description": "Filter by market category (case-insensitive).",
+            "description": "Filter by effective market category (case-insensitive). Falls back to stored provider category metadata when inferred_category is null.",
             "schema": { "type": "string" }
           },
           {
@@ -129,6 +131,8 @@
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "402": { "$ref": "#/components/responses/SubscriptionRequired" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "423": { "$ref": "#/components/responses/Locked" },
           "429": { "$ref": "#/components/responses/RateLimited" }
         }
       }
@@ -185,6 +189,8 @@
           },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "402": { "$ref": "#/components/responses/SubscriptionRequired" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "423": { "$ref": "#/components/responses/Locked" },
           "429": { "$ref": "#/components/responses/RateLimited" }
         }
       }
@@ -193,7 +199,7 @@
       "get": {
         "operationId": "search_markets",
         "summary": "Search markets",
-        "description": "Search prediction markets by keyword. Returns matching markets with status and category.",
+        "description": "Search prediction markets by keyword. Returns representative market matches with status, category, and platform metadata. Cursor pagination advances over grouped market results rather than raw sub-market rows.",
         "tags": ["Markets"],
         "parameters": [
           {
@@ -207,6 +213,12 @@
             "name": "limit",
             "in": "query",
             "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Pagination cursor from previous response's next_cursor.",
+            "schema": { "type": "string" }
           },
           {
             "name": "status",
@@ -233,6 +245,7 @@
                     "object": { "type": "string", "const": "list" },
                     "data": { "type": "array", "items": { "$ref": "#/components/schemas/MarketSearchResult" } },
                     "has_more": { "type": "boolean" },
+                    "next_cursor": { "type": "string", "nullable": true },
                     "meta": { "$ref": "#/components/schemas/ResponseMeta" }
                   }
                 }
@@ -242,6 +255,8 @@
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "402": { "$ref": "#/components/responses/SubscriptionRequired" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "423": { "$ref": "#/components/responses/Locked" },
           "429": { "$ref": "#/components/responses/RateLimited" }
         }
       }
@@ -250,7 +265,7 @@
       "get": {
         "operationId": "explore_markets",
         "summary": "Explore markets",
-        "description": "Browse whale-active titled markets with category, platform, status, and keyword filters. Returns a grouped discovery feed where entries are either standalone markets or event groups.",
+        "description": "Browse whale-active titled markets with category, platform, status, and keyword filters. Paginates visible discovery entries rather than raw market rows and returns live category/platform facets alongside grouped event clusters or standalone markets.",
         "tags": ["Markets"],
         "parameters": [
           {
@@ -303,13 +318,14 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "has_more", "meta"],
+                  "required": ["object", "data", "has_more", "facets", "meta"],
                   "properties": {
                     "object": { "type": "string", "const": "list" },
                     "data": { "type": "array", "items": { "$ref": "#/components/schemas/ExploreEntry" } },
                     "has_more": { "type": "boolean" },
                     "next_cursor": { "type": "string", "nullable": true },
                     "total": { "type": "integer", "nullable": true },
+                    "facets": { "$ref": "#/components/schemas/ExploreFacets" },
                     "meta": { "$ref": "#/components/schemas/ResponseMeta" }
                   }
                 }
@@ -319,6 +335,8 @@
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "402": { "$ref": "#/components/responses/SubscriptionRequired" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "423": { "$ref": "#/components/responses/Locked" },
           "429": { "$ref": "#/components/responses/RateLimited" }
         }
       }
@@ -363,7 +381,9 @@
           },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "402": { "$ref": "#/components/responses/SubscriptionRequired" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
           "404": { "$ref": "#/components/responses/NotFound" },
+          "423": { "$ref": "#/components/responses/Locked" },
           "429": { "$ref": "#/components/responses/RateLimited" }
         }
       }
@@ -421,6 +441,8 @@
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "402": { "$ref": "#/components/responses/SubscriptionRequired" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "423": { "$ref": "#/components/responses/Locked" },
           "429": { "$ref": "#/components/responses/RateLimited" }
         }
       }
@@ -577,7 +599,7 @@
               "condition_id": { "type": "string" },
               "title": { "type": "string" },
               "slug": { "type": "string", "nullable": true },
-              "category": { "type": "string", "nullable": true }
+              "category": { "type": "string", "nullable": true, "description": "Effective market category. Falls back to stored provider category metadata when inferred_category is null." }
             }
           }
         }
@@ -610,7 +632,7 @@
           "slug": { "type": "string", "nullable": true },
           "category": { "type": "string", "nullable": true },
           "platform": { "type": "string", "nullable": true },
-          "status": { "type": "string", "enum": ["active", "resolved"] }
+          "status": { "type": "string", "enum": ["active", "closed"] }
         }
       },
       "ExploreMarket": {
@@ -626,7 +648,7 @@
           "icon": { "type": "string", "nullable": true },
           "category": { "type": "string", "nullable": true },
           "platform": { "type": "string", "nullable": true },
-          "status": { "type": "string", "enum": ["active", "resolved"] },
+          "status": { "type": "string", "enum": ["active", "closed"] },
           "volume": { "type": "number", "nullable": true },
           "liquidity": { "type": "number", "nullable": true },
           "whale_trade_count": { "type": "integer", "nullable": true },
@@ -677,6 +699,23 @@
         "properties": {
           "type": { "type": "string", "const": "standalone" },
           "market": { "$ref": "#/components/schemas/ExploreMarket" }
+        }
+      },
+      "ExploreFacetValue": {
+        "type": "object",
+        "required": ["value", "label", "count"],
+        "properties": {
+          "value": { "type": "string" },
+          "label": { "type": "string" },
+          "count": { "type": "integer" }
+        }
+      },
+      "ExploreFacets": {
+        "type": "object",
+        "required": ["categories", "platforms"],
+        "properties": {
+          "categories": { "type": "array", "items": { "$ref": "#/components/schemas/ExploreFacetValue" } },
+          "platforms": { "type": "array", "items": { "$ref": "#/components/schemas/ExploreFacetValue" } }
         }
       },
       "ExploreEntry": {
@@ -819,6 +858,22 @@
           }
         }
       },
+      "Forbidden": {
+        "description": "Account access denied",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ApiError" }
+          }
+        }
+      },
+      "Locked": {
+        "description": "Account is locked",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ApiError" }
+          }
+        }
+      },
       "NotFound": {
         "description": "Resource not found",
         "content": {
@@ -842,6 +897,9 @@
           },
           "X-RateLimit-Reset": {
             "schema": { "type": "integer" }
+          },
+          "X-Request-Id": {
+            "schema": { "type": "string" }
           }
         },
         "content": {

--- a/mcp.mdx
+++ b/mcp.mdx
@@ -3,19 +3,22 @@ title: "MCP Server"
 description: "Connect AI agents to 0xinsider with the Model Context Protocol."
 ---
 
-The `@0xinsider/mcp` server lets AI agents (Claude, Cursor, and other MCP-compatible clients) access prediction market intelligence directly — trader grades, whale trades, smart money signals, and insider detection.
+The 0xinsider MCP server lets AI agents (Claude, Cursor, and other MCP-compatible clients) access prediction market intelligence directly — trader grades, whale trades, smart money signals, and insider detection.
+
+The npm package name exists in `package.json`, but `@0xinsider/mcp` is not published yet. Install from source today.
 
 ## Install
 
 <Tabs>
   <Tab title="Claude Code">
-    Run the interactive setup:
+    Clone and build the server:
 
     ```bash
-    npx @0xinsider/mcp init
+    git clone https://github.com/0xinsider/0xinsider
+    cd 0xinsider/mcp
+    npm install
+    npm run build
     ```
-
-    This detects your Claude Code config and writes the MCP server block automatically.
 
     Or add manually to `~/.claude/settings.json`:
 
@@ -23,8 +26,8 @@ The `@0xinsider/mcp` server lets AI agents (Claude, Cursor, and other MCP-compat
     {
       "mcpServers": {
         "0xinsider": {
-          "command": "npx",
-          "args": ["-y", "@0xinsider/mcp"],
+          "command": "node",
+          "args": ["/absolute/path/to/0xinsider/mcp/dist/index.js"],
           "env": {
             "OXINSIDER_API_KEY": "oxi_sk_live_..."
           }
@@ -40,8 +43,8 @@ The `@0xinsider/mcp` server lets AI agents (Claude, Cursor, and other MCP-compat
     {
       "mcpServers": {
         "0xinsider": {
-          "command": "npx",
-          "args": ["-y", "@0xinsider/mcp"],
+          "command": "node",
+          "args": ["/absolute/path/to/0xinsider/mcp/dist/index.js"],
           "env": {
             "OXINSIDER_API_KEY": "oxi_sk_live_..."
           }
@@ -56,7 +59,7 @@ The `@0xinsider/mcp` server lets AI agents (Claude, Cursor, and other MCP-compat
     Any MCP client that supports stdio transport:
 
     ```bash
-    OXINSIDER_API_KEY=oxi_sk_live_... npx @0xinsider/mcp
+    OXINSIDER_API_KEY=oxi_sk_live_... node /absolute/path/to/0xinsider/mcp/dist/index.js
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary
- sync the docs-site OpenAPI copy with the verified main-repo spec
- replace the nonexistent `npx @0xinsider/mcp` install path with the real source-install flow
- update the docs-site README to reflect real search cursor pagination and MCP publishing state

## Problem
The API/docs audit found that the external Mintlify docs repo had drifted away from the shipped contract. In particular, the OpenAPI copy still documented the old search response/status shape, and the MCP docs still told users to install an npm package that is not published.

## Verification
- synced `api-reference/openapi.json` from the verified main-repo spec on `bug/api-search-pagination-docs`
- manually reviewed `mcp.mdx` and `README.md` against the current `mcp/README.md` and llms/OpenAPI contract

## Issue
Refs 0xinsider/0xinsider#451

## Commit Log
- `a0306b2` docs: sync API and MCP install contract
  - what changed: updated the docs-site OpenAPI copy plus MCP and README install/documentation text
  - why it changed: the live docs site was still advertising stale market-search and MCP contracts after the API audit
  - affected files, systems, users, or operators: `api-reference/openapi.json`, `mcp.mdx`, `README.md`, and readers of `docs.0xinsider.com`
  - how to test and verify: compare the docs-site OpenAPI copy against the verified main-repo spec and review the MCP install instructions for source-install accuracy
