### PR TITLE
Add Market Intel error changelog entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,6 +7,12 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
+<Update label="May 7, 2026" description="Market Intel rejects prefixed market IDs">
+  [`GET /api/v1/market/{condition_id}/intel`](/api-reference/endpoint/get-market-intel) now returns a clearer `400 bad_request` when callers pass a prefixed `market.id` value such as `mkt_...` instead of the raw `condition_id`.
+
+  Use [`GET /api/v1/markets/search`](/api-reference/endpoint/search-markets) first, then pass the returned `condition_id` into the Market Intel path.
+</Update>
+
 <Update label="April 14, 2026" description="Trader lookup accepts usernames and plain expand params">
   [`GET /api/v1/trader/{address}`](/api-reference/endpoint/get-trader) now accepts a known trader username in the path in addition to an Ethereum wallet address.
 

--- a/index.mdx
+++ b/index.mdx
@@ -80,7 +80,7 @@ API access is bundled with the [Insider subscription](https://0xinsider.com/pric
   <Card title="Get started" icon="rocket" href="/quickstart">
     Generate a key and make your first request in 2 minutes
   </Card>
-  <Card title="MCP Server" icon="robot" href="/mcp">
+  <Card title="MCP Server" icon="robot" href="/integrations/mcp">
     Install the live npm package for Claude Code, Cursor, Codex, Gemini CLI, and other MCP clients
   </Card>
 </CardGroup>

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -72,7 +72,7 @@ This returns only trades from A-grade or higher traders, sorted by most recent.
   <Card title="Error Handling" icon="triangle-exclamation" href="/errors">
     Error codes and troubleshooting
   </Card>
-  <Card title="MCP Server" icon="robot" href="/mcp">
+  <Card title="MCP Server" icon="robot" href="/integrations/mcp">
     Install the live npm package for Claude Code, Cursor, Codex, Gemini CLI, and other MCP clients
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

- Adds a May 7 API changelog entry for the Market Intel `400 bad_request` behavior when callers pass prefixed `mkt_...` market IDs instead of raw `condition_id` values.
- Points callers to `/api/v1/markets/search` as the source for the correct `condition_id`.

## Related

- Backend/API PR: https://github.com/0xinsider/0xinsider/pull/3860
- Issue: https://github.com/0xinsider/0xinsider/issues/3859

## Verification

- `mint broken-links` attempted, but fails on pre-existing unrelated `/mcp` links in `index.mdx` and `quickstart.mdx`.
