### PR TITLE
docs: update MCP username lookup docs

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -26,22 +26,37 @@
       "get": {
         "operationId": "get_trader",
         "summary": "Get trader intelligence",
-        "description": "Returns a trader's grade (S through F), P&L, win rate, and optional strategy/category data. Unknown addresses return sync_status \"unknown\" instead of 404.",
+        "description": "Returns a trader's grade (S through F), P&L, win rate, and optional strategy/category data. The path accepts either an Ethereum wallet address or a known trader username. Unknown lookups return sync_status \"unknown\" instead of 404.",
         "tags": ["Traders"],
         "parameters": [
           {
             "name": "address",
             "in": "path",
             "required": true,
-            "description": "Ethereum wallet address (0x...)",
+            "description": "Ethereum wallet address (0x...) or known trader username",
             "schema": { "type": "string" }
           },
           {
             "name": "expand[]",
             "in": "query",
             "required": false,
+            "description": "Backward-compatible alias for expand. Repeatable: strategy, categories, quant_metrics.",
+            "schema": {
+              "type": "array",
+              "items": { "type": "string", "enum": ["strategy", "categories", "quant_metrics"] }
+            },
+            "style": "form",
+            "explode": true
+          },
+          {
+            "name": "expand",
+            "in": "query",
+            "required": false,
             "description": "Include heavy fields. Repeatable: strategy, categories, quant_metrics.",
-            "schema": { "type": "string", "enum": ["strategy", "categories", "quant_metrics"] },
+            "schema": {
+              "type": "array",
+              "items": { "type": "string", "enum": ["strategy", "categories", "quant_metrics"] }
+            },
             "style": "form",
             "explode": true
           }
@@ -541,7 +556,7 @@
           "category_strengths": {
             "type": "array",
             "nullable": true,
-            "description": "Category performance breakdown (expand[]=categories). Null unless expanded.",
+            "description": "Category performance breakdown (expand=categories or expand[]=categories). Null unless expanded.",
             "items": {
               "type": "object",
               "properties": {
@@ -556,7 +571,7 @@
           "quant_metrics": {
             "type": "object",
             "nullable": true,
-            "description": "Advanced risk/performance metrics (expand[]=quant_metrics). Null unless expanded.",
+            "description": "Advanced risk/performance metrics (expand=quant_metrics or expand[]=quant_metrics). Null unless expanded.",
             "properties": {
               "sharpe_ratio": { "type": "number", "nullable": true, "description": "Risk-adjusted return (annualized)" },
               "sortino_ratio": { "type": "number", "nullable": true, "description": "Downside risk-adjusted return" },

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,6 +7,12 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
+<Update label="April 14, 2026" description="Trader lookup accepts usernames and plain expand params">
+  [`GET /api/v1/trader/{address}`](/api-reference/endpoint/get-trader) now accepts a known trader username in the path in addition to an Ethereum wallet address.
+
+  Heavy trader fields can be requested with repeated `expand` query params, and the legacy `expand[]` form remains supported for existing clients.
+</Update>
+
 <Update label="April 2, 2026" description="Leaderboard strategy fields can be null">
   [`GET /api/v1/leaderboard`](/api-reference/endpoint/get-leaderboard) now safely returns traders without a classified strategy.
 

--- a/integrations/mcp.mdx
+++ b/integrations/mcp.mdx
@@ -132,7 +132,7 @@ The server exposes 6 read-only tools:
 
 | Tool | Description |
 |------|-------------|
-| `get_trader` | Look up a trader by wallet address — grade, P&L, win rate, strategy, quant metrics |
+| `get_trader` | Look up a trader by wallet address or username — grade, P&L, win rate, strategy, quant metrics |
 | `get_whale_trades` | Recent large trades with signal scoring, filterable by size/category/grade |
 | `get_leaderboard` | Top-ranked traders (S/A/B grades) with optional category/strategy filters |
 | `search_markets` | Search prediction markets by keyword |
@@ -140,6 +140,8 @@ The server exposes 6 read-only tools:
 | `get_insider_radar` | Suspicious trading pattern detection |
 
 All tools have `readOnlyHint: true` — they never modify data.
+
+`get_trader` accepts either an Ethereum wallet address or a known trader username like `swisstony`.
 
 ## Resources
 
@@ -176,6 +178,10 @@ What are whales buying in crypto markets?
 
 ```
 Analyze trader 0x1234... — is their strategy worth following?
+```
+
+```
+Analyze trader swisstony — is their strategy worth following?
 ```
 
 ```


### PR DESCRIPTION
Refs 0xinsider/0xinsider#981

## Summary
Update the public docs site for MCP trader username lookup and the new `expand` query alias on the trader endpoint.

## Why
The MCP package and public API contract now support trader lookup by username, and the REST docs need to describe the accepted `expand` and `expand[]` forms in the same release window.

## Scope
- update the MCP integration page for username lookup
- update the API changelog for the trader lookup contract change
- update the published OpenAPI spec used by the docs site

## Verification
- `node -e 'JSON.parse(require("fs").readFileSync("api-reference/openapi.json","utf8")); console.log("openapi ok")'`
- `git diff --check`
