### PR TITLE
docs: rewrite developer docs for clarity with real examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.worktrees/

--- a/.mintignore
+++ b/.mintignore
@@ -5,3 +5,6 @@
 # Draft content
 drafts/
 *.draft.mdx
+
+# Local git worktrees (not shipped)
+.worktrees/

--- a/api-reference/endpoint/batch-get-market-intel.mdx
+++ b/api-reference/endpoint/batch-get-market-intel.mdx
@@ -2,3 +2,14 @@
 title: "Batch Get Market Intel"
 openapi: "POST /api/v1/markets/intel/batch"
 ---
+
+Fetch market intel for up to 25 markets in one round trip. Same payload shape per item as [Get Market Intel](/api-reference/endpoint/get-market-intel), plus a per-item `error` field when one condition ID fails.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"condition_ids": ["0xabc...", "0xdef...", "0x123..."]}' \
+  "https://api.0xinsider.com/api/v1/markets/intel/batch"
+```
+
+Costs item units against the batch budget: a 25-market batch reserves 25 item units. The top-level HTTP status is `200` even when some items fail — check `data[i].error` per item. See [Rate Limits](/rate-limits).

--- a/api-reference/endpoint/batch-get-traders.mdx
+++ b/api-reference/endpoint/batch-get-traders.mdx
@@ -2,3 +2,14 @@
 title: "Batch Get Traders"
 openapi: "POST /api/v1/traders/batch"
 ---
+
+Fetch up to 25 trader profiles in one round trip. Each item in the response carries the same shape as [Get Trader](/api-reference/endpoint/get-trader), plus a per-item `error` field if that specific address failed.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"addresses": ["0xabc...", "0xdef...", "swisstony"]}' \
+  "https://api.0xinsider.com/api/v1/traders/batch"
+```
+
+Costs item units against the batch budget: a 25-address batch reserves 25 item units. The top-level HTTP status is `200` even when some items fail — check `data[i].error` per item. See [Rate Limits](/rate-limits).

--- a/api-reference/endpoint/create-webhook.mdx
+++ b/api-reference/endpoint/create-webhook.mdx
@@ -2,3 +2,17 @@
 title: "Create Webhook"
 openapi: "POST /api/v1/webhooks"
 ---
+
+Register a webhook endpoint to receive whale trade and radar events as they happen.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://api.yourapp.com/webhooks/0xinsider",
+    "events": ["whale_trade.created", "radar_flag.created"]
+  }' \
+  "https://api.0xinsider.com/api/v1/webhooks"
+```
+
+The response includes a one-time signing secret. **Copy it immediately** — you cannot retrieve it later. Use it to verify the `X-0xinsider-Signature` header on every delivery; see [Verify Webhook](/api-reference/endpoint/verify-webhook). If the secret leaks, [rotate it](/api-reference/endpoint/rotate-webhook-secret).

--- a/api-reference/endpoint/delete-webhook.mdx
+++ b/api-reference/endpoint/delete-webhook.mdx
@@ -2,3 +2,13 @@
 title: "Delete Webhook"
 openapi: "DELETE /api/v1/webhooks/{id}"
 ---
+
+Permanently remove a webhook registration. After deletion no further events are delivered to that URL and the signing secret is invalidated.
+
+```bash
+curl -X DELETE \
+  -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/webhooks/wh_abc123"
+```
+
+To temporarily stop deliveries without losing the registration, [update](/api-reference/endpoint/update-webhook) the webhook to `active: false` instead.

--- a/api-reference/endpoint/explore-markets.mdx
+++ b/api-reference/endpoint/explore-markets.mdx
@@ -3,4 +3,20 @@ title: "Explore Markets"
 openapi: "GET /api/v1/markets/explore"
 ---
 
-Returns whale-active markets with non-empty titles, grouped into standalone entries or event-level clusters for discovery surfaces.
+Browse whale-active markets. Unlike `search`, this is the "show me what is going on" feed — already filtered to titled, user-facing markets with real activity.
+
+Cluster behaviour: grouped events (e.g. "Next US president — by candidate") return one row per event with a primary market injected so you have something to link to.
+
+Common filters:
+
+- `category=crypto` — restrict to a category.
+- `platform=polymarket` or `platform=kalshi`.
+- `status=active` — exclude resolved markets.
+- `sort=volume` — sort by recent volume.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/markets/explore?category=crypto&status=active&limit=20"
+```
+
+Cursor-paginated. See [Pagination](/concepts/pagination).

--- a/api-reference/endpoint/get-daily-report-snapshot.mdx
+++ b/api-reference/endpoint/get-daily-report-snapshot.mdx
@@ -2,3 +2,12 @@
 title: "Get Daily Report Snapshot"
 openapi: "GET /api/v1/reports/daily"
 ---
+
+The daily recap snapshot — top traders, biggest whale trades, smart-money rotations — pre-baked for the requested date. Use this to power morning-email digests, Slack briefs, or dashboard "what happened yesterday?" panels without recomputing each query.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/reports/daily?date=2026-05-08"
+```
+
+For longer windows, use [Weekly](/api-reference/endpoint/get-weekly-report-snapshot) or [Monthly](/api-reference/endpoint/get-monthly-report-snapshot). Snapshot payloads carry trust metadata so partial or unavailable sections are explicit.

--- a/api-reference/endpoint/get-event-replay-since.mdx
+++ b/api-reference/endpoint/get-event-replay-since.mdx
@@ -2,3 +2,12 @@
 title: "Get Event Replay Since"
 openapi: "GET /api/v1/events/feed/since"
 ---
+
+Replay feed events your subscription missed during a disconnection. Pass the timestamp (or event ID) of the last event you successfully processed; the response is everything that came after.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/events/feed/since?since=2026-05-08T12:34:56Z&limit=100"
+```
+
+Cursor-paginated. Use this to catch your worker back up after a crash or deploy — no need to back-fill from the live feed. Pair with [Webhooks](/api-reference/endpoint/list-webhooks) when you would rather not poll at all.

--- a/api-reference/endpoint/get-insider-radar.mdx
+++ b/api-reference/endpoint/get-insider-radar.mdx
@@ -2,3 +2,14 @@
 title: "Get Insider Radar"
 openapi: "GET /api/v1/insider-radar"
 ---
+
+Flags wallets behaving like they know something the market does not — pre-resolution accumulation, unusually well-timed entries, or one-sided conviction with no offsetting hedges.
+
+Each flag carries a `suspicion_score` and a reason. High scores are worth a closer look; they are not proof of wrongdoing.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/insider-radar?limit=20"
+```
+
+Cursor-paginated by score. See [Pagination](/concepts/pagination).

--- a/api-reference/endpoint/get-leaderboard.mdx
+++ b/api-reference/endpoint/get-leaderboard.mdx
@@ -2,3 +2,14 @@
 title: "Get Leaderboard"
 openapi: "GET /api/v1/leaderboard"
 ---
+
+Top-ranked traders by composite score. Only S, A, and B grades appear — see [Trader Grades](/concepts/grades).
+
+Filter by category (e.g. `crypto`, `politics`, `sports`) or by strategy (`swing_trader`, etc.). Some traders rank but have no detected strategy; `strategy_type` is nullable.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/leaderboard?limit=20&category=crypto"
+```
+
+Cursor-paginated. Pass `next_cursor` from one response as `cursor` on the next. See [Pagination](/concepts/pagination).

--- a/api-reference/endpoint/get-market-intel.mdx
+++ b/api-reference/endpoint/get-market-intel.mdx
@@ -2,3 +2,14 @@
 title: "Get Market Intel"
 openapi: "GET /api/v1/market/{condition_id}/intel"
 ---
+
+Smart-money breakdown for a single market: buy vs sell volume from graded traders, top positions, and which side conviction is on.
+
+Pass the on-chain `condition_id` in the path — **not** the prefixed `mkt_...` form. The API returns `400 bad_request` if you pass `mkt_...`. You can find raw condition IDs in whale trades and in `search` / `explore` responses.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/market/0xabc.../intel"
+```
+
+For multiple markets in one call, use [Batch Get Market Intel](/api-reference/endpoint/batch-get-market-intel).

--- a/api-reference/endpoint/get-market-snapshot.mdx
+++ b/api-reference/endpoint/get-market-snapshot.mdx
@@ -2,3 +2,14 @@
 title: "Get Market Snapshot"
 openapi: "GET /api/v1/market/{condition_id}/snapshot"
 ---
+
+One-shot view of a single market — price, volume, status, recent activity — with trust-metadata fields so you can tell which values are live provider-backed and which are cached, partial, or unavailable.
+
+Pass the raw on-chain `condition_id` in the path.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/market/0xabc.../snapshot"
+```
+
+If a field comes back marked `unavailable`, treat it as missing — do not flatten to `0`. See [Trust metadata](/api-reference/introduction#trust-metadata).

--- a/api-reference/endpoint/get-monthly-report-snapshot.mdx
+++ b/api-reference/endpoint/get-monthly-report-snapshot.mdx
@@ -2,3 +2,10 @@
 title: "Get Monthly Report Snapshot"
 openapi: "GET /api/v1/reports/monthly"
 ---
+
+The monthly recap snapshot — rolling-30-day leaderboard, category-rotation summary, biggest realized P&L by trader and by market. Use this for end-of-month digests and longer-form newsletters.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/reports/monthly?month=2026-05"
+```

--- a/api-reference/endpoint/get-position-timeline-by-id.mdx
+++ b/api-reference/endpoint/get-position-timeline-by-id.mdx
@@ -4,3 +4,4 @@ sidebarTitle: "Position timeline by ID"
 openapi: "GET /api/v1/traders/{id}/position-timeline"
 ---
 
+Same data as [Get Position Timeline](/api-reference/endpoint/get-position-timeline) but keyed on the internal prefixed trader ID (`trd_...`) instead of a raw wallet address. Use this when you are paging through entities returned by other API responses and you already have the prefixed ID.

--- a/api-reference/endpoint/get-position-timeline.mdx
+++ b/api-reference/endpoint/get-position-timeline.mdx
@@ -4,3 +4,11 @@ sidebarTitle: "Position timeline"
 openapi: "GET /api/v1/trader/{address}/position-timeline"
 ---
 
+Per-market fill history for one trader. Each fill carries a server-computed running amount and average entry price, so you can see how a trader built or unwound a position over time without recomputing it client-side.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53/position-timeline?condition_id=0xabc..."
+```
+
+If you have the internal position ID instead of the trader + market combo, use [Get Position Timeline by ID](/api-reference/endpoint/get-position-timeline-by-id).

--- a/api-reference/endpoint/get-positions.mdx
+++ b/api-reference/endpoint/get-positions.mdx
@@ -4,3 +4,11 @@ sidebarTitle: "Positions"
 openapi: "GET /api/v1/positions"
 ---
 
+Current positions across traders or markets. Each row carries the trader, the market, the current position value, the side, and trust-metadata fields (source, freshness, completeness) so you can tell the difference between a live provider-backed value and a cached or partial one.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/positions?trader=0x863134d00841b2e200492805a01e1e2f5defaa53&limit=50"
+```
+
+For per-fill history (running amount and average entry price), use [Position Timeline](/api-reference/endpoint/get-position-timeline). When a position value is unavailable from the provider, do not flatten it to `0` — see [Trust metadata](/api-reference/introduction#trust-metadata).

--- a/api-reference/endpoint/get-trader-export-snapshot.mdx
+++ b/api-reference/endpoint/get-trader-export-snapshot.mdx
@@ -2,3 +2,12 @@
 title: "Get Trader Export Snapshot"
 openapi: "GET /api/v1/trader/{address}/export"
 ---
+
+One-shot export of everything 0xinsider knows about a trader — profile, positions, recent trades, category breakdown — bundled for offline analysis or for stuffing into an LLM prompt.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53/export"
+```
+
+The export carries trust metadata per section so you can tell which fields are live provider-backed and which are cached or partial.

--- a/api-reference/endpoint/get-trader.mdx
+++ b/api-reference/endpoint/get-trader.mdx
@@ -2,3 +2,14 @@
 title: "Get Trader"
 openapi: "GET /api/v1/trader/{address}"
 ---
+
+Full profile for a single wallet — grade, realized P&L, win rate, strategy classification, category strengths, and current open positions.
+
+The path accepts either a raw wallet address (strip the `trd_` prefix) or a known trader username. Heavy fields can be opted into with repeated `expand` query params (`expand=strategy&expand=categories`). The legacy `expand[]` form remains supported.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53?expand=strategy&expand=categories"
+```
+
+Use this when you already have an address (from the leaderboard or a whale trade) and want the full story behind it. For multiple traders in one call, see [Batch Get Traders](/api-reference/endpoint/batch-get-traders).

--- a/api-reference/endpoint/get-webhook.mdx
+++ b/api-reference/endpoint/get-webhook.mdx
@@ -2,3 +2,10 @@
 title: "Get Webhook"
 openapi: "GET /api/v1/webhooks/{id}"
 ---
+
+Inspect a single registered webhook — its URL, subscribed events, active flag, and recent delivery status. The signing secret is not returned (it is only shown once at create time).
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/webhooks/wh_abc123"
+```

--- a/api-reference/endpoint/get-weekly-report-snapshot.mdx
+++ b/api-reference/endpoint/get-weekly-report-snapshot.mdx
@@ -2,3 +2,12 @@
 title: "Get Weekly Report Snapshot"
 openapi: "GET /api/v1/reports/weekly"
 ---
+
+The weekly recap snapshot — top movers, sustained-flow markets, leaderboard shifts — pre-baked for the requested week. Same shape as the [daily report](/api-reference/endpoint/get-daily-report-snapshot), rolled up over seven days.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/reports/weekly?week_of=2026-05-04"
+```
+
+`week_of` accepts any date inside the target week.

--- a/api-reference/endpoint/get-whale-trades-history.mdx
+++ b/api-reference/endpoint/get-whale-trades-history.mdx
@@ -2,3 +2,12 @@
 title: "Get Whale Trades History"
 openapi: "GET /api/v1/whale-trades/history"
 ---
+
+Bounded historical whale-trade ranges. Built for backtests, recap reports, and warming a cache after a deploy. The live "what is happening now?" feed is [Get Whale Trades](/api-reference/endpoint/get-whale-trades).
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/whale-trades/history?from=2026-04-01T00:00:00Z&to=2026-04-30T23:59:59Z&min_grade=A&limit=100"
+```
+
+History responses carry trust metadata so you can distinguish provider-backed vs reconciled vs partial trade ranges. See [Trust metadata](/api-reference/introduction#trust-metadata).

--- a/api-reference/endpoint/get-whale-trades.mdx
+++ b/api-reference/endpoint/get-whale-trades.mdx
@@ -2,3 +2,19 @@
 title: "Get Whale Trades"
 openapi: "GET /api/v1/whale-trades"
 ---
+
+Recent large trades, sorted newest first, with the trader's grade and a signal score attached to each.
+
+The most useful filters:
+
+- `min_grade=A` — only show trades from S/A-grade traders (set to `B` to widen).
+- `category=crypto` — restrict to a market category.
+- `side=buy` — `buy` or `sell`.
+- `min_size_usd=10000` — floor on trade size.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&category=crypto&side=buy&limit=50"
+```
+
+Cursor-paginated by timestamp. For a fixed time range (backtests, recap reports), use [Whale Trades History](/api-reference/endpoint/get-whale-trades-history).

--- a/api-reference/endpoint/health.mdx
+++ b/api-reference/endpoint/health.mdx
@@ -2,3 +2,17 @@
 title: "Health Check"
 openapi: "GET /api/v1/health"
 ---
+
+A liveness probe. Returns `200` with database and cache status when the API is up. No authentication required — handy as a smoke test from CI or a status dashboard.
+
+```bash
+curl https://api.0xinsider.com/api/v1/health
+```
+
+```json
+{
+  "object": "health",
+  "data": { "status": "ok", "db": true, "cache": true },
+  "meta": { "request_id": "req_abc123", "cached": false }
+}
+```

--- a/api-reference/endpoint/list-webhooks.mdx
+++ b/api-reference/endpoint/list-webhooks.mdx
@@ -2,3 +2,19 @@
 title: "List Webhooks"
 openapi: "GET /api/v1/webhooks"
 ---
+
+List every webhook endpoint registered on your account. Each entry includes the destination URL, the events it subscribes to, its delivery status, and metadata for signature verification.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/webhooks"
+```
+
+## The webhook lifecycle
+
+- [Create](/api-reference/endpoint/create-webhook) a webhook with the URL and event types you care about.
+- [Get](/api-reference/endpoint/get-webhook) one to inspect its current state.
+- [Update](/api-reference/endpoint/update-webhook) to change URL, events, or active flag.
+- [Delete](/api-reference/endpoint/delete-webhook) when you no longer need it.
+- [Verify](/api-reference/endpoint/verify-webhook) signed delivery on your side using HMAC.
+- [Rotate secret](/api-reference/endpoint/rotate-webhook-secret) if a signing secret leaks.

--- a/api-reference/endpoint/remote-mcp-stream.mdx
+++ b/api-reference/endpoint/remote-mcp-stream.mdx
@@ -4,7 +4,13 @@ sidebarTitle: "Remote MCP stream"
 openapi: "GET /api/v1/mcp"
 ---
 
-Open the server-to-client stream with the `Mcp-Session-Id` returned by
-`initialize`. Use `Authorization: Bearer <token>` when the client supports
-headers.
+Open the server-to-client streaming channel for [Remote MCP](/api-reference/endpoint/remote-mcp). Pass the `Mcp-Session-Id` returned by the `initialize` call to attach to your session, plus `Authorization: Bearer ...` if your client supports headers.
 
+```bash
+curl -N \
+  -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  https://api.0xinsider.com/api/v1/mcp
+```
+
+This is the stdio analog over HTTP. Hold the connection open to receive tool responses, progress events, and resource updates streamed from the server.

--- a/api-reference/endpoint/remote-mcp.mdx
+++ b/api-reference/endpoint/remote-mcp.mdx
@@ -4,8 +4,22 @@ sidebarTitle: "Remote MCP"
 openapi: "POST /api/v1/mcp"
 ---
 
-Use `Authorization: Bearer <token>` for remote MCP clients that support custom
-headers. The `?token=` query parameter remains available only as legacy
-compatibility for URL-only clients; prefer headers because URL secrets can be
-stored in shell history, browser history, proxies, and logs.
+Hosted, streamable HTTP MCP endpoint. Use this when your agent runs in an environment that cannot spawn a local `npx` subprocess — for example, a serverless function, a browser-based agent, or a hosted automation runtime.
 
+Same nine read-only tools as the local [`@0xinsider/mcp`](https://www.npmjs.com/package/@0xinsider/mcp) server, same auth, same payload contracts.
+
+## Authentication
+
+Prefer the header form:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}' \
+  https://api.0xinsider.com/api/v1/mcp
+```
+
+A `?token=...` query parameter remains available for URL-only clients but is **legacy** — URL secrets leak into shell history, browser history, proxies, and logs. Use headers wherever possible.
+
+For the streaming response, see [Remote MCP Stream](/api-reference/endpoint/remote-mcp-stream).

--- a/api-reference/endpoint/rotate-webhook-secret.mdx
+++ b/api-reference/endpoint/rotate-webhook-secret.mdx
@@ -2,3 +2,13 @@
 title: "Rotate Webhook Secret"
 openapi: "POST /api/v1/webhooks/{id}/rotate-secret"
 ---
+
+Generate a fresh signing secret for a webhook. The response includes the new secret **once** — copy it immediately. The old secret stops working as soon as this call returns, so deploy the new secret to your verification code before rotating.
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/webhooks/wh_abc123/rotate-secret"
+```
+
+Rotate immediately if a secret has leaked (committed to git, exposed in a log, sent in a screenshot).

--- a/api-reference/endpoint/search-markets.mdx
+++ b/api-reference/endpoint/search-markets.mdx
@@ -2,3 +2,12 @@
 title: "Search Markets"
 openapi: "GET /api/v1/markets/search"
 ---
+
+Keyword search across Polymarket and Kalshi markets. Best when you already know what you are looking for and need the raw `condition_id` to pass into other endpoints.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/markets/search?q=trump&category=politics&status=active"
+```
+
+Pass the returned `condition_id` (raw on-chain, not the `mkt_...` prefixed form) into [Market Intel](/api-reference/endpoint/get-market-intel) or [Market Snapshot](/api-reference/endpoint/get-market-snapshot). For browsing rather than searching, use [Explore Markets](/api-reference/endpoint/explore-markets).

--- a/api-reference/endpoint/update-webhook.mdx
+++ b/api-reference/endpoint/update-webhook.mdx
@@ -2,3 +2,15 @@
 title: "Update Webhook"
 openapi: "PATCH /api/v1/webhooks/{id}"
 ---
+
+Change a webhook's destination URL, subscribed events, or active flag without recreating it. Useful for promoting a staging URL to production, or for pausing delivery during maintenance without losing the registration.
+
+```bash
+curl -X PATCH \
+  -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"active": false}' \
+  "https://api.0xinsider.com/api/v1/webhooks/wh_abc123"
+```
+
+The signing secret is not affected by `PATCH`. To change it, use [Rotate Webhook Secret](/api-reference/endpoint/rotate-webhook-secret).

--- a/api-reference/endpoint/verify-webhook.mdx
+++ b/api-reference/endpoint/verify-webhook.mdx
@@ -2,3 +2,13 @@
 title: "Verify Webhook"
 openapi: "POST /api/v1/webhooks/{id}/verify"
 ---
+
+Send a signed test payload to your webhook URL so you can confirm signature verification on your side before relying on live deliveries.
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/webhooks/wh_abc123/verify"
+```
+
+The webhook receives a `verify.test` event with an `X-0xinsider-Signature` header. Compute `HMAC_SHA256(secret, raw_body)` on your side and compare in constant time. Reject deliveries with mismatched signatures.

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: "API Reference"
 sidebarTitle: "Overview"
-description: "Complete reference for all 0xinsider API endpoints."
+description: "What every 0xinsider endpoint shares: base URL, auth, envelope, IDs, rate limits, and trust metadata."
 ---
 
 ## Base URL
@@ -12,74 +12,88 @@ https://api.0xinsider.com/api/v1/
 
 ## Authentication
 
-All endpoints (except `/api/v1/health`) require a Bearer token:
+Every endpoint except `/health` requires a Bearer token:
 
 ```bash
 Authorization: Bearer oxi_sk_live_...
 ```
 
-Generate your key at [0xinsider.com/developers](https://0xinsider.com/developers).
+Generate yours at [0xinsider.com/developers](https://0xinsider.com/developers). Full details in [Authentication](/authentication).
 
-## Response format
+## Response envelope
 
-Every response follows a consistent envelope:
+Single-resource endpoints return:
 
 ```json
 {
   "object": "trader",
   "data": { ... },
-  "meta": {
-    "request_id": "req_550e8400",
-    "cached": false
-  }
+  "meta": { "request_id": "req_550e8400", "cached": false }
 }
 ```
 
-List endpoints include pagination:
+List endpoints add pagination fields:
 
 ```json
 {
   "object": "list",
-  "data": [...],
+  "data": [ ... ],
   "has_more": true,
   "next_cursor": "97.94_0x863...",
-  "meta": { ... }
+  "meta": { "request_id": "req_550e8400", "cached": false }
 }
 ```
 
+| Field | Meaning |
+|---|---|
+| `object` | Shape of `data`. A singular type (`trader`, `market`, `health`, ...) or `list`. |
+| `data` | The actual payload — an object or an array. |
+| `meta.request_id` | Give us this when you write to support. |
+| `meta.cached` | `true` when the response came from cache. |
+| `has_more` / `next_cursor` | Present on list responses. See [Pagination](/concepts/pagination). |
+
+Errors share the same envelope, with `"object": "error"`. See [Errors](/errors).
+
 ## Prefixed IDs
 
-Every entity has a type-prefixed ID for easy identification:
+Every ID is prefixed with its type, so an ID is self-describing in logs and chat transcripts.
 
 | Entity | Prefix | Example |
-|--------|--------|---------|
+|---|---|---|
 | Trader | `trd_` | `trd_0xabc123def456` |
 | Market | `mkt_` | `mkt_0x789condition` |
 | Whale trade | `wt_` | `wt_12345` |
 | Radar flag | `rf_` | `rf_67890` |
 | Request | `req_` | `req_550e8400` |
 
+When an endpoint accepts an address in the path (`/trader/{address}`), pass the raw address — strip the `trd_` prefix. When an endpoint accepts a `condition_id` in the path (`/market/{condition_id}/intel`), pass the raw on-chain condition ID — not the prefixed `mkt_...` form.
+
 ## Rate limits
 
-100 requests per minute per user (sliding window). Check response headers:
+100 requests per minute per user, sliding window. Batch endpoints have an additional 100-item-unit-per-minute budget.
 
-| Header | Description |
-|--------|-------------|
-| `X-RateLimit-Limit` | Max requests per window |
-| `X-RateLimit-Remaining` | Requests remaining |
-| `X-RateLimit-Reset` | Unix timestamp when window resets |
-| `Retry-After` | Seconds to wait (only on 429) |
+| Header | Meaning |
+|---|---|
+| `X-RateLimit-Limit` | Maximum requests per window (`100`). |
+| `X-RateLimit-Remaining` | How many you have left in the current window. |
+| `X-RateLimit-Reset` | Unix timestamp (seconds) when the window resets. |
+| `X-Request-Cost` | Item units this single batch call charged. |
+| `X-Batch-RateLimit-Limit` | Max batch item units per minute. |
+| `X-Batch-RateLimit-Remaining` | Batch item units remaining. |
+| `X-Batch-RateLimit-Reset` | Unix timestamp when the batch window resets. |
+| `Retry-After` | Seconds to wait. Only on `429`. |
 
-Batch endpoints also expose `X-Request-Cost` and `X-Batch-RateLimit-*`
-headers. A batch item costs one item unit, so a 25-item batch reserves 25
-batch units before execution.
+See [Rate Limits](/rate-limits) for backoff patterns.
 
 ## Trust metadata
 
-Newer builder endpoints document source, freshness, reconciliation, and
-completeness metadata for values that can be cached, stale, partial, computed,
-or provider-unavailable.
+Newer builder endpoints (snapshots, history ranges, batch reads, reports) attach metadata to provider-owned values so clients can distinguish provider-backed, cached, partial, stale, and unavailable data.
 
-Do not convert unavailable provider-owned values into `0`, empty arrays, or
-empty objects. Treat explicit `unavailable` or `partial` metadata as part of the
-result.
+The shape per value is:
+
+- `source` — where the value came from (`provider`, `cache`, `computed`).
+- `freshness` — how stale the value is (e.g. an ISO timestamp or `live`).
+- `reconciliation` — whether the value has been cross-checked against the source of truth.
+- `completeness` — `full`, `partial`, or `unavailable`.
+
+Rule of thumb: **do not flatten unavailable values into `0`, `[]`, or `{}`.** Read the metadata, and surface "unavailable" to your consumer instead of inventing a zero. Provider data that quietly turns into `0` produces silent bugs downstream.

--- a/authentication.mdx
+++ b/authentication.mdx
@@ -1,52 +1,77 @@
 ---
 title: "Authentication"
-description: "API key management and security."
+description: "API keys, headers, and what to do if a key leaks."
 ---
 
-## API keys
-
-All authenticated endpoints require a Bearer token in the `Authorization` header:
+Every request (except `/health`) authenticates with a Bearer token:
 
 ```bash
 Authorization: Bearer oxi_sk_live_...
 ```
 
-### Key format
+## The key
 
-Keys follow the format `oxi_sk_live_` followed by 64 hex characters (76 characters total). Example:
+| Property | Value |
+|---|---|
+| Format | `oxi_sk_live_` + 64 hex chars (76 chars total) |
+| Storage on our side | HMAC-SHA256 hash. Plaintext is never stored. |
+| Active keys per account | 1. Regenerating revokes the old key. |
+| Where to generate | [0xinsider.com/developers](https://0xinsider.com/developers) |
 
-```
-<YOUR_API_KEY>
-```
+The key is shown **once**, at generation time. After that the dashboard only shows the prefix (`oxi_sk_live_XXXX`) for identification.
 
-### Generating a key
+## Generate a key
 
-1. Log in at [0xinsider.com](https://0xinsider.com)
-2. Go to [Developers](https://0xinsider.com/developers)
-3. Click **Generate Key**
-4. Copy the key immediately — it's shown only once
+1. Log in at [0xinsider.com](https://0xinsider.com).
+2. Open [Developers](https://0xinsider.com/developers).
+3. Click **Generate Key**.
+4. Copy it immediately.
 
-### Key security
+## Common mistakes
 
-- Keys are hashed (HMAC-SHA256) before storage. We never store plaintext keys.
-- Only the key prefix (`oxi_sk_live_XXXX`) is stored for display.
-- One active key per account. Regenerating revokes the previous key.
-- If compromised, regenerate immediately at [0xinsider.com/developers](https://0xinsider.com/developers).
+<AccordionGroup>
+  <Accordion title="Missing 'Bearer' prefix in the header">
+    Wrong:
+    ```
+    Authorization: oxi_sk_live_...
+    ```
+    Right:
+    ```
+    Authorization: Bearer oxi_sk_live_...
+    ```
+    The API returns `401 invalid_api_key` for either malformed format.
+  </Accordion>
+  <Accordion title="Pasting only part of the key">
+    The full key is 76 characters. Anything shorter is a partial copy.
+  </Accordion>
+  <Accordion title="Hitting an authenticated endpoint without a subscription">
+    Valid key, expired subscription returns `402 subscription_required`. Re-subscribe at [pricing](https://0xinsider.com/pricing); the same key resumes working.
+  </Accordion>
+  <Accordion title="Reusing an old key after regenerating">
+    Regenerating revokes the previous key in the same call. Update every place the old key lives — `.env` files, deployed secrets, MCP configs.
+  </Accordion>
+</AccordionGroup>
 
-### Key management endpoints
+## If a key leaks
+
+Treat it like any production secret:
+
+1. Go to [Developers](https://0xinsider.com/developers).
+2. Click **Regenerate Key**. The old key stops working immediately.
+3. Roll the new key into every consumer (bots, MCP configs, CI secrets, dashboards).
+
+## Key management endpoints
+
+These manage *your own* keys from the dashboard. They authenticate with the session cookie (JWT), not with an API key, so you cannot call them from a script using `oxi_sk_live_...`.
 
 | Action | Method | Endpoint |
-|--------|--------|----------|
+|---|---|---|
 | Create key | `POST` | `/api/keys` |
 | List keys | `GET` | `/api/keys` |
 | Revoke key | `DELETE` | `/api/keys/{id}` |
 | Regenerate | `POST` | `/api/keys/regenerate` |
 
-These endpoints use JWT authentication (session cookies), not API key auth.
-
-## Subscription requirement
-
-API access is bundled with the **Insider** subscription ($89/mo). Requests with a valid key but no active subscription return:
+## What a subscription-blocked response looks like
 
 ```json
 {
@@ -54,7 +79,7 @@ API access is bundled with the **Insider** subscription ($89/mo). Requests with 
   "error": {
     "code": "subscription_required",
     "message": "Active Insider subscription required.",
-    "doc_url": "https://docs.0xinsider.com/api-reference/introduction#authentication"
+    "doc_url": "https://docs.0xinsider.com/authentication"
   }
 }
 ```

--- a/concepts/grades.mdx
+++ b/concepts/grades.mdx
@@ -1,47 +1,114 @@
 ---
 title: "Trader Grades"
-description: "How 0xinsider grades traders from S to F."
+description: "What S, A, B, C, D, F mean — with real profile examples."
 ---
 
-Every trader synced by 0xinsider receives a grade from **S** (best) to **F** (worst). Grades appear in trader profiles, leaderboard entries, and whale trade objects.
+Every trader 0xinsider tracks gets a single letter grade. The grade is the short, opinionated answer to "should I pay attention to this wallet?"
 
-## Grade scale
+You will see grades on the leaderboard, on every trader profile, and inside every whale trade object.
 
-| Grade | Meaning | Leaderboard eligible |
-|-------|---------|---------------------|
-| **S** | Elite — top performers with exceptional track records | Yes |
-| **A** | Strong — consistently profitable with good win rates | Yes |
-| **B** | Above average — solid performance | Yes |
-| **C** | Average | No |
-| **D** | Below average | No |
-| **F** | Poor track record | No |
+## The scale
 
-## How grades are calculated
+| Grade | One-line meaning | On the leaderboard? |
+|---|---|---|
+| **S** | Elite. Years of evidence, outsized P&L, high win rate, real volume. | Yes |
+| **A** | Strong. Consistently profitable, well-diversified across markets. | Yes |
+| **B** | Above average. Solid recent track record, smaller sample. | Yes |
+| **C** | Roughly breakeven. Not a clear signal. | No |
+| **D** | Net losing across the sample. | No |
+| **F** | Persistently losing. Often coin-flip or chasing resolved markets. | No |
 
-Grades are computed from a composite score (0-100) that factors in:
+The leaderboard only ranks S, A, and B — those are the wallets worth following.
 
-- **Realized P&L** — actual profit from closed positions
-- **Win rate** — percentage of profitable markets
-- **Volume** — total trading volume (higher volume = more signal)
-- **Market count** — number of markets traded (diversification)
-- **Recency** — how recently the trader was active
+## What goes into the grade
 
-The leaderboard only includes traders with grades S, A, or B.
+The score is a composite (0-100) of five inputs:
+
+1. **Realized P&L** — actual profit from closed positions, not unrealized markings.
+2. **Win rate** — share of markets that resolved in their favor.
+3. **Volume** — total traded size. More volume = more signal per trade.
+4. **Market count** — how many distinct markets they have touched (diversification).
+5. **Recency** — penalizes wallets that have not traded in a long time.
+
+The letter is then assigned by score thresholds, with leaderboard eligibility capped at B or better.
+
+## Two real profiles, side by side
+
+### S-grade: deep history, sustained edge
+
+```json
+{
+  "object": "trader",
+  "data": {
+    "id": "trd_0x863134d00841b2e200492805a01e1e2f5defaa53",
+    "username": "RepTrump",
+    "grade": "S",
+    "score": 97.94,
+    "pnl": 7532409.67,
+    "win_rate": 1.0,
+    "markets_traded": 28,
+    "strategy_type": "swing_trader",
+    "best_category": "politics"
+  }
+}
+```
+
+Signals: very high realized P&L, perfect or near-perfect win rate, classifiable strategy, an identifiable category strength.
+
+### C-grade: noisy and small
+
+```json
+{
+  "object": "trader",
+  "data": {
+    "id": "trd_0xc111...",
+    "username": null,
+    "grade": "C",
+    "score": 42.10,
+    "pnl": 318.55,
+    "win_rate": 0.5238,
+    "markets_traded": 21,
+    "strategy_type": null,
+    "best_category": null
+  }
+}
+```
+
+Signals: P&L around breakeven, a coin-flip win rate, no detectable strategy. Visible in the API, but not in the leaderboard.
 
 ## Using grades in the API
 
 ### Filter whale trades by grade
 
+Only see trades from A-grade or better:
+
 ```bash
-curl -H "Authorization: Bearer oxi_sk_live_..." \
-  "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&limit=10"
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&limit=50"
 ```
 
-This returns only trades from traders with grade A or better (S and A).
+`min_grade` accepts `S`, `A`, `B`. Setting `min_grade=A` returns S **and** A.
 
-### Filter leaderboard by strategy
+### Filter the leaderboard by strategy
+
+Pull only S/A/B-grade swing traders:
 
 ```bash
-curl -H "Authorization: Bearer oxi_sk_live_..." \
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/leaderboard?strategy=swing_trader"
 ```
+
+Some traders are good enough to make the leaderboard but lack a classifiable strategy. In that case `strategy_type` is `null` — treat it as nullable when filtering client-side.
+
+### Combine grade + category
+
+What are A-grade or better crypto traders buying right now?
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&category=crypto&side=buy&limit=50"
+```
+
+## A note on null strategies
+
+A trader on the leaderboard without a strategy classification just means we have not detected a stable pattern. They are still a graded trader. Do not filter them out unless your use case actually requires a labeled strategy.

--- a/concepts/number-formatting.mdx
+++ b/concepts/number-formatting.mdx
@@ -1,27 +1,35 @@
 ---
 title: "Number Formatting"
-description: "How floating-point values are formatted in API responses."
+description: "How numeric values are formatted in API responses."
 ---
 
-All floating-point values are **truncated** (not rounded) at the API boundary for clean, predictable output.
+Numbers come back as plain JSON numbers (not strings). Floating-point values are **truncated** (not rounded) at the API edge so the displayed value never overstates the underlying value.
 
-## Precision rules
+## Precision
 
-| Field type | Decimal places | Example |
-|-----------|---------------|---------|
-| Money (PnL, volume, size_usd) | 2 | `7532409.67` |
-| Scores (score, suspicion_score) | 2 | `97.94` |
-| Rates (win_rate, daily_win_rate) | 4 | `0.4545` |
+| Field type | Decimals | Example |
+|---|---|---|
+| Money (`pnl`, `volume`, `size_usd`) | 2 | `7532409.67` |
+| Scores (`score`, `suspicion_score`) | 2 | `97.94` |
+| Rates (`win_rate`, `daily_win_rate`) | 4 | `0.4545` (= 45.45%) |
 | Prices | 4 | `0.8899` |
 
-## Truncation, not rounding
+## Truncated, not rounded
 
-Values are truncated toward zero. `97.9488...` becomes `97.94`, not `97.95`. This ensures the displayed value never overstates the actual value.
+`97.9488...` becomes `97.94`, not `97.95`. `-12.345` becomes `-12.34`. Always toward zero.
+
+If you need stricter precision for accounting, compute from the source data. The API edge value is the display-safe value.
 
 ## Integer fields
 
-These fields are always exact integers with no decimal component:
+These are exact integers — no decimals, no truncation:
 
 - `markets_traded`
 - `rank`
 - `whale_trade_count`
+
+## Nulls and `unavailable`
+
+Many fields are nullable (e.g. `strategy_type`, `best_category`). Treat them as nullable in your client even when a particular endpoint usually populates them.
+
+Newer builder endpoints additionally surface **trust metadata** — explicit `unavailable` or `partial` markers when a provider-owned value cannot be returned at request time. Do not convert these into `0`, `[]`, or `{}`. Read the metadata field and treat the value as missing.

--- a/concepts/pagination.mdx
+++ b/concepts/pagination.mdx
@@ -1,56 +1,110 @@
 ---
 title: "Pagination"
-description: "Cursor-based pagination for list endpoints."
+description: "Cursor-based pagination, with a full loop in JS and Python."
 ---
 
-All list endpoints use **cursor-based pagination**. This is more reliable than offset pagination for real-time data.
+Every list endpoint uses **cursor pagination**. There is no `offset` and no `page` number. Cursors are stable while a sort order keeps the same — much more reliable than offsets when data is live.
 
-## How it works
+## The shape
 
-1. Make your first request with a `limit`:
-
-```bash
-curl -H "Authorization: Bearer oxi_sk_live_..." \
-  "https://api.0xinsider.com/api/v1/leaderboard?limit=20"
-```
-
-2. Check `has_more` and `next_cursor` in the response:
+A list response looks like this:
 
 ```json
 {
   "object": "list",
-  "data": [...],
+  "data": [ /* up to `limit` items */ ],
   "has_more": true,
-  "next_cursor": "95.85_0x885783760858e1bd5dd09a3c3f916cfa251ac270"
+  "next_cursor": "95.85_0x885783760858e1bd5dd09a3c3f916cfa251ac270",
+  "meta": { "request_id": "req_abc123", "cached": false }
 }
 ```
 
-3. Pass `next_cursor` as the `cursor` param for the next page:
+To get the next page, pass `next_cursor` back as the `cursor` query param:
 
 ```bash
-curl -H "Authorization: Bearer oxi_sk_live_..." \
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/leaderboard?limit=20&cursor=95.85_0x885..."
 ```
 
-4. Repeat until `has_more` is `false`.
+Repeat until `has_more` is `false`.
 
 ## Parameters
 
 | Parameter | Type | Default | Max |
-|-----------|------|---------|-----|
-| `limit` | integer | 20 | 100 |
+|---|---|---|---|
+| `limit` | integer | `20` | `100` |
 | `cursor` | string | — | — |
 
-## Cursor format
+## Full loop, end to end
 
-Cursors are opaque strings — don't parse or construct them. Always use the `next_cursor` value from the previous response.
+This pulls every page of the leaderboard until exhausted.
 
-Different endpoints use different cursor formats internally:
+<CodeGroup>
+```javascript JavaScript
+const KEY = process.env.OXINSIDER_API_KEY;
+const headers = { Authorization: `Bearer ${KEY}` };
+
+async function listAll(path, params = {}) {
+  const items = [];
+  let cursor;
+  do {
+    const qs = new URLSearchParams({ limit: "100", ...params });
+    if (cursor) qs.set("cursor", cursor);
+
+    const res = await fetch(
+      `https://api.0xinsider.com/api/v1${path}?${qs}`,
+      { headers }
+    );
+    const body = await res.json();
+    items.push(...body.data);
+    cursor = body.has_more ? body.next_cursor : undefined;
+  } while (cursor);
+
+  return items;
+}
+
+const leaders = await listAll("/leaderboard");
+console.log(`Fetched ${leaders.length} traders`);
+```
+
+```python Python
+import os, requests
+
+BASE = "https://api.0xinsider.com/api/v1"
+H = {"Authorization": f"Bearer {os.environ['OXINSIDER_API_KEY']}"}
+
+def list_all(path, **params):
+    items, cursor = [], None
+    while True:
+        p = {"limit": 100, **params}
+        if cursor:
+            p["cursor"] = cursor
+        body = requests.get(f"{BASE}{path}", params=p, headers=H).json()
+        items.extend(body["data"])
+        if not body.get("has_more"):
+            return items
+        cursor = body["next_cursor"]
+
+leaders = list_all("/leaderboard")
+print(f"Fetched {len(leaders)} traders")
+```
+</CodeGroup>
+
+## Cursors are opaque
+
+Do not parse, construct, or store cursors long-term. Always use the `next_cursor` from the response you just received.
+
+Internally, different endpoints use different cursor encodings:
+
 - **Leaderboard**: `{score}_{address}`
 - **Whale trades**: `{timestamp}_{id}` (ISO 8601)
 - **Insider radar**: `{score}_{id}`
 
-## Tips
+You do not need to know this to use the API — just pass the string back.
 
-- Cursors are stable for the current sort order. Don't mix cursors between different filter combinations.
-- If you get a `400` with `"Invalid cursor format"`, you're using a cursor from a different endpoint or an expired cursor.
+## Gotchas
+
+- **Don't mix cursors across filters.** A cursor from `?category=crypto` is not valid on `?category=politics`. Restart pagination when filters change.
+- **Don't mix cursors across endpoints.** A leaderboard cursor will not work on whale trades.
+- **`400 Invalid cursor format` means the cursor came from a different filter set, a different endpoint, or has been mangled.** Drop the cursor and start over.
+- **Stale cursors expire.** If you pause for hours, the underlying sort can shift; expect to restart.

--- a/errors.mdx
+++ b/errors.mdx
@@ -1,11 +1,9 @@
 ---
 title: "Errors"
-description: "Error codes, formats, and troubleshooting."
+description: "How errors come back, what each code means, and how to recover."
 ---
 
-## Error format
-
-All errors follow a consistent envelope (RFC 7807-inspired):
+Errors are returned with a non-2xx HTTP status and a consistent JSON envelope:
 
 ```json
 {
@@ -13,7 +11,7 @@ All errors follow a consistent envelope (RFC 7807-inspired):
   "error": {
     "code": "invalid_api_key",
     "message": "Invalid or missing API key.",
-    "doc_url": "https://docs.0xinsider.com/api-reference/introduction#authentication",
+    "doc_url": "https://docs.0xinsider.com/authentication",
     "param": null
   },
   "meta": {
@@ -22,35 +20,93 @@ All errors follow a consistent envelope (RFC 7807-inspired):
 }
 ```
 
+The two fields to read in production: `error.code` (machine-readable) and `meta.request_id` (the ID you give us when you write to support).
+
 ## Error codes
 
-| HTTP Status | Code | Description |
-|-------------|------|-------------|
-| `400` | `bad_request` | Invalid parameter — check the `param` field for which one |
-| `401` | `invalid_api_key` | Missing, malformed, or revoked API key |
-| `402` | `subscription_required` | Valid key but no active Insider subscription |
-| `403` | `forbidden` | Account has been deleted |
-| `404` | `not_found` | Resource doesn't exist |
-| `423` | `account_locked` | Account is suspended |
-| `429` | `rate_limited` | Exceeded 100 req/min — check `Retry-After` header |
-| `500` | `internal_error` | Something went wrong on our end |
+| HTTP | `error.code` | What happened | What to do |
+|---|---|---|---|
+| `400` | `bad_request` | A parameter was invalid. Check `error.param`. | Fix the input. |
+| `401` | `invalid_api_key` | Key missing, malformed, or revoked. | Re-check the `Authorization` header. |
+| `402` | `subscription_required` | Key is valid, but no active Insider sub. | Subscribe at [pricing](https://0xinsider.com/pricing). |
+| `403` | `forbidden` | The account was deleted. | Contact support. |
+| `404` | `not_found` | The trader / market / resource does not exist. | Verify the ID. |
+| `423` | `account_locked` | Account is suspended. | Contact support. |
+| `429` | `rate_limited` | Over 100 req/min (or 100 batch item units/min). | Sleep `Retry-After` seconds and retry. See [Rate Limits](/rate-limits). |
+| `500` | `internal_error` | Bug on our side. | Retry. Include `meta.request_id` if you contact us. |
 
-## Troubleshooting
+## Handling errors in code
 
-### "Invalid or missing API key"
+<CodeGroup>
+```javascript JavaScript
+async function call(path, opts = {}) {
+  const res = await fetch(`https://api.0xinsider.com/api/v1${path}`, {
+    headers: { Authorization: `Bearer ${process.env.OXINSIDER_API_KEY}` },
+    ...opts,
+  });
+  const body = await res.json();
 
-- Verify the `Authorization` header format: `Bearer oxi_sk_live_...`
-- Check that the key hasn't been revoked at [0xinsider.com/developers](https://0xinsider.com/developers)
-- Keys are 76 characters total — ensure you copied the full key
+  if (!res.ok) {
+    const { code, message, param } = body.error;
+    if (code === "rate_limited") {
+      const wait = Number(res.headers.get("retry-after") ?? 1) * 1000;
+      await new Promise(r => setTimeout(r, wait));
+      return call(path, opts);
+    }
+    if (code === "subscription_required") {
+      throw new Error("Insider subscription required");
+    }
+    throw new Error(`${code}: ${message}${param ? ` (param=${param})` : ""}`);
+  }
 
-### "Active Insider subscription required"
+  return body;
+}
+```
 
-Your API key is valid but your subscription has expired or you're on the free tier. Subscribe at [0xinsider.com/pricing](https://0xinsider.com/pricing).
+```python Python
+import os, time, requests
 
-### "Rate limit exceeded"
+BASE = "https://api.0xinsider.com/api/v1"
+H = {"Authorization": f"Bearer {os.environ['OXINSIDER_API_KEY']}"}
 
-Wait for the number of seconds in the `Retry-After` response header, then retry. See [Rate Limits](/rate-limits) for best practices.
+def call(path, **params):
+    r = requests.get(f"{BASE}{path}", headers=H, params=params)
+    body = r.json()
+    if r.ok:
+        return body
 
-### 500 errors
+    code = body["error"]["code"]
+    if code == "rate_limited":
+        time.sleep(int(r.headers.get("Retry-After", "1")))
+        return call(path, **params)
+    if code == "subscription_required":
+        raise RuntimeError("Insider subscription required")
+    raise RuntimeError(f"{code}: {body['error']['message']}")
+```
+</CodeGroup>
 
-These are bugs on our end. Include the `request_id` from the response when contacting [support@0xinsider.com](mailto:support@0xinsider.com).
+## Per-item batch errors
+
+Batch endpoints (e.g. `POST /api/v1/traders/batch`) return `200 OK` even when individual items fail. Each item carries its own `error` field — read `data[i].error` per item, not just the top-level status.
+
+## Quick troubleshooting
+
+<AccordionGroup>
+  <Accordion title="401 invalid_api_key">
+    - Header literally needs `Authorization: Bearer oxi_sk_live_...`.
+    - Key is 76 characters end to end — confirm you copied the full string.
+    - If you regenerated, the previous key is dead. Update every consumer.
+  </Accordion>
+  <Accordion title="402 subscription_required">
+    Key is fine; billing is not. Re-subscribe at [pricing](https://0xinsider.com/pricing) and the same key resumes.
+  </Accordion>
+  <Accordion title="429 rate_limited">
+    Sleep `Retry-After` seconds, then retry. See the backoff example in [Rate Limits](/rate-limits).
+  </Accordion>
+  <Accordion title="400 bad_request on Market Intel with mkt_... prefix">
+    Market Intel takes the raw `condition_id`, not the prefixed `mkt_...` ID. Look up the market via [`/markets/search`](/api-reference/endpoint/search-markets) and use the returned `condition_id`.
+  </Accordion>
+  <Accordion title="500 internal_error">
+    Retry once. If it keeps happening, email [support@0xinsider.com](mailto:support@0xinsider.com) with the `meta.request_id` from the response.
+  </Accordion>
+</AccordionGroup>

--- a/index.mdx
+++ b/index.mdx
@@ -4,57 +4,43 @@ sidebarTitle: "Introduction"
 description: "Prediction market intelligence for AI agents, trading bots, and research tools."
 ---
 
-The 0xinsider API gives you programmatic access to the same intelligence powering the [0xinsider terminal](https://0xinsider.com) — trader grades, whale trade signals, smart money flow, and insider detection across Polymarket and Kalshi.
+The 0xinsider API gives your code access to the same intelligence layer powering the [0xinsider terminal](https://0xinsider.com) — trader grades, whale trade signals, smart-money flow, positions, and insider detection across Polymarket and Kalshi.
 
-The same data is also available through the live [`@0xinsider/mcp`](https://www.npmjs.com/package/@0xinsider/mcp) package for Claude Code, Cursor, Codex, Gemini CLI, and other MCP clients.
+Same data, three ways in:
+
+- **REST API** — `https://api.0xinsider.com/api/v1/` for bots, dashboards, and research code.
+- **Local MCP server** — [`@0xinsider/mcp`](https://www.npmjs.com/package/@0xinsider/mcp) on stdio for Claude Code, Cursor, Codex, Gemini CLI.
+- **Remote MCP** — streamable HTTP MCP for agents that cannot run a local subprocess.
+
+One [Insider subscription](https://0xinsider.com/pricing) covers all three.
+
+## What problem this solves
+
+You want to answer questions like:
+
+- "Which traders consistently beat the market on crypto resolution events?"
+- "Did anyone buy big into this market in the last hour, and are they sharp money?"
+- "Has someone been accumulating shares in a market that hasn't resolved yet — is this insider behavior?"
+- "Where is smart money flowing this week?"
+- "When that S-grade trader took their position, what price did they get filled at?"
+
+Polymarket and Kalshi publish raw trades. They do not publish grades, signal scores, smart-money breakdowns, position timelines, or pattern detection. That layer is what 0xinsider builds. The API exposes it.
 
 ## What you can build
 
-- **Trading bots** that react to whale trades and smart money signals in real-time
-- **AI agents** that analyze trader performance and market intelligence
-- **Research tools** that pull leaderboard data and historical patterns
-- **Dashboards** that visualize smart money flow across prediction markets
+- **Trading bots** that fire on whale buys from S-grade traders in a chosen category.
+- **AI agents** that summarize who is winning, what they hold, and at what cost basis.
+- **Research tools** that pull leaderboards, batch trader profiles, history ranges, and category performance.
+- **Dashboards** that visualize where capital is rotating across prediction markets.
+- **Webhooks** that push whale-trade and radar events to your stack in real time.
 
-## Endpoints
+## A real response
 
-<CardGroup cols={2}>
-  <Card title="Get Trader" icon="user" href="/api-reference/endpoint/get-trader">
-    Trader grades (S through F), P&L, win rate, strategy detection
-  </Card>
-  <Card title="Whale Trades" icon="whale" href="/api-reference/endpoint/get-whale-trades">
-    Large trades with signal scoring, filterable by grade and category
-  </Card>
-  <Card title="Positions" icon="chart-line" href="/api-reference/endpoint/get-positions">
-    Current position cards with trader, market, value, side, and freshness metadata
-  </Card>
-  <Card title="Position Timeline" icon="timeline" href="/api-reference/endpoint/get-position-timeline">
-    Per-market trader fills with server-computed running amount and average entry price
-  </Card>
-  <Card title="Explore Markets" icon="compass" href="/api-reference/endpoint/explore-markets">
-    Browse whale-active titled markets by category, platform, status, and sort order
-  </Card>
-  <Card title="Market Intel" icon="chart-mixed" href="/api-reference/endpoint/get-market-intel">
-    Smart money flow direction, buy/sell volumes, top positions
-  </Card>
-  <Card title="Leaderboard" icon="ranking-star" href="/api-reference/endpoint/get-leaderboard">
-    Top traders ranked by score with cursor pagination
-  </Card>
-  <Card title="Search Markets" icon="magnifying-glass" href="/api-reference/endpoint/search-markets">
-    Find markets by keyword with category and status filters
-  </Card>
-  <Card title="Insider Radar" icon="radar" href="/api-reference/endpoint/get-insider-radar">
-    Suspicious trading patterns — pre-resolution accumulation, unusual timing
-  </Card>
-  <Card title="Remote MCP" icon="robot" href="/api-reference/endpoint/remote-mcp">
-    Streamable HTTP MCP endpoint for agents that need remote tool access
-  </Card>
-</CardGroup>
-
-## Quick example
+Top 1 trader by composite score, right now:
 
 ```bash
 curl -H "Authorization: Bearer oxi_sk_live_..." \
-  https://api.0xinsider.com/api/v1/leaderboard?limit=3
+  "https://api.0xinsider.com/api/v1/leaderboard?limit=1"
 ```
 
 ```json
@@ -62,34 +48,89 @@ curl -H "Authorization: Bearer oxi_sk_live_..." \
   "object": "list",
   "data": [
     {
-      "id": "trd_0x863...",
+      "id": "trd_0x863134d00841b2e200492805a01e1e2f5defaa53",
       "username": "RepTrump",
       "grade": "S",
       "score": 97.94,
       "pnl": 7532409.67,
-      "win_rate": 1.0
+      "win_rate": 1.0,
+      "markets_traded": 28,
+      "strategy_type": "swing_trader"
     }
   ],
   "has_more": true,
-  "next_cursor": "97.94_0x863..."
+  "next_cursor": "97.94_0x863134d00841b2e200492805a01e1e2f5defaa53"
 }
 ```
 
-## Base URL
+That is one trader. The leaderboard ranks thousands.
 
-```
-https://api.0xinsider.com/api/v1/
-```
-
-## Authentication
-
-API access is bundled with the [Insider subscription](https://0xinsider.com/pricing) ($89/mo). Generate your API key at [0xinsider.com/developers](https://0xinsider.com/developers).
+## Endpoints
 
 <CardGroup cols={2}>
-  <Card title="Get started" icon="rocket" href="/quickstart">
-    Generate a key and make your first request in 2 minutes
+  <Card title="Get Trader" icon="user" href="/api-reference/endpoint/get-trader">
+    Full profile for a wallet — grade, P&L, win rate, strategy, category strengths.
   </Card>
-  <Card title="MCP Server" icon="robot" href="/integrations/mcp">
-    Install the live npm package for Claude Code, Cursor, Codex, Gemini CLI, and other MCP clients
+  <Card title="Batch Get Traders" icon="layer-group" href="/api-reference/endpoint/batch-get-traders">
+    Up to 25 trader profiles in one round trip.
+  </Card>
+  <Card title="Whale Trades" icon="whale" href="/api-reference/endpoint/get-whale-trades">
+    Recent large trades with signal scoring. Filter by grade, category, side.
+  </Card>
+  <Card title="Whale Trades History" icon="clock-rotate-left" href="/api-reference/endpoint/get-whale-trades-history">
+    Historical whale-trade ranges for backtesting and recap reports.
+  </Card>
+  <Card title="Positions" icon="chart-line" href="/api-reference/endpoint/get-positions">
+    Current positions across traders or markets, with freshness metadata.
+  </Card>
+  <Card title="Position Timeline" icon="timeline" href="/api-reference/endpoint/get-position-timeline">
+    Server-computed running amount and average entry price per fill.
+  </Card>
+  <Card title="Explore Markets" icon="compass" href="/api-reference/endpoint/explore-markets">
+    Browse whale-active titled markets by category, platform, status.
+  </Card>
+  <Card title="Market Intel" icon="chart-mixed" href="/api-reference/endpoint/get-market-intel">
+    Smart-money flow direction and top positions for a single market.
+  </Card>
+  <Card title="Market Snapshot" icon="camera" href="/api-reference/endpoint/get-market-snapshot">
+    One-shot market state with trust-metadata fields.
+  </Card>
+  <Card title="Leaderboard" icon="ranking-star" href="/api-reference/endpoint/get-leaderboard">
+    Top traders by composite score, cursor-paginated.
+  </Card>
+  <Card title="Search Markets" icon="magnifying-glass" href="/api-reference/endpoint/search-markets">
+    Keyword search across markets with filters.
+  </Card>
+  <Card title="Insider Radar" icon="radar" href="/api-reference/endpoint/get-insider-radar">
+    Suspicious patterns — pre-resolution accumulation, unusual timing.
+  </Card>
+  <Card title="Event Replay" icon="rotate-right" href="/api-reference/endpoint/get-event-replay-since">
+    Replay missed feed events after a disconnection.
+  </Card>
+  <Card title="Webhooks" icon="webhook" href="/api-reference/endpoint/list-webhooks">
+    Push whale-trade and radar events to your endpoint.
+  </Card>
+  <Card title="Report Snapshots" icon="file-chart-column" href="/api-reference/endpoint/get-daily-report-snapshot">
+    Daily, weekly, monthly recap exports.
+  </Card>
+  <Card title="Remote MCP" icon="robot" href="/api-reference/endpoint/remote-mcp">
+    Streamable HTTP MCP endpoint for hosted agents.
+  </Card>
+</CardGroup>
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
+    Generate a key, fire your first request, and walk through a real "follow the whales" workflow.
+  </Card>
+  <Card title="Local MCP Server" icon="terminal" href="/integrations/mcp">
+    Plug 0xinsider into Claude Code, Cursor, Codex, or Gemini CLI in two minutes.
+  </Card>
+  <Card title="TypeScript Client" icon="code" href="/integrations/typescript-client">
+    Drift-tested source client with typed errors and repeated `expand` params.
+  </Card>
+  <Card title="Trader Grades" icon="medal" href="/concepts/grades">
+    What S, A, B, C, D, F actually mean — with real profile examples.
   </Card>
 </CardGroup>

--- a/integrations/mcp.mdx
+++ b/integrations/mcp.mdx
@@ -1,27 +1,31 @@
 ---
-title: "MCP Server"
-description: "Connect AI agents to 0xinsider with the Model Context Protocol."
+title: "Local MCP Server"
+description: "Give your AI agent direct, read-only access to 0xinsider intelligence over stdio."
 ---
 
-The `@0xinsider/mcp` server lets AI agents access prediction market intelligence directly — trader grades, whale trades, smart money signals, and insider detection.
+[`@0xinsider/mcp`](https://www.npmjs.com/package/@0xinsider/mcp) is the official local Model Context Protocol server. It exposes the same intelligence as the REST API — trader grades, whale trades, smart-money flow, positions, insider detection — as MCP tools your agent can call directly.
 
-The package is live on npm: [`@0xinsider/mcp`](https://www.npmjs.com/package/@0xinsider/mcp).
+Works with **Claude Code, Cursor, Codex, Gemini CLI**, and any client that speaks stdio MCP.
 
-It works with Claude Code, Cursor, Codex, Gemini CLI, and other stdio-compatible MCP clients.
+<Note>
+  Need a hosted HTTP endpoint instead of a local subprocess? See [Remote MCP](/api-reference/endpoint/remote-mcp).
+</Note>
 
-## Install
+## Install — one command
+
+```bash
+npx -y @0xinsider/mcp init
+```
+
+`init` auto-detects which clients you have installed and writes the right config block in the right place. You will be asked for your API key once.
+
+If you prefer to edit configs by hand, the per-client paths and snippets are below.
+
+## Manual install per client
 
 <Tabs>
   <Tab title="Claude Code">
-    Run the interactive setup:
-
-    ```bash
-    npx -y @0xinsider/mcp init
-    ```
-
-    This detects Claude Code and writes the MCP server block automatically.
-
-    Or add manually to `~/.claude/settings.json`:
+    `~/.claude/settings.json`
 
     ```json
     {
@@ -29,24 +33,14 @@ It works with Claude Code, Cursor, Codex, Gemini CLI, and other stdio-compatible
         "0xinsider": {
           "command": "npx",
           "args": ["-y", "@0xinsider/mcp"],
-          "env": {
-            "OXINSIDER_API_KEY": "oxi_sk_live_..."
-          }
+          "env": { "OXINSIDER_API_KEY": "oxi_sk_live_..." }
         }
       }
     }
     ```
   </Tab>
   <Tab title="Cursor">
-    Run the interactive setup:
-
-    ```bash
-    npx -y @0xinsider/mcp init
-    ```
-
-    This detects Cursor and writes the MCP server block automatically.
-
-    Or add manually to `~/.cursor/mcp.json`:
+    `~/.cursor/mcp.json` (restart Cursor after saving)
 
     ```json
     {
@@ -54,26 +48,14 @@ It works with Claude Code, Cursor, Codex, Gemini CLI, and other stdio-compatible
         "0xinsider": {
           "command": "npx",
           "args": ["-y", "@0xinsider/mcp"],
-          "env": {
-            "OXINSIDER_API_KEY": "oxi_sk_live_..."
-          }
+          "env": { "OXINSIDER_API_KEY": "oxi_sk_live_..." }
         }
       }
     }
     ```
-
-    Restart Cursor after saving.
   </Tab>
   <Tab title="Codex">
-    Run the interactive setup:
-
-    ```bash
-    npx -y @0xinsider/mcp init
-    ```
-
-    This detects Codex and runs `codex mcp add` for you.
-
-    Or add manually to `~/.codex/config.toml`:
+    `~/.codex/config.toml`
 
     ```toml
     [mcp_servers."0xinsider"]
@@ -85,15 +67,7 @@ It works with Claude Code, Cursor, Codex, Gemini CLI, and other stdio-compatible
     ```
   </Tab>
   <Tab title="Gemini CLI">
-    Run the interactive setup:
-
-    ```bash
-    npx -y @0xinsider/mcp init
-    ```
-
-    This detects Gemini CLI when the `gemini` command is installed and runs `gemini mcp add --scope user` for you.
-
-    Or add manually to `~/.gemini/settings.json`:
+    `~/.gemini/settings.json`
 
     ```json
     {
@@ -101,24 +75,22 @@ It works with Claude Code, Cursor, Codex, Gemini CLI, and other stdio-compatible
         "0xinsider": {
           "command": "npx",
           "args": ["-y", "@0xinsider/mcp"],
-          "env": {
-            "OXINSIDER_API_KEY": "oxi_sk_live_..."
-          }
+          "env": { "OXINSIDER_API_KEY": "oxi_sk_live_..." }
         }
       }
     }
     ```
 
-    Gemini CLI discovers MCP servers from `settings.json` and exposes the tools through `/mcp`.
+    Gemini exposes the tools through `/mcp`.
   </Tab>
-  <Tab title="Other Clients">
-    Any MCP client that supports stdio transport:
+  <Tab title="Other clients">
+    Any stdio-MCP client works:
 
     ```bash
     OXINSIDER_API_KEY=oxi_sk_live_... npx -y @0xinsider/mcp
     ```
 
-    Need the command list?
+    See all options:
 
     ```bash
     npx -y @0xinsider/mcp --help
@@ -126,82 +98,60 @@ It works with Claude Code, Cursor, Codex, Gemini CLI, and other stdio-compatible
   </Tab>
 </Tabs>
 
-## Tools
+## What the server exposes
 
-The server exposes 9 read-only tools:
+### Tools (read-only)
 
-| Tool | Description |
-|------|-------------|
-| `get_trader` | Look up a trader by wallet address or username — grade, P&L, win rate, strategy, quant metrics |
-| `get_whale_trades` | Recent large trades with signal scoring, filterable by size/category/grade |
-| `get_leaderboard` | Top-ranked traders (S/A/B grades) with optional category/strategy filters |
-| `search_markets` | Search prediction markets by keyword |
-| `explore_markets` | Browse whale-active markets with facets and grouped discovery entries |
-| `get_market_intel` | Smart money flow analysis for a specific market |
-| `get_positions` | Current positions with trader, market, value, side, P&L, and freshness context |
-| `get_position_timeline` | Per-market trader fills with running amount and average entry price |
-| `get_insider_radar` | Suspicious trading pattern detection |
+| Tool | What it does |
+|---|---|
+| `get_trader` | Wallet profile — grade, P&L, win rate, strategy, category strengths. |
+| `get_whale_trades` | Recent large trades, filterable by size, category, grade. |
+| `get_leaderboard` | Top-ranked traders (S/A/B) with optional category/strategy filter. |
+| `get_positions` | Current positions across traders or markets. |
+| `get_position_timeline` | Per-market trader fills with running amount and average entry price. |
+| `search_markets` | Keyword search across prediction markets. |
+| `explore_markets` | Browse whale-active markets by category, platform, status. |
+| `get_market_intel` | Smart-money breakdown for a single market. |
+| `get_insider_radar` | Suspicious accumulation and timing patterns. |
 
-All tools have `readOnlyHint: true` — they never modify data.
+All tools advertise `readOnlyHint: true`. The server cannot place trades or write data.
 
-`get_trader` accepts either an Ethereum wallet address or a known trader username like `swisstony`.
+### Resources (auto-attached context)
 
-## Resources
+| URI | What you get |
+|---|---|
+| `oxinsider://docs/api` | Full API reference, ready for the model to read. |
+| `oxinsider://docs/agents` | Decision tree for agents — when to use which tool. |
+| `oxinsider://data/leaderboard` | Live top 20 traders. |
+| `oxinsider://data/whale-trades` | Live latest 20 whale trades. |
 
-Static and live data available as MCP resources:
+### Prompts (one-shot templates)
 
-| Resource | URI | Description |
-|----------|-----|-------------|
-| API Docs | `oxinsider://docs/api` | Complete API reference |
-| Agent Instructions | `oxinsider://docs/agents` | Decision tree for AI agents |
-| Leaderboard | `oxinsider://data/leaderboard` | Current top 20 traders |
-| Whale Trades | `oxinsider://data/whale-trades` | Latest 20 whale trades |
+| Prompt | Use when |
+|---|---|
+| `analyze_trader` | You want a full breakdown of a specific wallet. |
+| `market_report` | You want smart-money flow on a market topic. |
+| `trading_signals` | You want a scan for high-conviction signals across markets. |
 
-## Prompts
+## Try it
 
-Pre-built prompt templates for common workflows:
+After install, ask your agent things like:
 
-| Prompt | Description |
-|--------|-------------|
-| `analyze_trader` | Deep analysis of a trader — performance, risk profile, category strengths |
-| `market_report` | Smart money flow report for a market topic |
-| `trading_signals` | Scan for high-conviction signals across markets |
+- "Who are the top prediction-market traders right now?"
+- "What are A-grade or better whales buying in crypto markets today?"
+- "Analyze trader `0x863134d00841b2e200492805a01e1e2f5defaa53` — is their strategy worth following?"
+- "Are there suspicious accumulation patterns on the Trump election market?"
+- "Show me the position timeline for that whale on the Ethereum market."
 
-## Example Usage
+The agent will pick the right tool and call it for you.
 
-Once configured, ask your AI agent:
+## Environment variables
 
-```
-Who are the top prediction market traders right now?
-```
-
-```
-What are whales buying in crypto markets?
-```
-
-```
-Analyze trader 0x1234... — is their strategy worth following?
-```
-
-```
-Analyze trader swisstony — is their strategy worth following?
-```
-
-```
-Are there any suspicious trading patterns on the Trump election market?
-```
-
-```
-Generate a smart money report for AI markets
-```
-
-## Environment Variables
-
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `OXINSIDER_API_KEY` | Yes | Your API key (`oxi_sk_live_...`) |
-| `OXINSIDER_API_URL` | No | Override API base URL |
+| Variable | Required | What it controls |
+|---|---|---|
+| `OXINSIDER_API_KEY` | Yes | Your API key (`oxi_sk_live_...`). |
+| `OXINSIDER_API_URL` | No | Override the base URL (mostly for self-hosted dev). |
 
 <Note>
-  The MCP server uses the same API key and rate limits (100 req/min) as direct API access. Get your key at [0xinsider.com/developers](https://0xinsider.com/developers).
+  The MCP server uses your normal API key and shares the 100 req/min rate limit with direct API access. One key, one budget. Get yours at [0xinsider.com/developers](https://0xinsider.com/developers).
 </Note>

--- a/integrations/typescript-client.mdx
+++ b/integrations/typescript-client.mdx
@@ -1,23 +1,23 @@
 ---
-title: "TypeScript client"
-description: "Use the repo-owned TypeScript client source for 0xinsider API calls."
+title: "TypeScript Client"
+description: "Drift-tested source client for the 0xinsider API."
 ---
 
-The TypeScript client source lives in the app repo at `web/src/lib/api-client`.
-It is drift-tested against the checked-in OpenAPI spec, but it is not published
-as an npm package yet.
+A typed TypeScript client lives in the app repo at `web/src/lib/api-client`. It is drift-tested against the checked-in OpenAPI spec — when the spec moves, the client either moves with it or its test suite fails.
 
-Use it as source or example code for now. A package release needs a follow-up
-issue that defines package name, semver policy, changelog ownership, and npm
-access.
+It is **not** published to npm yet. Use it as source or as a reference implementation.
+
+<Note>
+  Want a package release? That needs a separate decision on package name, semver policy, changelog ownership, and npm access. Open an issue if you depend on it.
+</Note>
 
 ## What it handles
 
-- `Authorization: Bearer` API key headers
-- Path parameter interpolation
-- Repeated query parameters such as `expand=strategy&expand=categories`
-- JSON request bodies
-- V1 error envelopes as typed exceptions
+- `Authorization: Bearer` header injection.
+- Path parameter interpolation (`/trader/{address}`, `/market/{condition_id}/intel`).
+- Repeated query parameters such as `expand=strategy&expand=categories`. The legacy `expand[]` form is also accepted by the API.
+- JSON request bodies for batch and webhook endpoints.
+- V1 error envelopes as typed exceptions (`code`, `message`, `param`, `request_id`).
 
 ## Example
 
@@ -29,6 +29,7 @@ const client = new OxinsiderApiClient({
   apiKey: process.env.OXINSIDER_API_KEY,
 });
 
+// Wallet address or username — both work.
 const trader = await client.getTrader("swisstony", {
   query: { expand: ["strategy", "categories"] },
 });
@@ -38,7 +39,30 @@ const markets = await client.searchMarkets("NBA", {
 });
 ```
 
-<Note>
-  Keep using the OpenAPI spec as the source of truth. The client operation table
-  must move whenever `api-reference/openapi.json` changes.
-</Note>
+## Handling errors
+
+The client raises typed exceptions instead of returning a generic error object, so you can match on `error.code` directly:
+
+```ts
+import { OxinsiderApiError } from "./api-client";
+
+try {
+  const trader = await client.getTrader("not-a-real-trader");
+} catch (err) {
+  if (err instanceof OxinsiderApiError) {
+    if (err.code === "not_found") {
+      // expected: unknown trader
+    } else if (err.code === "rate_limited") {
+      await new Promise(r => setTimeout(r, err.retryAfterMs ?? 1000));
+    } else {
+      throw err;
+    }
+  } else {
+    throw err;
+  }
+}
+```
+
+## Keep OpenAPI as the source of truth
+
+The client operation table is regenerated from [`api-reference/openapi.json`](https://github.com/0xinsider/docs/blob/main/api-reference/openapi.json). When you change the OpenAPI spec, the client moves with it. Do not edit the client by hand to add new operations without updating the spec.

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -1,28 +1,43 @@
 ---
 title: "Quickstart"
-description: "Get up and running with the 0xinsider API in 2 minutes."
+description: "From zero to your first whale-trade signal in two minutes."
 ---
 
-## 1. Get an API key
+In this quickstart you will:
 
-API access requires an active [Insider subscription](https://0xinsider.com/pricing) ($89/mo).
+1. Generate an API key.
+2. Confirm it works.
+3. Pull a real "follow the smartest traders" workflow end to end.
+
+## 1. Generate your API key
+
+API access is bundled with the [Insider subscription](https://0xinsider.com/pricing) ($89/mo).
 
 <Steps>
   <Step title="Sign up or log in">
-    Go to [0xinsider.com/sign-up](https://0xinsider.com/sign-up)
+    [0xinsider.com/sign-up](https://0xinsider.com/sign-up)
   </Step>
   <Step title="Subscribe to Insider">
-    Go to [Pricing](https://0xinsider.com/pricing) and subscribe to the Insider plan
+    Pick the Insider plan on [Pricing](https://0xinsider.com/pricing).
   </Step>
-  <Step title="Generate your API key">
-    Go to [Developers](https://0xinsider.com/developers) and click **Generate Key**. Copy the key immediately — you won't see it again.
+  <Step title="Generate your key">
+    On [Developers](https://0xinsider.com/developers), click **Generate Key**. The key is shown once — copy it now. Lost keys can be regenerated, but the old key stops working.
   </Step>
 </Steps>
 
-## 2. Make your first request
+Keys look like `oxi_sk_live_` followed by 64 hex characters.
+
+<Tip>
+  Export it once so the rest of this page just works:
+  ```bash
+  export OXINSIDER_API_KEY="oxi_sk_live_..."
+  ```
+</Tip>
+
+## 2. Confirm the key works
 
 ```bash
-curl -H "Authorization: Bearer oxi_sk_live_YOUR_KEY" \
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   https://api.0xinsider.com/api/v1/health
 ```
 
@@ -34,48 +49,135 @@ curl -H "Authorization: Bearer oxi_sk_live_YOUR_KEY" \
 }
 ```
 
-## 3. Fetch the leaderboard
+If you see `status: "ok"`, you are wired up.
+
+## 3. Follow the smartest traders
+
+The interesting question is rarely "who is #1." It is "what are the best traders doing right now, and am I early?"
+
+### Step A: Pull the top 5 S-grade traders
 
 ```bash
-curl -H "Authorization: Bearer oxi_sk_live_YOUR_KEY" \
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/leaderboard?limit=5"
 ```
 
-## 4. Look up a trader
+Each entry includes the trader's wallet address (`id`), grade, score, P&L, and strategy. Pick one to follow.
+
+### Step B: Look up that trader's full profile
+
+The trader endpoint accepts either a wallet address or a known username:
 
 ```bash
-curl -H "Authorization: Bearer oxi_sk_live_YOUR_KEY" \
-  https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53"
 ```
 
-## 5. Get whale trades
+The response gives you their realized P&L, win rate, category strengths, and current open positions.
+
+### Step C: See what whales are buying right now
+
+Filter to A-grade or better, last 50 trades:
 
 ```bash
-curl -H "Authorization: Bearer oxi_sk_live_YOUR_KEY" \
-  "https://api.0xinsider.com/api/v1/whale-trades?limit=10&min_grade=A"
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&limit=50"
 ```
 
-This returns only trades from A-grade or higher traders, sorted by most recent.
+You can layer filters. For example, A-grade or better, crypto markets only, BUY side:
 
-## Next steps
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&category=crypto&side=buy&limit=50"
+```
+
+### Step D: Drill into one of those markets
+
+Grab the `condition_id` from a whale trade you find interesting (raw hex — not the prefixed `mkt_...` form), then:
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/market/<condition_id>/intel"
+```
+
+Market Intel returns the smart-money breakdown: buy volume vs sell volume from graded traders, top positions, and which side conviction is on.
+
+That is the loop: **leaderboard -> trader profile -> whale trades -> market intel**. Bolt it onto a cron, a chatbot, or a dashboard.
+
+## Same workflow, in code
+
+<CodeGroup>
+```javascript JavaScript
+const KEY = process.env.OXINSIDER_API_KEY;
+const headers = { Authorization: `Bearer ${KEY}` };
+
+const top = await fetch(
+  "https://api.0xinsider.com/api/v1/leaderboard?limit=5",
+  { headers }
+).then(r => r.json());
+
+const topId = top.data[0].id.replace(/^trd_/, "");
+
+const trader = await fetch(
+  `https://api.0xinsider.com/api/v1/trader/${topId}`,
+  { headers }
+).then(r => r.json());
+
+const whales = await fetch(
+  "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&limit=50",
+  { headers }
+).then(r => r.json());
+
+console.log({ top: top.data[0], trader: trader.data, whales: whales.data.length });
+```
+
+```python Python
+import os, requests
+
+KEY = os.environ["OXINSIDER_API_KEY"]
+H = {"Authorization": f"Bearer {KEY}"}
+BASE = "https://api.0xinsider.com/api/v1"
+
+top = requests.get(f"{BASE}/leaderboard", params={"limit": 5}, headers=H).json()
+top_id = top["data"][0]["id"].removeprefix("trd_")
+
+trader = requests.get(f"{BASE}/trader/{top_id}", headers=H).json()
+whales = requests.get(
+    f"{BASE}/whale-trades",
+    params={"min_grade": "A", "limit": 50},
+    headers=H,
+).json()
+
+print(top["data"][0], trader["data"]["grade"], len(whales["data"]))
+```
+</CodeGroup>
+
+## Want the call count even lower? Use a batch endpoint
+
+If you already have the addresses of N traders you care about, fetch them all in one call:
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"addresses": ["0xabc...", "0xdef...", "0x123..."]}' \
+  "https://api.0xinsider.com/api/v1/traders/batch"
+```
+
+Batch reads return the same per-item shape, with per-item error fields when one address fails. They count against a separate batch-item rate-limit budget — see [Rate Limits](/rate-limits).
+
+## Next
 
 <CardGroup cols={2}>
-  <Card title="Authentication" icon="key" href="/authentication">
-    API key format, headers, and security
-  </Card>
-  <Card title="Rate Limits" icon="gauge" href="/rate-limits">
-    100 requests per minute, sliding window
-  </Card>
-  <Card title="API Reference" icon="code" href="/api-reference/introduction">
-    Full endpoint documentation
-  </Card>
-  <Card title="Error Handling" icon="triangle-exclamation" href="/errors">
-    Error codes and troubleshooting
-  </Card>
-  <Card title="MCP Server" icon="robot" href="/integrations/mcp">
-    Install the live npm package for Claude Code, Cursor, Codex, Gemini CLI, and other MCP clients
+  <Card title="Local MCP Server" icon="terminal" href="/integrations/mcp">
+    Skip the HTTP plumbing — give your AI agent the same tools directly.
   </Card>
   <Card title="TypeScript Client" icon="code" href="/integrations/typescript-client">
-    Use the repo-owned source client and OpenAPI drift-tested examples
+    Use the repo-owned source client with typed errors and `expand` helpers.
+  </Card>
+  <Card title="Trader Grades" icon="medal" href="/concepts/grades">
+    What S, A, B, C, D, F actually mean.
+  </Card>
+  <Card title="Errors & Rate Limits" icon="triangle-exclamation" href="/errors">
+    What to do when a request fails.
   </Card>
 </CardGroup>

--- a/rate-limits.mdx
+++ b/rate-limits.mdx
@@ -1,50 +1,52 @@
 ---
 title: "Rate Limits"
-description: "Request limits and how to handle them."
+description: "How many requests you can make, and how to back off cleanly."
 ---
 
-## Limits
+The API allows **100 requests per minute** on a sliding window. The limit is **per user**, shared across every key and every endpoint.
 
-| Metric | Value |
-|--------|-------|
-| Requests per minute | **100** |
-| Window type | Sliding window |
-| Scope | Per user (not per key) |
-| Batch item units per minute | **100** |
+Batch read endpoints (e.g. `POST /api/v1/traders/batch`, `POST /api/v1/markets/intel/batch`) have a **separate** budget measured in *item units*, also 100 per minute. A 25-item batch reserves 25 item units before it executes.
 
-The rate limit is shared across all endpoints and all keys belonging to the same user.
+| Setting | Value |
+|---|---|
+| Requests per minute | 100 |
+| Batch item units per minute | 100 |
+| Window type | Sliding (not bucket-of-60-seconds) |
+| Scope | Per user (sum of all keys) |
+| Header on success | `X-RateLimit-*` (+ `X-Batch-RateLimit-*` on batch endpoints) |
+| Header on `429` | `Retry-After` |
 
-Batch read endpoints also reserve item units before execution. A 25-trader
-batch costs 25 item units; a 25-market intel batch costs 25 item units.
+## Headers you should read
 
-## Response headers
-
-Every authenticated response includes rate limit headers:
+Every authenticated response carries:
 
 ```
-X-RateLimit-Limit: 100
+X-RateLimit-Limit:     100
 X-RateLimit-Remaining: 87
-X-RateLimit-Reset: 1774450631
+X-RateLimit-Reset:     1774450631
 ```
 
-| Header | Description |
-|--------|-------------|
-| `X-RateLimit-Limit` | Maximum requests per minute |
-| `X-RateLimit-Remaining` | Requests remaining in current window |
-| `X-RateLimit-Reset` | Unix timestamp when the window resets |
+| Header | Meaning |
+|---|---|
+| `X-RateLimit-Limit` | Max requests per minute. |
+| `X-RateLimit-Remaining` | Remaining slots in the current window. |
+| `X-RateLimit-Reset` | Unix timestamp (seconds) when the window resets. |
 
-Batch responses also include:
+Batch responses additionally carry:
 
-| Header | Description |
-|--------|-------------|
-| `X-Request-Cost` | Number of batch item units charged for the request |
-| `X-Batch-RateLimit-Limit` | Maximum batch item units per minute |
-| `X-Batch-RateLimit-Remaining` | Batch item units remaining |
-| `X-Batch-RateLimit-Reset` | Unix timestamp when the batch item window resets |
+| Header | Meaning |
+|---|---|
+| `X-Request-Cost` | Item units this single call charged (one per batch item). |
+| `X-Batch-RateLimit-Limit` | Max item units per minute. |
+| `X-Batch-RateLimit-Remaining` | Item units remaining in the window. |
+| `X-Batch-RateLimit-Reset` | Unix timestamp when the batch window resets. |
 
-## Rate limit exceeded
+If you go over either budget, you get a `429` plus a `Retry-After` header in seconds:
 
-When you exceed the limit, you'll receive a `429` response:
+```
+HTTP/1.1 429 Too Many Requests
+Retry-After: 12
+```
 
 ```json
 {
@@ -52,20 +54,57 @@ When you exceed the limit, you'll receive a `429` response:
   "error": {
     "code": "rate_limited",
     "message": "Rate limit exceeded. Retry after 12s.",
-    "doc_url": "https://docs.0xinsider.com/api-reference/introduction#rate-limits"
+    "doc_url": "https://docs.0xinsider.com/rate-limits"
   }
 }
 ```
 
-The `Retry-After` header tells you how many seconds to wait:
+## A real "respect the retry" client
 
+<CodeGroup>
+```javascript JavaScript
+async function fetchWithBackoff(url, opts = {}, maxRetries = 5) {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    const res = await fetch(url, opts);
+    if (res.status !== 429) return res;
+
+    const wait = Number(res.headers.get("retry-after") ?? 1) * 1000;
+    await new Promise(r => setTimeout(r, wait));
+  }
+  throw new Error("Rate limit retries exhausted");
+}
+
+const res = await fetchWithBackoff(
+  "https://api.0xinsider.com/api/v1/whale-trades?limit=50",
+  { headers: { Authorization: `Bearer ${process.env.OXINSIDER_API_KEY}` } }
+);
+const body = await res.json();
 ```
-Retry-After: 12
+
+```python Python
+import os, time, requests
+
+def get_with_backoff(url, params=None, max_retries=5):
+    headers = {"Authorization": f"Bearer {os.environ['OXINSIDER_API_KEY']}"}
+    for _ in range(max_retries):
+        r = requests.get(url, params=params, headers=headers)
+        if r.status_code != 429:
+            return r
+        time.sleep(int(r.headers.get("Retry-After", "1")))
+    raise RuntimeError("Rate limit retries exhausted")
+
+body = get_with_backoff(
+    "https://api.0xinsider.com/api/v1/whale-trades",
+    params={"limit": 50},
+).json()
 ```
+</CodeGroup>
 
-## Best practices
+## Staying well under the limit
 
-- **Cache responses** — most data updates every 30-120 seconds
-- **Use cursor pagination** instead of re-fetching full lists
-- **Backoff on 429** — respect the `Retry-After` header
-- **Batch your reads** — fetch what you need in fewer, larger requests (higher `limit`)
+- **Cache.** Most of this data updates every 30-120 seconds. Re-fetching every second is wasted budget.
+- **Paginate, do not re-list.** Use cursors instead of refetching the full leaderboard each loop.
+- **Ask for more per request.** Bump `limit` up to 100 instead of making 10 calls of `limit=10`.
+- **Use batch endpoints when you already know your IDs.** One batch call for 25 traders costs 25 batch-item units, but only one regular request.
+- **Watch `X-RateLimit-Remaining`.** If it crosses below 10, pause your polling for the next reset.
+- **One process owns the polling.** Avoid every container in a fleet polling the same endpoint with the same key.


### PR DESCRIPTION
## Summary

Rewrites every shipping page on `docs.0xinsider.com` so the docs read clearly, lead with concrete outcomes, and include real curl + JS + Python examples on every page where it matters.

Fixes #17

## What changed

- **`index.mdx`** — opens with the problem this API solves; shows a real leaderboard response shape; refreshed card grid.
- **`quickstart.mdx`** — one connected scenario (leaderboard -> trader profile -> whale trades -> market intel) instead of five disjoint snippets; full JS + Python code-group at the end.
- **`authentication.mdx`** — adds a common-mistakes accordion (Bearer prefix, partial copy, expired subscription, stale key after regenerate); keeps the key-management table.
- **`rate-limits.mdx`** — adds a Retry-After backoff client in JS + Python; staying-under-the-limit tactics.
- **`errors.mdx`** — adds an error-handling client in JS + Python; troubleshooting accordion for the four codes that actually happen.
- **`concepts/grades.mdx`** — real S-grade vs C-grade JSON side by side; explains the 5 score inputs; shows grade + category combined filter.
- **`concepts/pagination.mdx`** — full pagination loop in JS + Python; cursor opacity rules; gotchas (mixed filters, stale cursors).
- **`concepts/number-formatting.mdx`** — tightened; surfaces nullability rule.
- **`api-reference/introduction.mdx`** — splits envelope into single vs list; field table for `meta` / `has_more`; note about stripping `trd_` for path params.
- **`api-reference/endpoint/*.mdx`** — adds one paragraph + one example curl above every OpenAPI playground for all 8 endpoints.
- **`integrations/mcp.mdx`** — de-duplicates the "Run interactive setup" block that was repeated 4× across tabs; leads with one `npx init`; collapses manual configs to one snippet per client; tools/resources/prompts tables.

## What did not change

- `docs.json` navigation
- OpenAPI spec (`api-reference/openapi.json`)
- `changelog.mdx` (no shipped REST API changes are part of this PR)
- `custom.css`, logos, favicon

## Mechanics

- `mint broken-links` clean.
- No emojis.
- Added `.worktrees/` to `.gitignore` and `.mintignore` (was leaking 4 false broken-link reports from old local worktrees).

## Test plan

- [x] `mint broken-links` reports no broken links.
- [x] Non-ASCII glyph scan returns only em dashes (intentional), no emoji.
- [ ] Mintlify preview deploy renders all pages without MDX errors.
- [ ] Spot-check on preview: `/`, `/quickstart`, `/concepts/grades`, `/integrations/mcp`, `/api-reference/endpoint/get-whale-trades`.

---

## Update — 2026-05-22: rebased onto new main, scope expanded

Main shipped the May 8 builder API expansion (batch, history, events, webhooks, reports, snapshots, position endpoints, remote MCP) while this branch was open. Rebased and integrated:

- `index.mdx` card grid now covers positions, position timeline, batch endpoints, whale trades history, market snapshot, event replay, webhooks, report snapshots, and remote MCP.
- `api-reference/introduction.mdx` documents the second rate-limit budget (batch item units), `X-Batch-RateLimit-*` / `X-Request-Cost` headers, and trust-metadata fields (`source`, `freshness`, `reconciliation`, `completeness`).
- `rate-limits.mdx` and `errors.mdx` updated to match (batch budget; per-item batch error rule; Market Intel mkt_-prefix 400).
- `concepts/number-formatting.mdx` adds the "do not flatten `unavailable` into `0`" trust-metadata rule.
- `integrations/mcp.mdx` updated tool list (9 tools incl. `get_positions`, `get_position_timeline`, `explore_markets`) and points at remote MCP.
- `integrations/typescript-client.mdx` adds a typed-error example.
- Added prose intros for every new endpoint file: `batch-get-traders`, `batch-get-market-intel`, `get-positions`, `get-position-timeline`, `get-position-timeline-by-id`, `get-trader-export-snapshot`, `get-whale-trades-history`, `get-market-snapshot`, `get-event-replay-since`, `list-webhooks` (+ webhook lifecycle map), `create-webhook`, `get-webhook`, `update-webhook`, `delete-webhook`, `verify-webhook`, `rotate-webhook-secret`, `get-daily-report-snapshot`, `get-weekly-report-snapshot`, `get-monthly-report-snapshot`, `remote-mcp`, `remote-mcp-stream`.
- Branch force-pushed; `mint broken-links` still clean; no emojis.
