### PR TITLE
docs: document API DX hardening

### DIFF
--- a/api-reference/endpoint/create-webhook.mdx
+++ b/api-reference/endpoint/create-webhook.mdx
@@ -7,12 +7,16 @@ Register a webhook endpoint to receive whale trade and radar events as they happ
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  -H "Idempotency-Key: webhook-create-2026-06-01" \
   -H "Content-Type: application/json" \
   -d '{
+    "name": "Production webhook",
     "url": "https://api.yourapp.com/webhooks/0xinsider",
-    "events": ["whale_trade.created", "radar_flag.created"]
+    "event_types": ["whale_trades_inserted"]
   }' \
   "https://api.0xinsider.com/api/v1/webhooks"
 ```
 
 The response includes a one-time signing secret. **Copy it immediately** — you cannot retrieve it later. Use it to verify the `X-0xinsider-Signature` header on every delivery; see [Verify Webhook](/api-reference/endpoint/verify-webhook). If the secret leaks, [rotate it](/api-reference/endpoint/rotate-webhook-secret).
+
+Use `Idempotency-Key` when retrying create after a timeout. Reusing the same key with the same body returns the original webhook; reusing it with a different body returns `422`.

--- a/api-reference/endpoint/delete-webhook.mdx
+++ b/api-reference/endpoint/delete-webhook.mdx
@@ -8,7 +8,10 @@ Permanently remove a webhook registration. After deletion no further events are 
 ```bash
 curl -X DELETE \
   -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  -H "Idempotency-Key: webhook-delete-2026-06-01" \
   "https://api.0xinsider.com/api/v1/webhooks/wh_abc123"
 ```
 
-To temporarily stop deliveries without losing the registration, [update](/api-reference/endpoint/update-webhook) the webhook to `active: false` instead.
+To temporarily stop deliveries without losing the registration, [update](/api-reference/endpoint/update-webhook) the webhook to `enabled: false` instead.
+
+Use `Idempotency-Key` when retrying a delete. A matching retry returns the original disabled webhook response instead of a second delete attempt.

--- a/api-reference/endpoint/get-api-discovery.mdx
+++ b/api-reference/endpoint/get-api-discovery.mdx
@@ -1,0 +1,14 @@
+---
+title: "Get API Discovery"
+openapi: "GET /api/v1"
+---
+
+Discover the public V1 API surface without an API key.
+
+`GET /api/v1` returns the canonical API base URL, full docs URL, OpenAPI URL, unauthenticated health URL, and representative authenticated data routes.
+
+```bash
+curl "https://api.0xinsider.com/api/v1"
+```
+
+Use this endpoint as the first API-origin probe for agents, SDK setup flows, and uptime checks that need to find the docs and health endpoints before authenticating.

--- a/api-reference/endpoint/get-usage.mdx
+++ b/api-reference/endpoint/get-usage.mdx
@@ -3,9 +3,11 @@ title: "Get Usage"
 openapi: "GET /api/v1/usage"
 ---
 
-Read your current request budget without spending a request against it.
+Read your current request budget without spending primary request quota.
 
-`GET /api/v1/usage` returns the live per-minute limiter window plus UTC-day usage. The daily `limit` and `remaining` fields are `null` because V1 does not have a daily hard cap.
+`GET /api/v1/usage` returns the live per-minute primary limiter window plus UTC-day usage. It does not increment the primary request counter and does not log itself into daily usage. To protect the usage-count query, the endpoint has its own 100 reads/minute per-user guard; a 429 from this endpoint is a backoff signal, not evidence that primary quota was spent.
+
+The daily `limit` and `remaining` fields are `null` because V1 does not have a daily hard cap.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \

--- a/api-reference/endpoint/get-usage.mdx
+++ b/api-reference/endpoint/get-usage.mdx
@@ -1,0 +1,15 @@
+---
+title: "Get Usage"
+openapi: "GET /api/v1/usage"
+---
+
+Read your current request budget without spending a request against it.
+
+`GET /api/v1/usage` returns the live per-minute limiter window plus UTC-day usage. The daily `limit` and `remaining` fields are `null` because V1 does not have a daily hard cap.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/usage"
+```
+
+Use this endpoint for quota introspection instead of polling another data endpoint just to infer remaining budget.

--- a/api-reference/endpoint/redirect-api-openapi-spec.mdx
+++ b/api-reference/endpoint/redirect-api-openapi-spec.mdx
@@ -1,0 +1,14 @@
+---
+title: "Redirect OpenAPI Spec"
+openapi: "GET /api/v1/openapi.json"
+---
+
+Resolve the canonical OpenAPI document from the API origin.
+
+`GET /api/v1/openapi.json` returns a temporary redirect to the web-origin spec at `https://0xinsider.com/api/v1/openapi.json`. The redirect avoids duplicating OpenAPI ownership while still letting API-origin probes discover the spec.
+
+```bash
+curl -I "https://api.0xinsider.com/api/v1/openapi.json"
+```
+
+Use the `Location` header as the canonical OpenAPI URL for code generation and docs tooling.

--- a/api-reference/endpoint/rotate-webhook-secret.mdx
+++ b/api-reference/endpoint/rotate-webhook-secret.mdx
@@ -8,7 +8,10 @@ Generate a fresh signing secret for a webhook. The response includes the new sec
 ```bash
 curl -X POST \
   -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  -H "Idempotency-Key: webhook-rotate-2026-06-01" \
   "https://api.0xinsider.com/api/v1/webhooks/wh_abc123/rotate-secret"
 ```
 
 Rotate immediately if a secret has leaked (committed to git, exposed in a log, sent in a screenshot).
+
+Use `Idempotency-Key` when retrying a rotate after a timeout. A matching retry returns the same one-time signing secret response instead of rotating again.

--- a/api-reference/endpoint/update-webhook.mdx
+++ b/api-reference/endpoint/update-webhook.mdx
@@ -8,9 +8,12 @@ Change a webhook's destination URL, subscribed events, or active flag without re
 ```bash
 curl -X PATCH \
   -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  -H "Idempotency-Key: webhook-update-2026-06-01" \
   -H "Content-Type: application/json" \
-  -d '{"active": false}' \
+  -d '{"enabled": false}' \
   "https://api.0xinsider.com/api/v1/webhooks/wh_abc123"
 ```
 
 The signing secret is not affected by `PATCH`. To change it, use [Rotate Webhook Secret](/api-reference/endpoint/rotate-webhook-secret).
+
+Use `Idempotency-Key` when retrying the same update body. A matching retry replays the original response; a different body with the same key returns `422`.

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -70,7 +70,7 @@ When an endpoint accepts an address in the path (`/trader/{address}`), pass the 
 
 ## Rate limits
 
-100 requests per minute per user, sliding window. Batch endpoints have an additional 100-item-unit-per-minute budget.
+100 requests per minute per user, sliding window. Batch endpoints have an additional 100-item-unit-per-minute budget. `GET /api/v1/usage` does not spend primary quota, but it has its own 100 reads/minute guard.
 
 | Header | Meaning |
 |---|---|

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -24,10 +24,12 @@
   "paths": {
     "/api/v1/trader/{address}": {
       "get": {
-        "operationId": "get_trader",
+        "operationId": "getTrader",
         "summary": "Get trader intelligence",
         "description": "Returns a trader's grade (S through F), P&L, win rate, and optional strategy/category data. The path accepts either an Ethereum wallet address or a known trader username. Unknown lookups return sync_status \"unknown\" instead of 404.",
-        "tags": ["Traders"],
+        "tags": [
+          "Traders"
+        ],
         "parameters": [
           {
             "name": "address",
@@ -47,7 +49,11 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["strategy", "categories", "quant_metrics"]
+                "enum": [
+                  "strategy",
+                  "categories",
+                  "quant_metrics"
+                ]
               }
             },
             "style": "form",
@@ -62,11 +68,24 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["strategy", "categories", "quant_metrics"]
+                "enum": [
+                  "strategy",
+                  "categories",
+                  "quant_metrics"
+                ]
               }
             },
             "style": "form",
             "explode": true
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "Conditional GET validator from a previous ETag. Matching values return 304 Not Modified with an empty body.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -76,7 +95,11 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "meta"
+                  ],
                   "properties": {
                     "object": {
                       "type": "string",
@@ -89,7 +112,45 @@
                       "$ref": "#/components/schemas/ResponseMeta"
                     }
                   }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "traders",
+                      "data": {},
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
                 }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified. Returned when If-None-Match matches the current payload.",
+            "headers": {
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
               }
             }
           },
@@ -117,30 +178,74 @@
           "503": {
             "$ref": "#/components/responses/RateLimitUnavailable"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/trader/{address}'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "traders",
+            "data": {},
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/traders/batch": {
       "post": {
-        "operationId": "batch_get_traders",
+        "operationId": "batchGetTraders",
         "summary": "Batch trader intelligence",
         "description": "Returns trader intelligence for 1-25 wallet addresses or known usernames. Results preserve request order, duplicate inputs return duplicate rows, and each item is charged one batch item unit before execution. Unknown trader lookups return data with sync_status \"unknown\" matching the single trader endpoint.",
-        "tags": ["Traders"],
+        "tags": [
+          "Traders"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["traders"],
+                "required": [
+                  "traders"
+                ],
                 "properties": {
-                  "traders": { "type": "array", "minItems": 1, "maxItems": 25, "items": { "type": "string" } },
+                  "traders": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 25,
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "expand": {
                     "type": "array",
-                    "items": { "type": "string", "enum": ["strategy", "categories", "quant_metrics"] },
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "strategy",
+                        "categories",
+                        "quant_metrics"
+                      ]
+                    },
                     "description": "Shared expand flags applied to every trader item."
                   }
                 }
+              },
+              "example": {
+                "traders": [
+                  "swisstony",
+                  "0x0000000000000000000000000000000000000000"
+                ],
+                "expand": [
+                  "strategy"
+                ]
               }
             }
           }
@@ -150,54 +255,138 @@
             "description": "Ordered batch trader results",
             "headers": {
               "X-Request-Cost": {
-                "schema": { "type": "integer" },
+                "schema": {
+                  "type": "integer"
+                },
                 "description": "Number of batch item units charged for this request."
               },
               "X-Batch-RateLimit-Limit": {
-                "schema": { "type": "integer" },
+                "schema": {
+                  "type": "integer"
+                },
                 "description": "Batch item units allowed per minute."
               },
               "X-Batch-RateLimit-Remaining": {
-                "schema": { "type": "integer" },
+                "schema": {
+                  "type": "integer"
+                },
                 "description": "Batch item units remaining in the current sliding window."
               },
               "X-Batch-RateLimit-Reset": {
-                "schema": { "type": "integer" },
+                "schema": {
+                  "type": "integer"
+                },
                 "description": "Unix timestamp when the batch item window resets."
+              },
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "meta"
+                  ],
                   "properties": {
-                    "object": { "type": "string", "const": "trader_batch" },
-                    "data": { "type": "array", "items": { "$ref": "#/components/schemas/BatchTraderItem" } },
-                    "meta": { "$ref": "#/components/schemas/BatchResponseMeta" }
+                    "object": {
+                      "type": "string",
+                      "const": "trader_batch"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/BatchTraderItem"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/BatchResponseMeta"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "traders",
+                      "data": {},
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
                   }
                 }
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "402": { "$ref": "#/components/responses/SubscriptionRequired" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "408": { "$ref": "#/components/responses/RequestTimeout" },
-          "423": { "$ref": "#/components/responses/Locked" },
-          "429": { "$ref": "#/components/responses/RateLimited" },
-          "503": { "$ref": "#/components/responses/RateLimitUnavailable" },
-          "500": { "$ref": "#/components/responses/InternalError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/SubscriptionRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "423": {
+            "$ref": "#/components/responses/Locked"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "503": {
+            "$ref": "#/components/responses/RateLimitUnavailable"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -X POST \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"traders\":[\"swisstony\",\"0x0000000000000000000000000000000000000000\"],\"expand\":[\"strategy\"]}' \\\n  'https://api.0xinsider.com/api/v1/traders/batch'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "traders",
+            "data": {},
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/trader/{address}/position-timeline": {
       "get": {
-        "operationId": "get_position_timeline",
+        "operationId": "getPositionTimeline",
         "summary": "Get a trader's position timeline for one market",
         "description": "Returns every Polymarket fill for one trader in one market, newest first, with server-computed running_amount and running_avg_price. Only HOT and WARM tier traders are tracked; other traders return 404. running_avg_price is a buy-weighted entry basis (sells do not change the running average) matching Polymarket /positions avgPrice semantics. Cursor-paginated. An id-keyed alias exists at GET /api/v1/traders/{id}/position-timeline.",
-        "tags": ["Traders"],
+        "tags": [
+          "Traders"
+        ],
         "parameters": [
           {
             "name": "address",
@@ -234,6 +423,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "Conditional GET validator from a previous ETag. Matching values return 304 Not Modified with an empty body.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -243,7 +441,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "has_more", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "has_more",
+                    "meta"
+                  ],
                   "properties": {
                     "object": {
                       "type": "string",
@@ -266,7 +469,48 @@
                       "$ref": "#/components/schemas/ResponseMeta"
                     }
                   }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "list",
+                      "data": [],
+                      "has_more": false,
+                      "next_cursor": null,
+                      "total": 0,
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
                 }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified. Returned when If-None-Match matches the current payload.",
+            "headers": {
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
               }
             }
           },
@@ -300,15 +544,37 @@
           "503": {
             "$ref": "#/components/responses/RateLimitUnavailable"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/trader/{address}/position-timeline'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "next_cursor": null,
+            "total": 0,
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/traders/{id}/position-timeline": {
       "get": {
-        "operationId": "get_position_timeline_by_id",
+        "operationId": "getPositionTimelineById",
         "summary": "Get a trader's position timeline by integer id",
         "description": "Id-keyed alias of GET /api/v1/trader/{address}/position-timeline. Response body is byte-identical for the same underlying trader. Useful for worker tasks and agent clients already holding a numeric traders.id.",
-        "tags": ["Traders"],
+        "tags": [
+          "Traders"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -346,6 +612,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "Conditional GET validator from a previous ETag. Matching values return 304 Not Modified with an empty body.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -355,7 +630,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "has_more", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "has_more",
+                    "meta"
+                  ],
                   "properties": {
                     "object": {
                       "type": "string",
@@ -378,7 +658,48 @@
                       "$ref": "#/components/schemas/ResponseMeta"
                     }
                   }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "list",
+                      "data": [],
+                      "has_more": false,
+                      "next_cursor": null,
+                      "total": 0,
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
                 }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified. Returned when If-None-Match matches the current payload.",
+            "headers": {
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
               }
             }
           },
@@ -412,15 +733,37 @@
           "503": {
             "$ref": "#/components/responses/RateLimitUnavailable"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/traders/{id}/position-timeline'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "next_cursor": null,
+            "total": 0,
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/positions": {
       "get": {
-        "operationId": "get_positions",
+        "operationId": "listPositions",
         "summary": "List current positions (positions-board feed)",
         "description": "Returns the current positions-board feed backed by the wallet_positions mirror. Ordered by current_value_usd DESC with deterministic (wallet, condition_id, outcome_index) tiebreakers. Pre-reconcile rows (current_value_usd IS NULL) are excluded. Cursor-paginated. Every filter pushes into SQL.",
-        "tags": ["Positions"],
+        "tags": [
+          "Positions"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -463,7 +806,14 @@
             "description": "Minimum trader grade allowlist. `A` matches S and A; `B` matches S, A, B; etc.",
             "schema": {
               "type": "string",
-              "enum": ["S", "A", "B", "C", "D", "F"]
+              "enum": [
+                "S",
+                "A",
+                "B",
+                "C",
+                "D",
+                "F"
+              ]
             }
           },
           {
@@ -472,7 +822,19 @@
             "description": "Filter by the binary outcome side. `yes` maps to outcome_index=0, `no` to outcome_index=1.",
             "schema": {
               "type": "string",
-              "enum": ["yes", "no"]
+              "enum": [
+                "yes",
+                "no"
+              ]
+            }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "Conditional GET validator from a previous ETag. Matching values return 304 Not Modified with an empty body.",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -483,7 +845,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "has_more", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "has_more",
+                    "meta"
+                  ],
                   "properties": {
                     "object": {
                       "type": "string",
@@ -506,7 +873,48 @@
                       "$ref": "#/components/schemas/ResponseMeta"
                     }
                   }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "list",
+                      "data": [],
+                      "has_more": false,
+                      "next_cursor": null,
+                      "total": 0,
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
                 }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified. Returned when If-None-Match matches the current payload.",
+            "headers": {
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
               }
             }
           },
@@ -534,15 +942,37 @@
           "503": {
             "$ref": "#/components/responses/RateLimitUnavailable"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/positions'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "next_cursor": null,
+            "total": 0,
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/whale-trades": {
       "get": {
-        "operationId": "get_whale_trades",
+        "operationId": "listWhaleTrades",
         "summary": "List whale trades",
         "description": "Returns recent large trades with signal scoring. Filter by size, category, or trader grade. Filters are applied before pagination, and every request uses SQL-backed limit + 1 pagination so has_more and next_cursor reflect the filtered result set. Cursor-paginated, newest first. Market categories come from provider-backed market_canonical identity.",
-        "tags": ["Whale Trades"],
+        "tags": [
+          "Whale Trades"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -585,7 +1015,23 @@
             "description": "Minimum trader grade.",
             "schema": {
               "type": "string",
-              "enum": ["S", "A", "B", "C", "D", "F"]
+              "enum": [
+                "S",
+                "A",
+                "B",
+                "C",
+                "D",
+                "F"
+              ]
+            }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "Conditional GET validator from a previous ETag. Matching values return 304 Not Modified with an empty body.",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -596,7 +1042,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "has_more", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "has_more",
+                    "meta"
+                  ],
                   "properties": {
                     "object": {
                       "type": "string",
@@ -619,7 +1070,48 @@
                       "$ref": "#/components/schemas/ResponseMeta"
                     }
                   }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "list",
+                      "data": [],
+                      "has_more": false,
+                      "next_cursor": null,
+                      "total": 0,
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
                 }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified. Returned when If-None-Match matches the current payload.",
+            "headers": {
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
               }
             }
           },
@@ -647,74 +1139,144 @@
           "503": {
             "$ref": "#/components/responses/RateLimitUnavailable"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/whale-trades'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "next_cursor": null,
+            "total": 0,
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/whale-trades/history": {
       "get": {
-        "operationId": "get_whale_trades_history",
+        "operationId": "listWhaleTradeHistory",
         "summary": "Replay historical whale trades",
         "description": "Returns historical whale trades from local whale_alerts rows, not request-time provider fetches. Filter by condition_id, trader, category, minimum grade, platform, and RFC3339 from/to windows. All filters are pushed into SQL before LIMIT, every request uses SQL-backed limit + 1 pagination, and results are ordered newest first by traded_at desc, id desc. Metadata exposes local_replay source and best_effort completeness.",
-        "tags": ["Whale Trades"],
+        "tags": [
+          "Whale Trades"
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 }
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
           },
           {
             "name": "cursor",
             "in": "query",
             "description": "Pagination cursor from previous response's next_cursor. Prefix: wth_. URL-encode when replaying as a query parameter.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "min_size",
             "in": "query",
             "description": "Minimum trade size in USD.",
-            "schema": { "type": "number", "default": 5000 }
+            "schema": {
+              "type": "number",
+              "default": 5000
+            }
           },
           {
             "name": "condition_id",
             "in": "query",
             "description": "Exact raw provider condition_id. Unknown markets return an empty list.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "trader",
             "in": "query",
             "description": "Trader wallet address, timestamp-suffixed wallet alias, or username resolved against the traders table. Unknown traders return an empty list.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "category",
             "in": "query",
             "description": "Filter by provider-backed market_canonical category (case-insensitive).",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "min_grade",
             "in": "query",
             "description": "Minimum trader grade.",
-            "schema": { "type": "string", "enum": ["S", "A", "B", "C", "D", "F"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "S",
+                "A",
+                "B",
+                "C",
+                "D",
+                "F"
+              ]
+            }
           },
           {
             "name": "platform",
             "in": "query",
             "description": "Filter by whale_alerts.platform. all is equivalent to omitted.",
-            "schema": { "type": "string", "enum": ["polymarket", "kalshi", "all"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "all"
+              ]
+            }
           },
           {
             "name": "from",
             "in": "query",
             "description": "Inclusive RFC3339 lower bound on whale_alerts.traded_at.",
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "to",
             "in": "query",
             "description": "Exclusive RFC3339 upper bound on whale_alerts.traded_at. Must be after from when both are present.",
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "Conditional GET validator from a previous ETag. Matching values return 304 Not Modified with an empty body.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -724,35 +1286,134 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "has_more", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "has_more",
+                    "meta"
+                  ],
                   "properties": {
-                    "object": { "type": "string", "const": "list" },
-                    "data": { "type": "array", "items": { "$ref": "#/components/schemas/WhaleTrade" } },
-                    "has_more": { "type": "boolean" },
-                    "next_cursor": { "type": "string", "nullable": true },
-                    "meta": { "$ref": "#/components/schemas/WhaleTradeHistoryMeta" }
+                    "object": {
+                      "type": "string",
+                      "const": "list"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/WhaleTrade"
+                      }
+                    },
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "next_cursor": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/WhaleTradeHistoryMeta"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "list",
+                      "data": [],
+                      "has_more": false,
+                      "next_cursor": null,
+                      "total": 0,
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
                   }
                 }
               }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "402": { "$ref": "#/components/responses/SubscriptionRequired" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "408": { "$ref": "#/components/responses/RequestTimeout" },
-          "423": { "$ref": "#/components/responses/Locked" },
-          "429": { "$ref": "#/components/responses/RateLimited" },
-          "503": { "$ref": "#/components/responses/RateLimitUnavailable" }
+          "304": {
+            "description": "Not Modified. Returned when If-None-Match matches the current payload.",
+            "headers": {
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/SubscriptionRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "423": {
+            "$ref": "#/components/responses/Locked"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "503": {
+            "$ref": "#/components/responses/RateLimitUnavailable"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/whale-trades/history'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "next_cursor": null,
+            "total": 0,
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/leaderboard": {
       "get": {
-        "operationId": "get_leaderboard",
+        "operationId": "listLeaderboard",
         "summary": "Get trader leaderboard",
         "description": "Returns ranked traders (grades S/A/B) sorted by score descending. Supports cursor pagination and optional category/strategy filters.",
-        "tags": ["Leaderboard"],
+        "tags": [
+          "Leaderboard"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -819,13 +1480,30 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "has_more", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "has_more",
+                    "meta"
+                  ],
                   "properties": {
                     "object": {
                       "type": "string",
@@ -846,6 +1524,22 @@
                     },
                     "meta": {
                       "$ref": "#/components/schemas/ResponseMeta"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "list",
+                      "data": [],
+                      "has_more": false,
+                      "next_cursor": null,
+                      "total": 0,
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
                     }
                   }
                 }
@@ -884,15 +1578,37 @@
           "503": {
             "$ref": "#/components/responses/RateLimitUnavailable"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/leaderboard'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "next_cursor": null,
+            "total": 0,
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/markets/search": {
       "get": {
-        "operationId": "search_markets",
+        "operationId": "searchMarkets",
         "summary": "Search markets",
         "description": "Search prediction markets by keyword. Returns representative market matches with status, category, and platform metadata. Cursor pagination advances over grouped market results rather than raw sub-market rows.",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "parameters": [
           {
             "name": "q",
@@ -929,7 +1645,11 @@
             "description": "Filter by market status.",
             "schema": {
               "type": "string",
-              "enum": ["active", "closed", "all"],
+              "enum": [
+                "active",
+                "closed",
+                "all"
+              ],
               "default": "all"
             }
           },
@@ -949,7 +1669,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "has_more", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "has_more",
+                    "meta"
+                  ],
                   "properties": {
                     "object": {
                       "type": "string",
@@ -972,7 +1697,37 @@
                       "$ref": "#/components/schemas/ResponseMeta"
                     }
                   }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "list",
+                      "data": [],
+                      "has_more": false,
+                      "next_cursor": null,
+                      "total": 0,
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
                 }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
               }
             }
           },
@@ -1000,15 +1755,37 @@
           "503": {
             "$ref": "#/components/responses/RateLimitUnavailable"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/markets/search'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "next_cursor": null,
+            "total": 0,
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/markets/explore": {
       "get": {
-        "operationId": "explore_markets",
+        "operationId": "exploreMarkets",
         "summary": "Explore markets",
         "description": "Browse whale-active titled markets with category, platform, status, and keyword filters. Paginates visible discovery entries rather than raw market rows, returns live category/platform facets alongside grouped event clusters or standalone markets, and includes total on the first page only. Categories come straight from provider metadata (Polymarket Gamma, Kalshi) and facets are flat value/label/count rows.",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "parameters": [
           {
             "name": "category",
@@ -1024,7 +1801,11 @@
             "description": "Filter by market status.",
             "schema": {
               "type": "string",
-              "enum": ["active", "closed", "all"],
+              "enum": [
+                "active",
+                "closed",
+                "all"
+              ],
               "default": "all"
             }
           },
@@ -1034,7 +1815,11 @@
             "description": "Filter by source platform.",
             "schema": {
               "type": "string",
-              "enum": ["polymarket", "kalshi", "all"],
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "all"
+              ],
               "default": "all"
             }
           },
@@ -1044,7 +1829,14 @@
             "description": "Sort order for the discovery feed.",
             "schema": {
               "type": "string",
-              "enum": ["trending", "whales", "volume", "newest"],
+              "enum": [
+                "trending",
+                "hot",
+                "expiring",
+                "whales",
+                "volume",
+                "newest"
+              ],
               "default": "trending"
             }
           },
@@ -1094,13 +1886,31 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "has_more", "facets", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "has_more",
+                    "facets",
+                    "meta"
+                  ],
                   "properties": {
                     "object": {
                       "type": "string",
@@ -1129,6 +1939,22 @@
                     },
                     "meta": {
                       "$ref": "#/components/schemas/ResponseMeta"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "list",
+                      "data": [],
+                      "has_more": false,
+                      "next_cursor": null,
+                      "total": 0,
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
                     }
                   }
                 }
@@ -1170,15 +1996,37 @@
           "503": {
             "$ref": "#/components/responses/RateLimitUnavailable"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/markets/explore'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "next_cursor": null,
+            "total": 0,
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/market/{condition_id}/intel": {
       "get": {
-        "operationId": "get_market_intel",
+        "operationId": "getMarketIntel",
         "summary": "Get market intelligence",
         "description": "Smart money flow analysis for a specific market — net flow direction, whale trade count, buy/sell volumes, and top graded trader positions.",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "parameters": [
           {
             "name": "condition_id",
@@ -1195,8 +2043,22 @@
             "description": "Lookback window for whale flow aggregation.",
             "schema": {
               "type": "string",
-              "enum": ["1h", "4h", "24h", "7d"],
+              "enum": [
+                "1h",
+                "4h",
+                "24h",
+                "7d"
+              ],
               "default": "24h"
+            }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "Conditional GET validator from a previous ETag. Matching values return 304 Not Modified with an empty body.",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -1207,7 +2069,11 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "meta"
+                  ],
                   "properties": {
                     "object": {
                       "type": "string",
@@ -1220,7 +2086,45 @@
                       "$ref": "#/components/schemas/ResponseMeta"
                     }
                   }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "markets",
+                      "data": {},
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
                 }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified. Returned when If-None-Match matches the current payload.",
+            "headers": {
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
               }
             }
           },
@@ -1251,26 +2155,69 @@
           "503": {
             "$ref": "#/components/responses/RateLimitUnavailable"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/market/{condition_id}/intel'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "markets",
+            "data": {},
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/markets/intel/batch": {
       "post": {
-        "operationId": "batch_get_market_intel",
+        "operationId": "batchGetMarketIntel",
         "summary": "Batch market intelligence",
         "description": "Returns smart-money market intelligence for 1-25 raw provider condition_id values. Results preserve request order, duplicate inputs return duplicate rows, and each item is charged one batch item unit before execution. Do not pass prefixed mkt_ IDs; use market.condition_id from search or explore.",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["condition_ids"],
+                "required": [
+                  "condition_ids"
+                ],
                 "properties": {
-                  "condition_ids": { "type": "array", "minItems": 1, "maxItems": 25, "items": { "type": "string" } },
-                  "timeframe": { "type": "string", "enum": ["1h", "4h", "24h", "7d"], "default": "24h" }
+                  "condition_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 25,
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "timeframe": {
+                    "type": "string",
+                    "enum": [
+                      "1h",
+                      "4h",
+                      "24h",
+                      "7d"
+                    ],
+                    "default": "24h"
+                  }
                 }
+              },
+              "example": {
+                "condition_ids": [
+                  "0x1234567890abcdef"
+                ],
+                "timeframe": "24h"
               }
             }
           }
@@ -1280,61 +2227,162 @@
             "description": "Ordered batch market intelligence results",
             "headers": {
               "X-Request-Cost": {
-                "schema": { "type": "integer" },
+                "schema": {
+                  "type": "integer"
+                },
                 "description": "Number of batch item units charged for this request."
               },
               "X-Batch-RateLimit-Limit": {
-                "schema": { "type": "integer" },
+                "schema": {
+                  "type": "integer"
+                },
                 "description": "Batch item units allowed per minute."
               },
               "X-Batch-RateLimit-Remaining": {
-                "schema": { "type": "integer" },
+                "schema": {
+                  "type": "integer"
+                },
                 "description": "Batch item units remaining in the current sliding window."
               },
               "X-Batch-RateLimit-Reset": {
-                "schema": { "type": "integer" },
+                "schema": {
+                  "type": "integer"
+                },
                 "description": "Unix timestamp when the batch item window resets."
+              },
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "meta"
+                  ],
                   "properties": {
-                    "object": { "type": "string", "const": "market_intel_batch" },
-                    "data": { "type": "array", "items": { "$ref": "#/components/schemas/BatchMarketIntelItem" } },
-                    "meta": { "$ref": "#/components/schemas/BatchResponseMeta" }
+                    "object": {
+                      "type": "string",
+                      "const": "market_intel_batch"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/BatchMarketIntelItem"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/BatchResponseMeta"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "list",
+                      "data": [],
+                      "has_more": false,
+                      "next_cursor": null,
+                      "total": 0,
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
                   }
                 }
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "402": { "$ref": "#/components/responses/SubscriptionRequired" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "408": { "$ref": "#/components/responses/RequestTimeout" },
-          "423": { "$ref": "#/components/responses/Locked" },
-          "429": { "$ref": "#/components/responses/RateLimited" },
-          "503": { "$ref": "#/components/responses/RateLimitUnavailable" },
-          "500": { "$ref": "#/components/responses/InternalError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/SubscriptionRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "423": {
+            "$ref": "#/components/responses/Locked"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "503": {
+            "$ref": "#/components/responses/RateLimitUnavailable"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -X POST \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"condition_ids\":[\"0x1234567890abcdef\"],\"timeframe\":\"24h\"}' \\\n  'https://api.0xinsider.com/api/v1/markets/intel/batch'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "next_cursor": null,
+            "total": 0,
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/market/{condition_id}/snapshot": {
       "get": {
-        "operationId": "get_market_snapshot",
+        "operationId": "getMarketSnapshot",
         "summary": "Get market live snapshot",
         "description": "Provider-first market card snapshot with canonical identity, outcome labels, cached top-of-book when available, liquidity, live sports context, and explicit freshness/unavailable states.",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "parameters": [
           {
             "name": "condition_id",
             "in": "path",
             "required": true,
             "description": "Market condition ID. Use the condition_id returned by /api/v1/markets/search or /api/v1/markets/explore, not the prefixed market.id value (mkt_...).",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "Conditional GET validator from a previous ETag. Matching values return 304 Not Modified with an empty body.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1344,34 +2392,120 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "meta"
+                  ],
                   "properties": {
-                    "object": { "type": "string", "const": "market_snapshot" },
-                    "data": { "$ref": "#/components/schemas/MarketSnapshot" },
-                    "meta": { "$ref": "#/components/schemas/ResponseMeta" }
+                    "object": {
+                      "type": "string",
+                      "const": "market_snapshot"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MarketSnapshot"
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/ResponseMeta"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "markets",
+                      "data": {},
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
                   }
                 }
               }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "402": { "$ref": "#/components/responses/SubscriptionRequired" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "408": { "$ref": "#/components/responses/RequestTimeout" },
-          "423": { "$ref": "#/components/responses/Locked" },
-          "429": { "$ref": "#/components/responses/RateLimited" },
-          "503": { "$ref": "#/components/responses/RateLimitUnavailable" }
+          "304": {
+            "description": "Not Modified. Returned when If-None-Match matches the current payload.",
+            "headers": {
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/SubscriptionRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "423": {
+            "$ref": "#/components/responses/Locked"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "503": {
+            "$ref": "#/components/responses/RateLimitUnavailable"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/market/{condition_id}/snapshot'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "markets",
+            "data": {},
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/insider-radar": {
       "get": {
-        "operationId": "get_insider_radar",
+        "operationId": "listInsiderRadar",
         "summary": "Get insider radar flags",
         "description": "Suspicious trading patterns — pre-resolution accumulation, coordinated wallets, unusual timing. Cursor-paginated by suspicion score.",
-        "tags": ["Insider Radar"],
+        "tags": [
+          "Insider Radar"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -1406,7 +2540,19 @@
             "description": "Filter by severity level.",
             "schema": {
               "type": "string",
-              "enum": ["flag", "watch"]
+              "enum": [
+                "flag",
+                "watch"
+              ]
+            }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "Conditional GET validator from a previous ETag. Matching values return 304 Not Modified with an empty body.",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -1417,7 +2563,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "has_more", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "has_more",
+                    "meta"
+                  ],
                   "properties": {
                     "object": {
                       "type": "string",
@@ -1440,7 +2591,45 @@
                       "$ref": "#/components/schemas/ResponseMeta"
                     }
                   }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "insider_radar",
+                      "data": {},
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
                 }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified. Returned when If-None-Match matches the current payload.",
+            "headers": {
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
               }
             }
           },
@@ -1468,29 +2657,55 @@
           "503": {
             "$ref": "#/components/responses/RateLimitUnavailable"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/insider-radar'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "insider_radar",
+            "data": {},
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/events/feed/since": {
       "get": {
-        "operationId": "get_event_replay_since",
+        "operationId": "getEventReplaySince",
         "summary": "Replay public whale-trade intelligence events",
         "description": "Returns durable public whale-trade intelligence events strictly after an opaque cursor backed by whale_alerts.id. This is a separate API-key contract from the browser/session /api/events/feed stream: browser-only and private alert, following, radar, and position patch events are excluded until they have a durable public outbox.",
-        "tags": ["Events"],
+        "tags": [
+          "Events"
+        ],
         "parameters": [
           {
             "name": "cursor",
             "in": "query",
             "required": false,
             "description": "Opaque event replay cursor returned as next_cursor by a prior response. The cursor maps to whale_alerts.id and is valid across backend replicas. Omit to fetch the latest durable public suffix.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "required": false,
             "description": "Maximum durable public whale-trade events to return.",
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 50 }
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 50
+            }
           }
         ],
         "responses": {
@@ -1500,203 +2715,691 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "has_more", "next_cursor", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "has_more",
+                    "next_cursor",
+                    "meta"
+                  ],
                   "properties": {
-                    "object": { "type": "string", "const": "event_replay" },
+                    "object": {
+                      "type": "string",
+                      "const": "event_replay"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/EventReplayEvent" }
+                      "items": {
+                        "$ref": "#/components/schemas/EventReplayEvent"
+                      }
                     },
-                    "has_more": { "type": "boolean" },
-                    "next_cursor": { "type": "string" },
-                    "meta": { "$ref": "#/components/schemas/EventReplayMeta" }
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "next_cursor": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/EventReplayMeta"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "events",
+                      "data": {},
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
                   }
                 }
               }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "402": { "$ref": "#/components/responses/SubscriptionRequired" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "408": { "$ref": "#/components/responses/RequestTimeout" },
-          "423": { "$ref": "#/components/responses/Locked" },
-          "429": { "$ref": "#/components/responses/RateLimited" },
-          "503": { "$ref": "#/components/responses/RateLimitUnavailable" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/SubscriptionRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "423": {
+            "$ref": "#/components/responses/Locked"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "503": {
+            "$ref": "#/components/responses/RateLimitUnavailable"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/events/feed/since'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "events",
+            "data": {},
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/webhooks": {
       "get": {
-        "operationId": "list_webhooks",
+        "operationId": "listWebhooks",
         "summary": "List builder webhook destinations",
         "description": "Returns webhook destinations owned by the authenticated API key user. Disabled endpoints are omitted.",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "responses": {
-          "200": { "$ref": "#/components/responses/WebhookList" },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "402": { "$ref": "#/components/responses/SubscriptionRequired" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "408": { "$ref": "#/components/responses/RequestTimeout" },
-          "423": { "$ref": "#/components/responses/Locked" },
-          "429": { "$ref": "#/components/responses/RateLimited" },
-          "503": { "$ref": "#/components/responses/RateLimitUnavailable" },
-          "500": { "$ref": "#/components/responses/InternalError" }
+          "200": {
+            "$ref": "#/components/responses/WebhookList"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/SubscriptionRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "423": {
+            "$ref": "#/components/responses/Locked"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "503": {
+            "$ref": "#/components/responses/RateLimitUnavailable"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"name\":\"Production webhook\",\"url\":\"https://example.com/0xinsider/webhook\",\"event_types\":[\"whale_trades_inserted\"]}' \\\n  'https://api.0xinsider.com/api/v1/webhooks'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "webhook",
+            "data": {
+              "id": 1,
+              "object": "webhook",
+              "name": "Production webhook",
+              "url": "https://example.com/0xinsider/webhook",
+              "event_types": [
+                "whale_trades_inserted"
+              ],
+              "status": "pending_verification"
+            },
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       },
       "post": {
-        "operationId": "create_webhook",
+        "operationId": "createWebhook",
         "summary": "Create a builder webhook destination",
         "description": "Creates a pending HTTPS webhook destination. The response includes one-time signing_secret and verification.token values. Deliveries are not sent until the endpoint is verified.",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateWebhookRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateWebhookRequest"
+              },
+              "example": {
+                "name": "Production webhook",
+                "url": "https://example.com/0xinsider/webhook",
+                "event_types": [
+                  "whale_trades_inserted"
+                ]
+              }
             }
           }
         },
         "responses": {
-          "200": { "$ref": "#/components/responses/WebhookObject" },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "402": { "$ref": "#/components/responses/SubscriptionRequired" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "408": { "$ref": "#/components/responses/RequestTimeout" },
-          "423": { "$ref": "#/components/responses/Locked" },
-          "429": { "$ref": "#/components/responses/RateLimited" },
-          "503": { "$ref": "#/components/responses/RateLimitUnavailable" },
-          "500": { "$ref": "#/components/responses/InternalError" }
-        }
+          "200": {
+            "$ref": "#/components/responses/WebhookObject"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/SubscriptionRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "409": {
+            "$ref": "#/components/responses/IdempotencyInProgress"
+          },
+          "422": {
+            "$ref": "#/components/responses/IdempotencyConflict"
+          },
+          "423": {
+            "$ref": "#/components/responses/Locked"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "503": {
+            "$ref": "#/components/responses/RateLimitUnavailable"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -X POST \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"name\":\"Production webhook\",\"url\":\"https://example.com/0xinsider/webhook\",\"event_types\":[\"whale_trades_inserted\"]}' \\\n  'https://api.0xinsider.com/api/v1/webhooks'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "webhook",
+            "data": {
+              "id": 1,
+              "object": "webhook",
+              "name": "Production webhook",
+              "url": "https://example.com/0xinsider/webhook",
+              "event_types": [
+                "whale_trades_inserted"
+              ],
+              "status": "pending_verification"
+            },
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKey"
+          }
+        ]
       }
     },
     "/api/v1/webhooks/{id}": {
       "get": {
-        "operationId": "get_webhook",
+        "operationId": "getWebhook",
         "summary": "Get one builder webhook destination",
         "description": "Returns one webhook destination owned by the authenticated API key user.",
-        "tags": ["Webhooks"],
-        "parameters": [{ "$ref": "#/components/parameters/WebhookId" }],
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/WebhookId"
+          }
+        ],
         "responses": {
-          "200": { "$ref": "#/components/responses/WebhookObject" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "402": { "$ref": "#/components/responses/SubscriptionRequired" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "408": { "$ref": "#/components/responses/RequestTimeout" },
-          "423": { "$ref": "#/components/responses/Locked" },
-          "429": { "$ref": "#/components/responses/RateLimited" },
-          "503": { "$ref": "#/components/responses/RateLimitUnavailable" },
-          "500": { "$ref": "#/components/responses/InternalError" }
+          "200": {
+            "$ref": "#/components/responses/WebhookObject"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/SubscriptionRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "423": {
+            "$ref": "#/components/responses/Locked"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "503": {
+            "$ref": "#/components/responses/RateLimitUnavailable"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/webhooks/{id}'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "webhook",
+            "data": {
+              "id": 1,
+              "object": "webhook",
+              "name": "Production webhook",
+              "url": "https://example.com/0xinsider/webhook",
+              "event_types": [
+                "whale_trades_inserted"
+              ],
+              "status": "pending_verification"
+            },
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       },
       "patch": {
-        "operationId": "update_webhook",
+        "operationId": "updateWebhook",
         "summary": "Update a builder webhook destination",
         "description": "Updates name, HTTPS URL, event types, or enabled state. URL changes force pending_verification and return a new verification token.",
-        "tags": ["Webhooks"],
-        "parameters": [{ "$ref": "#/components/parameters/WebhookId" }],
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/WebhookId"
+          },
+          {
+            "$ref": "#/components/parameters/IdempotencyKey"
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateWebhookRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWebhookRequest"
+              },
+              "example": {
+                "name": "Updated webhook",
+                "enabled": true
+              }
             }
           }
         },
         "responses": {
-          "200": { "$ref": "#/components/responses/WebhookObject" },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "402": { "$ref": "#/components/responses/SubscriptionRequired" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "408": { "$ref": "#/components/responses/RequestTimeout" },
-          "423": { "$ref": "#/components/responses/Locked" },
-          "429": { "$ref": "#/components/responses/RateLimited" },
-          "503": { "$ref": "#/components/responses/RateLimitUnavailable" },
-          "500": { "$ref": "#/components/responses/InternalError" }
+          "200": {
+            "$ref": "#/components/responses/WebhookObject"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/SubscriptionRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "409": {
+            "$ref": "#/components/responses/IdempotencyInProgress"
+          },
+          "422": {
+            "$ref": "#/components/responses/IdempotencyConflict"
+          },
+          "423": {
+            "$ref": "#/components/responses/Locked"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "503": {
+            "$ref": "#/components/responses/RateLimitUnavailable"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -X PATCH \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"name\":\"Updated webhook\",\"enabled\":true}' \\\n  'https://api.0xinsider.com/api/v1/webhooks/{id}'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "webhook",
+            "data": {
+              "id": 1,
+              "object": "webhook",
+              "name": "Production webhook",
+              "url": "https://example.com/0xinsider/webhook",
+              "event_types": [
+                "whale_trades_inserted"
+              ],
+              "status": "pending_verification"
+            },
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       },
       "delete": {
-        "operationId": "delete_webhook",
+        "operationId": "deleteWebhook",
         "summary": "Disable a builder webhook destination",
         "description": "Soft-deletes a webhook destination owned by the authenticated API key user. Existing delivery audit rows remain retained.",
-        "tags": ["Webhooks"],
-        "parameters": [{ "$ref": "#/components/parameters/WebhookId" }],
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/WebhookId"
+          },
+          {
+            "$ref": "#/components/parameters/IdempotencyKey"
+          }
+        ],
         "responses": {
-          "200": { "$ref": "#/components/responses/WebhookObject" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "402": { "$ref": "#/components/responses/SubscriptionRequired" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "408": { "$ref": "#/components/responses/RequestTimeout" },
-          "423": { "$ref": "#/components/responses/Locked" },
-          "429": { "$ref": "#/components/responses/RateLimited" },
-          "503": { "$ref": "#/components/responses/RateLimitUnavailable" },
-          "500": { "$ref": "#/components/responses/InternalError" }
+          "200": {
+            "$ref": "#/components/responses/WebhookObject"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/SubscriptionRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "409": {
+            "$ref": "#/components/responses/IdempotencyInProgress"
+          },
+          "422": {
+            "$ref": "#/components/responses/IdempotencyConflict"
+          },
+          "423": {
+            "$ref": "#/components/responses/Locked"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "503": {
+            "$ref": "#/components/responses/RateLimitUnavailable"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -X DELETE \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/webhooks/{id}'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "webhook",
+            "data": {
+              "id": 1,
+              "object": "webhook",
+              "name": "Production webhook",
+              "url": "https://example.com/0xinsider/webhook",
+              "event_types": [
+                "whale_trades_inserted"
+              ],
+              "status": "pending_verification"
+            },
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/webhooks/{id}/verify": {
       "post": {
-        "operationId": "verify_webhook",
+        "operationId": "verifyWebhook",
         "summary": "Verify a builder webhook destination",
         "description": "Activates a pending webhook destination when the one-time verification token matches and has not expired.",
-        "tags": ["Webhooks"],
-        "parameters": [{ "$ref": "#/components/parameters/WebhookId" }],
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/WebhookId"
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/VerifyWebhookRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/VerifyWebhookRequest"
+              },
+              "example": {
+                "verification_token": "whv_example"
+              }
             }
           }
         },
         "responses": {
-          "200": { "$ref": "#/components/responses/WebhookObject" },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "402": { "$ref": "#/components/responses/SubscriptionRequired" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "408": { "$ref": "#/components/responses/RequestTimeout" },
-          "423": { "$ref": "#/components/responses/Locked" },
-          "429": { "$ref": "#/components/responses/RateLimited" },
-          "503": { "$ref": "#/components/responses/RateLimitUnavailable" },
-          "500": { "$ref": "#/components/responses/InternalError" }
+          "200": {
+            "$ref": "#/components/responses/WebhookObject"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/SubscriptionRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "423": {
+            "$ref": "#/components/responses/Locked"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "503": {
+            "$ref": "#/components/responses/RateLimitUnavailable"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -X POST \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"verification_token\":\"whv_example\"}' \\\n  'https://api.0xinsider.com/api/v1/webhooks/{id}/verify'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "webhooks",
+            "data": {},
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/webhooks/{id}/rotate-secret": {
       "post": {
-        "operationId": "rotate_webhook_secret",
+        "operationId": "rotateWebhookSecret",
         "summary": "Rotate a builder webhook signing secret",
         "description": "Rotates the endpoint signing secret and returns the new signing_secret once in the response.",
-        "tags": ["Webhooks"],
-        "parameters": [{ "$ref": "#/components/parameters/WebhookId" }],
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/WebhookId"
+          },
+          {
+            "$ref": "#/components/parameters/IdempotencyKey"
+          }
+        ],
         "responses": {
-          "200": { "$ref": "#/components/responses/WebhookObject" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "402": { "$ref": "#/components/responses/SubscriptionRequired" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "408": { "$ref": "#/components/responses/RequestTimeout" },
-          "423": { "$ref": "#/components/responses/Locked" },
-          "429": { "$ref": "#/components/responses/RateLimited" },
-          "503": { "$ref": "#/components/responses/RateLimitUnavailable" },
-          "500": { "$ref": "#/components/responses/InternalError" }
+          "200": {
+            "$ref": "#/components/responses/WebhookObject"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/SubscriptionRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "409": {
+            "$ref": "#/components/responses/IdempotencyInProgress"
+          },
+          "422": {
+            "$ref": "#/components/responses/IdempotencyConflict"
+          },
+          "423": {
+            "$ref": "#/components/responses/Locked"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "503": {
+            "$ref": "#/components/responses/RateLimitUnavailable"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -X POST \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  -H 'Content-Type: application/json' \\\n  -d '{}' \\\n  'https://api.0xinsider.com/api/v1/webhooks/{id}/rotate-secret'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "webhook",
+            "data": {
+              "id": 1,
+              "object": "webhook",
+              "name": "Production webhook",
+              "url": "https://example.com/0xinsider/webhook",
+              "event_types": [
+                "whale_trades_inserted"
+              ],
+              "status": "pending_verification"
+            },
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/health": {
       "get": {
-        "operationId": "health",
+        "operationId": "getHealth",
         "summary": "Health check",
         "description": "Returns API health status. No authentication required. Limited to 60 requests per minute per IP.",
-        "tags": ["System"],
+        "tags": [
+          "System"
+        ],
         "security": [],
         "parameters": [
           {
@@ -1724,7 +3427,11 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "meta"
+                  ],
                   "properties": {
                     "object": {
                       "type": "string",
@@ -1735,7 +3442,12 @@
                       "properties": {
                         "status": {
                           "type": "string",
-                          "enum": ["ok", "degraded", "down", "maintenance"]
+                          "enum": [
+                            "ok",
+                            "degraded",
+                            "down",
+                            "maintenance"
+                          ]
                         },
                         "db": {
                           "type": "boolean"
@@ -1745,7 +3457,9 @@
                         },
                         "subsystems": {
                           "type": "object",
-                          "required": ["background_jobs"],
+                          "required": [
+                            "background_jobs"
+                          ],
                           "properties": {
                             "background_jobs": {
                               "type": "object",
@@ -1807,6 +3521,21 @@
                       "$ref": "#/components/schemas/ResponseMeta"
                     }
                   }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "health",
+                      "data": {
+                        "status": "ok"
+                      },
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -1828,15 +3557,36 @@
           "429": {
             "$ref": "#/components/responses/RateLimited"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/health'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "health",
+            "data": {
+              "status": "ok"
+            },
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/mcp": {
       "post": {
-        "operationId": "mcp_post",
+        "operationId": "createMcpJsonRpcResponse",
         "summary": "Remote MCP endpoint (JSON-RPC)",
         "description": "Model Context Protocol (MCP) Streamable HTTP transport. Accepts a JSON-RPC 2.0 request and returns a JSON-RPC response. Supported methods: initialize, notifications/initialized, ping, tools/list, tools/call. Nine tools are exposed: get_leaderboard, get_trader, get_whale_trades, get_market_intel, get_insider_radar, get_positions, get_position_timeline, search_markets, explore_markets — each dispatches to the matching /api/v1/* handler in-process so auth, rate limits, and payload shape match. Auth should use Authorization: Bearer <token>. ?token=<token> remains a legacy compatibility path for URL-only MCP clients, but URL secrets can land in shell history, browser history, and logs, so prefer headers or the stdio package. Mcp-Session-Id is minted on initialize and echoed on every response. Origin header, when present, is validated against the 0xinsider + localhost allowlist.",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "parameters": [
           {
             "name": "token",
@@ -1863,7 +3613,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["jsonrpc", "method"],
+                "required": [
+                  "jsonrpc",
+                  "method"
+                ],
                 "properties": {
                   "jsonrpc": {
                     "type": "string",
@@ -1896,7 +3649,8 @@
                     "type": "object"
                   }
                 }
-              }
+              },
+              "example": {}
             }
           }
         },
@@ -1907,7 +3661,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["jsonrpc", "id"],
+                  "required": [
+                    "jsonrpc",
+                    "id"
+                  ],
                   "properties": {
                     "jsonrpc": {
                       "type": "string",
@@ -1931,7 +3688,10 @@
                     },
                     "error": {
                       "type": "object",
-                      "required": ["code", "message"],
+                      "required": [
+                        "code",
+                        "message"
+                      ],
                       "properties": {
                         "code": {
                           "type": "integer"
@@ -1942,12 +3702,53 @@
                       }
                     }
                   }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "mcp",
+                      "data": {},
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
                 }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
               }
             }
           },
           "202": {
-            "description": "Notification acknowledged (no body)"
+            "description": "Notification acknowledged (no body)",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
           },
           "400": {
             "description": "JSON-RPC parse or invalid-request error"
@@ -1967,13 +3768,31 @@
           "500": {
             "$ref": "#/components/responses/InternalError"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -X POST \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  -H 'Content-Type: application/json' \\\n  -d '{}' \\\n  'https://api.0xinsider.com/api/v1/mcp'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+              "protocolVersion": "2025-11-25"
+            }
+          }
         }
       },
       "get": {
-        "operationId": "mcp_get",
+        "operationId": "openMcpEventStream",
         "summary": "Open MCP server-to-client stream",
         "description": "Opens a text/event-stream connection for server-initiated notifications as described in the MCP Streamable HTTP transport. The endpoint currently sends no notifications — clients that only care about request/response use POST.",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "parameters": [
           {
             "name": "token",
@@ -2003,6 +3822,20 @@
                   "type": "string"
                 }
               }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
             }
           },
           "401": {
@@ -2014,15 +3847,33 @@
           "429": {
             "$ref": "#/components/responses/RateLimited"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/mcp'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+              "protocolVersion": "2025-11-25"
+            }
+          }
         }
       }
     },
     "/api/v1/reports/daily": {
       "get": {
-        "operationId": "get_daily_report_snapshot",
+        "operationId": "getDailyReportSnapshot",
         "summary": "Daily report snapshot",
         "description": "Returns a dated daily whale-activity report snapshot with source_range, snapshot.status, completeness, and reconciliation metadata. Report whale volume is local whale-alert activity volume, not provider lifetime trader volume.",
-        "tags": ["Reports"],
+        "tags": [
+          "Reports"
+        ],
         "parameters": [
           {
             "name": "date",
@@ -2042,7 +3893,11 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "meta"
+                  ],
                   "properties": {
                     "object": {
                       "type": "string",
@@ -2055,7 +3910,37 @@
                       "$ref": "#/components/schemas/ResponseMeta"
                     }
                   }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "list",
+                      "data": [],
+                      "has_more": false,
+                      "next_cursor": null,
+                      "total": 0,
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
                 }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
               }
             }
           },
@@ -2086,15 +3971,37 @@
           "503": {
             "$ref": "#/components/responses/RateLimitUnavailable"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/reports/daily'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "next_cursor": null,
+            "total": 0,
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/reports/weekly": {
       "get": {
-        "operationId": "get_weekly_report_snapshot",
+        "operationId": "getWeeklyReportSnapshot",
         "summary": "Weekly report snapshot",
         "description": "Returns a weekly whale-activity report snapshot. Pass either from/to UTC dates or an ISO YYYY-WW week token. The response identifies closed ranges as final and current ranges as rolling.",
-        "tags": ["Reports"],
+        "tags": [
+          "Reports"
+        ],
         "parameters": [
           {
             "name": "from",
@@ -2134,7 +4041,11 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "meta"
+                  ],
                   "properties": {
                     "object": {
                       "type": "string",
@@ -2147,7 +4058,37 @@
                       "$ref": "#/components/schemas/ResponseMeta"
                     }
                   }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "list",
+                      "data": [],
+                      "has_more": false,
+                      "next_cursor": null,
+                      "total": 0,
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
                 }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
               }
             }
           },
@@ -2178,15 +4119,37 @@
           "503": {
             "$ref": "#/components/responses/RateLimitUnavailable"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/reports/weekly'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "next_cursor": null,
+            "total": 0,
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/reports/monthly": {
       "get": {
-        "operationId": "get_monthly_report_snapshot",
+        "operationId": "getMonthlyReportSnapshot",
         "summary": "Monthly report snapshot",
         "description": "Returns a UTC monthly whale-activity report snapshot with source_range, completeness, and reconciliation metadata.",
-        "tags": ["Reports"],
+        "tags": [
+          "Reports"
+        ],
         "parameters": [
           {
             "name": "month",
@@ -2206,7 +4169,11 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "meta"
+                  ],
                   "properties": {
                     "object": {
                       "type": "string",
@@ -2219,7 +4186,37 @@
                       "$ref": "#/components/schemas/ResponseMeta"
                     }
                   }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "list",
+                      "data": [],
+                      "has_more": false,
+                      "next_cursor": null,
+                      "total": 0,
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
                 }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
               }
             }
           },
@@ -2250,15 +4247,37 @@
           "503": {
             "$ref": "#/components/responses/RateLimitUnavailable"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/reports/monthly'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "next_cursor": null,
+            "total": 0,
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     },
     "/api/v1/trader/{address}/export": {
       "get": {
-        "operationId": "get_trader_export_snapshot",
+        "operationId": "getTraderExportSnapshot",
         "summary": "Trader export snapshot metadata",
         "description": "Returns export source-range, completeness, volume reconciliation, row-count estimate, and large-export policy for one trader. V1 is metadata-only; full raw dataset export remains on the internal streaming or async export route.",
-        "tags": ["Traders"],
+        "tags": [
+          "Traders"
+        ],
         "parameters": [
           {
             "name": "address",
@@ -2277,7 +4296,11 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["object", "data", "meta"],
+                  "required": [
+                    "object",
+                    "data",
+                    "meta"
+                  ],
                   "properties": {
                     "object": {
                       "type": "string",
@@ -2290,7 +4313,34 @@
                       "$ref": "#/components/schemas/ResponseMeta"
                     }
                   }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "traders",
+                      "data": {},
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
                 }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
               }
             }
           },
@@ -2324,6 +4374,139 @@
           "503": {
             "$ref": "#/components/responses/RateLimitUnavailable"
           }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/trader/{address}/export'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "traders",
+            "data": {},
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/usage": {
+      "get": {
+        "tags": [
+          "Usage"
+        ],
+        "operationId": "getUsage",
+        "summary": "Inspect current API usage without spending a request",
+        "description": "Returns the authenticated caller sliding-window request budget and UTC-day usage. This endpoint is authenticated but does not increment the Redis rate-limit counter or log itself into the API usage table.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Usage budget and counters for the authenticated API key owner.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Usage"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "usage",
+                      "data": {
+                        "rate_limit": {
+                          "used": 7,
+                          "limit": 100,
+                          "remaining": 93,
+                          "reset_at": 1710772860,
+                          "window_seconds": 60
+                        },
+                        "daily_usage": {
+                          "used": 42,
+                          "limit": null,
+                          "remaining": null,
+                          "reset_at": 1710806400,
+                          "window_seconds": 86400
+                        }
+                      },
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/InvalidApiKey"
+          },
+          "402": {
+            "$ref": "#/components/responses/SubscriptionRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "423": {
+            "$ref": "#/components/responses/Locked"
+          },
+          "503": {
+            "$ref": "#/components/responses/RateLimitUnavailable"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/usage'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "usage",
+            "data": {
+              "rate_limit": {
+                "used": 7,
+                "limit": 100,
+                "remaining": 93,
+                "reset_at": 1710772860,
+                "window_seconds": 60
+              },
+              "daily_usage": {
+                "used": 42,
+                "limit": null,
+                "remaining": null,
+                "reset_at": 1710806400,
+                "window_seconds": 86400
+              }
+            },
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
         }
       }
     }
@@ -2342,82 +4525,214 @@
         "in": "path",
         "required": true,
         "description": "Webhook endpoint id owned by the authenticated API key user.",
-        "schema": { "type": "integer", "format": "int64" }
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "IdempotencyKey": {
+        "name": "Idempotency-Key",
+        "in": "header",
+        "required": false,
+        "description": "Optional safe-retry key. Reuse the same value only when retrying the exact same mutation request body; a different body returns 422 and an in-flight matching request returns 409.",
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "example": "wh_idem_01HX7Y9ZQ4K7Z0Q2E4N6A8C1BF"
       }
     },
     "schemas": {
       "WebhookEventType": {
         "type": "string",
-        "enum": ["whale_trades_inserted", "live_sports_updated", "whale_trader_synced", "large_positions_updated"]
+        "enum": [
+          "whale_trades_inserted",
+          "live_sports_updated",
+          "whale_trader_synced",
+          "large_positions_updated"
+        ]
       },
       "WebhookStatus": {
         "type": "string",
-        "enum": ["pending_verification", "active", "disabled"]
+        "enum": [
+          "pending_verification",
+          "active",
+          "disabled"
+        ]
       },
       "WebhookRetryPolicy": {
         "type": "object",
-        "required": ["max_attempts", "terminal_status"],
+        "required": [
+          "max_attempts",
+          "terminal_status"
+        ],
         "properties": {
-          "max_attempts": { "type": "integer", "const": 8 },
-          "terminal_status": { "type": "string", "const": "dead_letter" }
+          "max_attempts": {
+            "type": "integer",
+            "const": 8
+          },
+          "terminal_status": {
+            "type": "string",
+            "const": "dead_letter"
+          }
         }
       },
       "WebhookVerification": {
         "type": "object",
-        "required": ["token", "expires_at"],
+        "required": [
+          "token",
+          "expires_at"
+        ],
         "properties": {
-          "token": { "type": "string", "description": "One-time verification token returned only on create or URL change." },
-          "expires_at": { "type": "string", "format": "date-time" }
+          "token": {
+            "type": "string",
+            "description": "One-time verification token returned only on create or URL change."
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "WebhookEndpoint": {
         "type": "object",
-        "required": ["id", "object", "name", "url", "event_types", "status", "verification_token_expires_at", "failure_count", "created_at", "updated_at", "retry_policy"],
+        "required": [
+          "id",
+          "object",
+          "name",
+          "url",
+          "event_types",
+          "status",
+          "verification_token_expires_at",
+          "failure_count",
+          "created_at",
+          "updated_at",
+          "retry_policy"
+        ],
         "properties": {
-          "id": { "type": "integer", "format": "int64" },
-          "object": { "type": "string", "const": "webhook" },
-          "name": { "type": "string" },
-          "url": { "type": "string", "format": "uri" },
-          "event_types": { "type": "array", "items": { "$ref": "#/components/schemas/WebhookEventType" } },
-          "status": { "$ref": "#/components/schemas/WebhookStatus" },
-          "verified_at": { "type": "string", "format": "date-time", "nullable": true },
-          "verification_token_expires_at": { "type": "string", "format": "date-time" },
-          "failure_count": { "type": "integer" },
-          "created_at": { "type": "string", "format": "date-time" },
-          "updated_at": { "type": "string", "format": "date-time" },
-          "retry_policy": { "$ref": "#/components/schemas/WebhookRetryPolicy" },
-          "signing_secret": { "type": "string", "description": "Returned only on create or rotate-secret." },
-          "verification": { "$ref": "#/components/schemas/WebhookVerification" }
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "object": {
+            "type": "string",
+            "const": "webhook"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "event_types": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WebhookEventType"
+            }
+          },
+          "status": {
+            "$ref": "#/components/schemas/WebhookStatus"
+          },
+          "verified_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "verification_token_expires_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "failure_count": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retry_policy": {
+            "$ref": "#/components/schemas/WebhookRetryPolicy"
+          },
+          "signing_secret": {
+            "type": "string",
+            "description": "Returned only on create or rotate-secret."
+          },
+          "verification": {
+            "$ref": "#/components/schemas/WebhookVerification"
+          }
         }
       },
       "CreateWebhookRequest": {
         "type": "object",
-        "required": ["name", "url", "event_types"],
+        "required": [
+          "name",
+          "url",
+          "event_types"
+        ],
         "properties": {
-          "name": { "type": "string", "maxLength": 100 },
-          "url": { "type": "string", "format": "uri", "description": "Public HTTPS callback URL. Local/private/internal targets are rejected." },
-          "event_types": { "type": "array", "minItems": 1, "items": { "$ref": "#/components/schemas/WebhookEventType" } }
+          "name": {
+            "type": "string",
+            "maxLength": 100
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Public HTTPS callback URL. Local/private/internal targets are rejected."
+          },
+          "event_types": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/WebhookEventType"
+            }
+          }
         }
       },
       "UpdateWebhookRequest": {
         "type": "object",
         "properties": {
-          "name": { "type": "string", "maxLength": 100 },
-          "url": { "type": "string", "format": "uri" },
-          "event_types": { "type": "array", "minItems": 1, "items": { "$ref": "#/components/schemas/WebhookEventType" } },
-          "enabled": { "type": "boolean" }
+          "name": {
+            "type": "string",
+            "maxLength": 100
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "event_types": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/WebhookEventType"
+            }
+          },
+          "enabled": {
+            "type": "boolean"
+          }
         }
       },
       "VerifyWebhookRequest": {
         "type": "object",
-        "required": ["verification_token"],
+        "required": [
+          "verification_token"
+        ],
         "properties": {
-          "verification_token": { "type": "string" }
+          "verification_token": {
+            "type": "string"
+          }
         }
       },
       "ResponseMeta": {
         "type": "object",
-        "required": ["request_id", "cached"],
+        "required": [
+          "request_id",
+          "cached"
+        ],
         "properties": {
           "request_id": {
             "type": "string",
@@ -2435,101 +4750,252 @@
       },
       "WhaleTradeHistoryMeta": {
         "type": "object",
-        "required": ["request_id", "cached", "source", "completeness"],
+        "required": [
+          "request_id",
+          "cached",
+          "source",
+          "completeness"
+        ],
         "properties": {
-          "request_id": { "type": "string", "description": "Unique request ID (req_ prefix)." },
-          "cached": { "type": "boolean" },
-          "cache_age_s": { "type": "integer", "nullable": true, "description": "Cache age in seconds, null if not cached." },
+          "request_id": {
+            "type": "string",
+            "description": "Unique request ID (req_ prefix)."
+          },
+          "cached": {
+            "type": "boolean"
+          },
+          "cache_age_s": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Cache age in seconds, null if not cached."
+          },
           "source": {
             "type": "object",
-            "required": ["kind", "table", "provider_fetch_at_request_time"],
+            "required": [
+              "kind",
+              "table",
+              "provider_fetch_at_request_time"
+            ],
             "properties": {
-              "kind": { "type": "string", "const": "local_replay" },
-              "table": { "type": "string", "const": "whale_alerts" },
-              "provider_fetch_at_request_time": { "type": "boolean", "const": false }
+              "kind": {
+                "type": "string",
+                "const": "local_replay"
+              },
+              "table": {
+                "type": "string",
+                "const": "whale_alerts"
+              },
+              "provider_fetch_at_request_time": {
+                "type": "boolean",
+                "const": false
+              }
             }
           },
           "completeness": {
             "type": "object",
-            "required": ["status", "reason"],
+            "required": [
+              "status",
+              "reason"
+            ],
             "properties": {
-              "status": { "type": "string", "const": "best_effort" },
-              "reason": { "type": "string", "description": "Explains that local replay completeness can vary by market and time window." }
+              "status": {
+                "type": "string",
+                "const": "best_effort"
+              },
+              "reason": {
+                "type": "string",
+                "description": "Explains that local replay completeness can vary by market and time window."
+              }
             }
           }
         }
       },
       "EventReplayEvent": {
         "type": "object",
-        "required": ["id", "type", "cursor", "sequence", "published_at", "payload", "source", "freshness"],
+        "required": [
+          "id",
+          "type",
+          "cursor",
+          "sequence",
+          "published_at",
+          "payload",
+          "source",
+          "freshness"
+        ],
         "properties": {
-          "id": { "type": "string", "description": "Opaque event ID; currently identical to cursor for the whale_alerts.id sequence." },
+          "id": {
+            "type": "string",
+            "description": "Opaque event ID; currently identical to cursor for the whale_alerts.id sequence."
+          },
           "type": {
             "type": "string",
-            "enum": ["whale_trades_inserted"]
+            "enum": [
+              "whale_trades_inserted"
+            ]
           },
-          "cursor": { "type": "string", "description": "Cursor positioned at this event." },
-          "sequence": { "type": "integer", "minimum": 1, "description": "Global whale_alerts.id sequence." },
-          "published_at": { "type": "string", "format": "date-time" },
-          "payload": { "type": "object", "additionalProperties": true },
-          "source": { "$ref": "#/components/schemas/EventReplaySource" },
-          "freshness": { "$ref": "#/components/schemas/EventReplayFreshness" }
+          "cursor": {
+            "type": "string",
+            "description": "Cursor positioned at this event."
+          },
+          "sequence": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Global whale_alerts.id sequence."
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "payload": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "source": {
+            "$ref": "#/components/schemas/EventReplaySource"
+          },
+          "freshness": {
+            "$ref": "#/components/schemas/EventReplayFreshness"
+          }
         }
       },
       "EventReplaySource": {
         "type": "object",
-        "required": ["kind", "producer_family", "owner", "provider_fetch_at_request_time"],
+        "required": [
+          "kind",
+          "producer_family",
+          "owner",
+          "provider_fetch_at_request_time"
+        ],
         "properties": {
-          "kind": { "type": "string", "const": "local_durable_replay" },
+          "kind": {
+            "type": "string",
+            "const": "local_durable_replay"
+          },
           "producer_family": {
             "type": "string",
-            "enum": ["whale_trades"]
+            "enum": [
+              "whale_trades"
+            ]
           },
-          "owner": { "type": "string", "const": "whale_alerts" },
-          "provider_fetch_at_request_time": { "type": "boolean", "const": false }
+          "owner": {
+            "type": "string",
+            "const": "whale_alerts"
+          },
+          "provider_fetch_at_request_time": {
+            "type": "boolean",
+            "const": false
+          }
         }
       },
       "EventReplayFreshness": {
         "type": "object",
-        "required": ["status", "observed_at"],
+        "required": [
+          "status",
+          "observed_at"
+        ],
         "properties": {
-          "status": { "type": "string", "const": "observed" },
-          "observed_at": { "type": "string", "format": "date-time" }
+          "status": {
+            "type": "string",
+            "const": "observed"
+          },
+          "observed_at": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "EventReplayMeta": {
         "type": "object",
-        "required": ["request_id", "cached", "replay", "retention", "completeness"],
+        "required": [
+          "request_id",
+          "cached",
+          "replay",
+          "retention",
+          "completeness"
+        ],
         "properties": {
-          "request_id": { "type": "string", "description": "Unique request ID (req_ prefix)." },
-          "cached": { "type": "boolean" },
-          "cache_age_s": { "type": "integer", "nullable": true },
+          "request_id": {
+            "type": "string",
+            "description": "Unique request ID (req_ prefix)."
+          },
+          "cached": {
+            "type": "boolean"
+          },
+          "cache_age_s": {
+            "type": "integer",
+            "nullable": true
+          },
           "replay": {
             "type": "object",
-            "required": ["from_cursor", "to_cursor", "from_sequence", "to_sequence", "ordering"],
+            "required": [
+              "from_cursor",
+              "to_cursor",
+              "from_sequence",
+              "to_sequence",
+              "ordering"
+            ],
             "properties": {
-              "from_cursor": { "type": "string" },
-              "to_cursor": { "type": "string" },
-              "from_sequence": { "type": "integer", "minimum": 0 },
-              "to_sequence": { "type": "integer", "minimum": 0 },
-              "ordering": { "type": "string", "const": "whale_alerts_id_asc" }
+              "from_cursor": {
+                "type": "string"
+              },
+              "to_cursor": {
+                "type": "string"
+              },
+              "from_sequence": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "to_sequence": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "ordering": {
+                "type": "string",
+                "const": "whale_alerts_id_asc"
+              }
             }
           },
           "retention": {
             "type": "object",
-            "required": ["status", "retained_events", "cursor_expired"],
+            "required": [
+              "status",
+              "retained_events",
+              "cursor_expired"
+            ],
             "properties": {
-              "status": { "type": "string", "enum": ["durable_database"] },
-              "retained_events": { "type": "integer", "minimum": 0 },
-              "cursor_expired": { "type": "boolean", "const": false }
+              "status": {
+                "type": "string",
+                "enum": [
+                  "durable_database"
+                ]
+              },
+              "retained_events": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "cursor_expired": {
+                "type": "boolean",
+                "const": false
+              }
             }
           },
           "completeness": {
             "type": "object",
-            "required": ["status", "reason"],
+            "required": [
+              "status",
+              "reason"
+            ],
             "properties": {
-              "status": { "type": "string", "enum": ["complete", "caught_up"] },
-              "reason": { "type": "string" }
+              "status": {
+                "type": "string",
+                "enum": [
+                  "complete",
+                  "caught_up"
+                ]
+              },
+              "reason": {
+                "type": "string"
+              }
             }
           }
         }
@@ -2537,62 +5003,132 @@
       "TrustSource": {
         "type": "object",
         "description": "Source metadata for a trust-critical value. Providers and DB/read models own business truth; clients should not infer missing provider facts from titles, slugs, zeros, or empty arrays.",
-        "required": ["kind", "owner"],
+        "required": [
+          "kind",
+          "owner"
+        ],
         "properties": {
           "kind": {
             "type": "string",
-            "enum": ["provider", "database", "cache", "computed", "client_input", "unavailable"]
+            "enum": [
+              "provider",
+              "database",
+              "cache",
+              "computed",
+              "client_input",
+              "unavailable"
+            ]
           },
-          "owner": { "type": "string", "description": "Provider, table/read-model, cache, or service that owns the value." },
-          "field": { "type": "string", "nullable": true, "description": "Provider field, DB column, or computed field name when applicable." }
+          "owner": {
+            "type": "string",
+            "description": "Provider, table/read-model, cache, or service that owns the value."
+          },
+          "field": {
+            "type": "string",
+            "nullable": true,
+            "description": "Provider field, DB column, or computed field name when applicable."
+          }
         }
       },
       "TrustFreshness": {
         "type": "object",
         "description": "Freshness metadata for a trust-critical value. This is separate from transport cache fields in ResponseMeta.",
-        "required": ["status"],
+        "required": [
+          "status"
+        ],
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["fresh", "refreshing", "stale", "not_live", "unknown", "unavailable"]
+            "enum": [
+              "fresh",
+              "refreshing",
+              "stale",
+              "not_live",
+              "unknown",
+              "unavailable"
+            ]
           },
-          "as_of": { "type": "string", "format": "date-time", "nullable": true },
-          "max_age_s": { "type": "integer", "nullable": true, "minimum": 0 }
+          "as_of": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "max_age_s": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0
+          }
         }
       },
       "TrustReconciliation": {
         "type": "object",
         "description": "How provider-owned facts were reconciled with stored/read-model values.",
-        "required": ["status"],
+        "required": [
+          "status"
+        ],
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["provider_backed", "db_mirror", "computed", "partial", "not_applicable", "unavailable"]
+            "enum": [
+              "provider_backed",
+              "db_mirror",
+              "computed",
+              "partial",
+              "not_applicable",
+              "unavailable"
+            ]
           },
-          "detail": { "type": "string", "nullable": true }
+          "detail": {
+            "type": "string",
+            "nullable": true
+          }
         }
       },
       "TrustCompleteness": {
         "type": "object",
         "description": "Whether the described value or result set is complete for its stated contract.",
-        "required": ["status"],
+        "required": [
+          "status"
+        ],
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["complete", "partial", "not_computed", "not_applicable", "unavailable"]
+            "enum": [
+              "complete",
+              "partial",
+              "not_computed",
+              "not_applicable",
+              "unavailable"
+            ]
           },
-          "detail": { "type": "string", "nullable": true }
+          "detail": {
+            "type": "string",
+            "nullable": true
+          }
         }
       },
       "TrustMetadata": {
         "type": "object",
         "description": "Shared source/freshness/reconciliation/completeness metadata for public API values that may be cached, stale, partial, computed, or provider-unavailable. Unavailable provider values must be represented with explicit metadata instead of fabricated zeros or empty arrays.",
-        "required": ["source", "freshness", "reconciliation", "completeness"],
+        "required": [
+          "source",
+          "freshness",
+          "reconciliation",
+          "completeness"
+        ],
         "properties": {
-          "source": { "$ref": "#/components/schemas/TrustSource" },
-          "freshness": { "$ref": "#/components/schemas/TrustFreshness" },
-          "reconciliation": { "$ref": "#/components/schemas/TrustReconciliation" },
-          "completeness": { "$ref": "#/components/schemas/TrustCompleteness" }
+          "source": {
+            "$ref": "#/components/schemas/TrustSource"
+          },
+          "freshness": {
+            "$ref": "#/components/schemas/TrustFreshness"
+          },
+          "reconciliation": {
+            "$ref": "#/components/schemas/TrustReconciliation"
+          },
+          "completeness": {
+            "$ref": "#/components/schemas/TrustCompleteness"
+          }
         }
       },
       "PositionTimelineEvent": {
@@ -2621,12 +5157,18 @@
           },
           "action": {
             "type": "string",
-            "enum": ["buy", "sell"],
+            "enum": [
+              "buy",
+              "sell"
+            ],
             "description": "From the taker's perspective."
           },
           "outcome_side": {
             "type": "string",
-            "enum": ["yes", "no"]
+            "enum": [
+              "yes",
+              "no"
+            ]
           },
           "amount_delta": {
             "type": "number",
@@ -2656,7 +5198,12 @@
       },
       "Trader": {
         "type": "object",
-        "required": ["id", "address", "pnl", "stats"],
+        "required": [
+          "id",
+          "address",
+          "pnl",
+          "stats"
+        ],
         "properties": {
           "id": {
             "type": "string",
@@ -2671,8 +5218,27 @@
           },
           "grade": {
             "type": "string",
-            "enum": ["S", "A", "B", "C", "D", "F"],
+            "enum": [
+              "S",
+              "A",
+              "B",
+              "C",
+              "D",
+              "F"
+            ],
             "nullable": true
+          },
+          "form_tier": {
+            "type": "string",
+            "enum": [
+              "hot",
+              "rising",
+              "neutral",
+              "cooling",
+              "cold"
+            ],
+            "nullable": true,
+            "description": "Recent-form tier (trailing-7d cross-sectional percentile); a separate axis from the all-time grade. Null when no recent activity."
           },
           "score": {
             "type": "number",
@@ -2746,70 +5312,16 @@
             }
           },
           "category_strengths": {
-            "type": "array",
+            "type": "object",
             "nullable": true,
-            "description": "Category performance breakdown (expand=categories or expand[]=categories). Null unless expanded.",
-            "items": {
-              "type": "object",
-              "properties": {
-                "category": {
-                  "type": "string"
-                },
-                "grade": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "rank": {
-                  "type": "integer",
-                  "nullable": true
-                },
-                "markets": {
-                  "type": "integer",
-                  "nullable": true
-                },
-                "pnl": {
-                  "type": "number",
-                  "nullable": true
-                }
-              }
-            }
+            "additionalProperties": true,
+            "description": "Per-category performance breakdown (expand=categories or expand[]=categories). Null unless expanded. Object keyed by category name; each value is the precomputed trader_rankings.category_ranks payload (rank, total_in_category, total_pnl, scaled_total_pnl, n_markets, wins, losses, win_rate; scaled_total_pnl is a legacy alias that currently equals total_pnl). Pass-through DB JSON: keys and value shape are DB-owned, so the inner shape is intentionally unconstrained and may carry additional compatibility fields."
           },
           "quant_metrics": {
             "type": "object",
             "nullable": true,
-            "description": "Advanced risk/performance metrics (expand=quant_metrics or expand[]=quant_metrics). Null unless expanded.",
-            "properties": {
-              "sharpe_ratio": {
-                "type": "number",
-                "nullable": true,
-                "description": "Risk-adjusted return (annualized)"
-              },
-              "sortino_ratio": {
-                "type": "number",
-                "nullable": true,
-                "description": "Downside risk-adjusted return"
-              },
-              "max_drawdown": {
-                "type": "number",
-                "nullable": true,
-                "description": "Largest peak-to-trough decline (0.0-1.0)"
-              },
-              "profit_factor": {
-                "type": "number",
-                "nullable": true,
-                "description": "Gross profit / gross loss"
-              },
-              "kelly_fraction": {
-                "type": "number",
-                "nullable": true,
-                "description": "Optimal bet size (Kelly criterion)"
-              },
-              "sharpe_percentile": {
-                "type": "number",
-                "nullable": true,
-                "description": "Percentile rank among all traders"
-              }
-            }
+            "additionalProperties": true,
+            "description": "Advanced risk/performance metrics (expand=quant_metrics or expand[]=quant_metrics). Null unless expanded. Pass-through of the advanced_metrics row as JSON (trader_id and id stripped); the metric key-set is DB-owned and additive, so the inner shape is intentionally unconstrained."
           },
           "last_active": {
             "type": "string",
@@ -2848,7 +5360,10 @@
           },
           "platform": {
             "type": "string",
-            "enum": ["polymarket", "kalshi"],
+            "enum": [
+              "polymarket",
+              "kalshi"
+            ],
             "description": "Provider discriminator. Slice 5 ships Polymarket only; the field stays in the response shape so Kalshi positions can land without a breaking change."
           },
           "wallet": {
@@ -2857,7 +5372,10 @@
           },
           "side": {
             "type": "string",
-            "enum": ["YES", "NO"],
+            "enum": [
+              "YES",
+              "NO"
+            ],
             "description": "Binary outcome side. Non-binary positions are not surfaced on V1."
           },
           "shares": {
@@ -2895,12 +5413,21 @@
           },
           "freshness": {
             "type": "string",
-            "enum": ["fresh", "refreshing", "stale", "unknown"],
+            "enum": [
+              "fresh",
+              "refreshing",
+              "stale",
+              "unknown"
+            ],
             "description": "Backend-computed staleness bucket derived from last_reconciled_at."
           },
           "trader": {
             "type": "object",
-            "required": ["id", "address", "is_new_wallet"],
+            "required": [
+              "id",
+              "address",
+              "is_new_wallet"
+            ],
             "properties": {
               "id": {
                 "type": "string",
@@ -2915,7 +5442,14 @@
               },
               "grade": {
                 "type": "string",
-                "enum": ["S", "A", "B", "C", "D", "F"],
+                "enum": [
+                  "S",
+                  "A",
+                  "B",
+                  "C",
+                  "D",
+                  "F"
+                ],
                 "nullable": true
               },
               "win_rate": {
@@ -2943,7 +5477,11 @@
           },
           "market": {
             "type": "object",
-            "required": ["id", "condition_id", "title"],
+            "required": [
+              "id",
+              "condition_id",
+              "title"
+            ],
             "properties": {
               "id": {
                 "type": "string",
@@ -3008,7 +5546,10 @@
           },
           "side": {
             "type": "string",
-            "enum": ["BUY", "SELL"]
+            "enum": [
+              "BUY",
+              "SELL"
+            ]
           },
           "price": {
             "type": "number"
@@ -3019,7 +5560,10 @@
           },
           "trader": {
             "type": "object",
-            "required": ["id", "address"],
+            "required": [
+              "id",
+              "address"
+            ],
             "properties": {
               "id": {
                 "type": "string"
@@ -3039,7 +5583,11 @@
           },
           "market": {
             "type": "object",
-            "required": ["id", "condition_id", "title"],
+            "required": [
+              "id",
+              "condition_id",
+              "title"
+            ],
             "properties": {
               "id": {
                 "type": "string"
@@ -3065,7 +5613,11 @@
       },
       "LeaderboardEntry": {
         "type": "object",
-        "required": ["id", "address", "platform"],
+        "required": [
+          "id",
+          "address",
+          "platform"
+        ],
         "properties": {
           "id": {
             "type": "string"
@@ -3080,6 +5632,18 @@
           "grade": {
             "type": "string",
             "nullable": true
+          },
+          "form_tier": {
+            "type": "string",
+            "enum": [
+              "hot",
+              "rising",
+              "neutral",
+              "cooling",
+              "cold"
+            ],
+            "nullable": true,
+            "description": "Recent-form tier (trailing-7d cross-sectional percentile); a separate axis from the all-time grade. Null when no recent activity."
           },
           "score": {
             "type": "number",
@@ -3117,7 +5681,12 @@
       },
       "MarketSearchResult": {
         "type": "object",
-        "required": ["id", "condition_id", "title", "status"],
+        "required": [
+          "id",
+          "condition_id",
+          "title",
+          "status"
+        ],
         "properties": {
           "id": {
             "type": "string"
@@ -3142,13 +5711,21 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "closed"]
+            "enum": [
+              "active",
+              "closed"
+            ]
           }
         }
       },
       "ExploreMarket": {
         "type": "object",
-        "required": ["id", "condition_id", "title", "status"],
+        "required": [
+          "id",
+          "condition_id",
+          "title",
+          "status"
+        ],
         "properties": {
           "id": {
             "type": "string"
@@ -3189,7 +5766,10 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "closed"]
+            "enum": [
+              "active",
+              "closed"
+            ]
           },
           "volume": {
             "type": "number",
@@ -3254,6 +5834,26 @@
             "type": "string",
             "nullable": true
           },
+          "outcome_yes_label": {
+            "type": "string",
+            "nullable": true,
+            "description": "Display label for the YES/outcome_index=0 side, enriched from provider outcome metadata when available."
+          },
+          "outcome_no_label": {
+            "type": "string",
+            "nullable": true,
+            "description": "Display label for the NO/outcome_index=1 side, enriched from provider outcome metadata when available."
+          },
+          "outcome_yes_provider_id": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Provider-owned YES/outcome_index=0 identifier when available for trade-ticket wiring."
+          },
+          "outcome_no_provider_id": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Provider-owned NO/outcome_index=1 identifier when available for trade-ticket wiring."
+          },
           "open_interest": {
             "type": "number",
             "nullable": true
@@ -3273,12 +5873,108 @@
                 "type": "number"
               }
             }
+          },
+          "no_price_points": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "last_price": {
+            "type": "number",
+            "nullable": true
+          },
+          "no_last_price": {
+            "type": "number",
+            "nullable": true
+          },
+          "change_pct_24h": {
+            "type": "number",
+            "nullable": true
+          },
+          "no_change_pct_24h": {
+            "type": "number",
+            "nullable": true
+          },
+          "discover_score": {
+            "type": "number",
+            "nullable": true,
+            "description": "Backend-owned deterministic market discovery score used by the hot sort."
+          },
+          "score_components": {
+            "type": "object",
+            "required": [
+              "missing_price_penalty"
+            ],
+            "properties": {
+              "volume_signal": {
+                "type": "number",
+                "nullable": true
+              },
+              "whale_signal": {
+                "type": "number",
+                "nullable": true
+              },
+              "liquidity_signal": {
+                "type": "number",
+                "nullable": true
+              },
+              "recency_signal": {
+                "type": "number",
+                "nullable": true
+              },
+              "smart_money_signal": {
+                "type": "number",
+                "nullable": true
+              },
+              "price_move_signal": {
+                "type": "number",
+                "nullable": true
+              },
+              "missing_price_penalty": {
+                "type": "number"
+              }
+            }
+          },
+          "freshness": {
+            "type": "object",
+            "required": [
+              "enrichment_status",
+              "price_status"
+            ],
+            "properties": {
+              "enrichment_status": {
+                "type": "string",
+                "enum": [
+                  "available",
+                  "unavailable"
+                ]
+              },
+              "price_status": {
+                "type": "string",
+                "enum": [
+                  "available",
+                  "unavailable"
+                ]
+              }
+            }
           }
         }
       },
       "ExploreGroup": {
         "type": "object",
-        "required": ["type", "event_slug", "parent_title", "markets"],
+        "required": [
+          "type",
+          "event_slug",
+          "parent_title",
+          "markets"
+        ],
         "properties": {
           "type": {
             "type": "string",
@@ -3320,7 +6016,10 @@
       },
       "ExploreStandalone": {
         "type": "object",
-        "required": ["type", "market"],
+        "required": [
+          "type",
+          "market"
+        ],
         "properties": {
           "type": {
             "type": "string",
@@ -3333,7 +6032,11 @@
       },
       "ExploreFacetValue": {
         "type": "object",
-        "required": ["value", "label", "count"],
+        "required": [
+          "value",
+          "label",
+          "count"
+        ],
         "properties": {
           "value": {
             "type": "string"
@@ -3348,7 +6051,10 @@
       },
       "ExploreFacets": {
         "type": "object",
-        "required": ["categories", "platforms"],
+        "required": [
+          "categories",
+          "platforms"
+        ],
         "properties": {
           "categories": {
             "type": "array",
@@ -3383,11 +6089,19 @@
       },
       "MarketIntel": {
         "type": "object",
-        "required": ["market", "smart_money", "timeframe"],
+        "required": [
+          "market",
+          "smart_money",
+          "timeframe"
+        ],
         "properties": {
           "market": {
             "type": "object",
-            "required": ["id", "condition_id", "title"],
+            "required": [
+              "id",
+              "condition_id",
+              "title"
+            ],
             "properties": {
               "id": {
                 "type": "string"
@@ -3428,7 +6142,10 @@
               },
               "direction": {
                 "type": "string",
-                "enum": ["YES", "NO"]
+                "enum": [
+                  "YES",
+                  "NO"
+                ]
               },
               "whale_trade_count": {
                 "type": "integer"
@@ -3443,7 +6160,12 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["id", "address", "side", "size_usd"],
+                  "required": [
+                    "id",
+                    "address",
+                    "side",
+                    "size_usd"
+                  ],
                   "properties": {
                     "id": {
                       "type": "string"
@@ -3461,7 +6183,10 @@
                     },
                     "side": {
                       "type": "string",
-                      "enum": ["YES", "NO"]
+                      "enum": [
+                        "YES",
+                        "NO"
+                      ]
                     },
                     "size_usd": {
                       "type": "number"
@@ -3478,101 +6203,293 @@
       },
       "MarketSnapshotFreshness": {
         "type": "object",
-        "required": ["status", "source"],
+        "required": [
+          "status",
+          "source"
+        ],
         "properties": {
-          "status": { "type": "string", "enum": ["fresh", "stale", "available", "not_live", "unavailable"] },
-          "source": { "type": "string" },
-          "as_of": { "type": "string", "format": "date-time", "nullable": true },
-          "stale_after_s": { "type": "integer", "nullable": true },
-          "reason": { "type": "string", "nullable": true }
+          "status": {
+            "type": "string",
+            "enum": [
+              "fresh",
+              "stale",
+              "available",
+              "not_live",
+              "unavailable"
+            ]
+          },
+          "source": {
+            "type": "string"
+          },
+          "as_of": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "stale_after_s": {
+            "type": "integer",
+            "nullable": true
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true
+          }
         }
       },
       "MarketSnapshotTopOfBook": {
         "type": "object",
-        "required": ["status", "source"],
+        "required": [
+          "status",
+          "source"
+        ],
         "properties": {
-          "status": { "type": "string", "enum": ["available", "unavailable"] },
-          "source": { "type": "string" },
-          "best_bid": { "type": "number", "nullable": true },
-          "best_ask": { "type": "number", "nullable": true },
-          "spread_bps": { "type": "integer", "nullable": true },
-          "bid_depth_usdc": { "type": "number", "nullable": true },
-          "ask_depth_usdc": { "type": "number", "nullable": true },
-          "reason": { "type": "string", "nullable": true }
+          "status": {
+            "type": "string",
+            "enum": [
+              "available",
+              "unavailable"
+            ]
+          },
+          "source": {
+            "type": "string"
+          },
+          "best_bid": {
+            "type": "number",
+            "nullable": true
+          },
+          "best_ask": {
+            "type": "number",
+            "nullable": true
+          },
+          "spread_bps": {
+            "type": "integer",
+            "nullable": true
+          },
+          "bid_depth_usdc": {
+            "type": "number",
+            "nullable": true
+          },
+          "ask_depth_usdc": {
+            "type": "number",
+            "nullable": true
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true
+          }
         }
       },
       "MarketSnapshot": {
         "type": "object",
-        "required": ["market", "outcomes", "liquidity", "sports", "freshness"],
+        "required": [
+          "market",
+          "outcomes",
+          "liquidity",
+          "sports",
+          "freshness"
+        ],
         "properties": {
           "market": {
             "type": "object",
-            "required": ["id", "condition_id", "provider", "status"],
+            "required": [
+              "id",
+              "condition_id",
+              "provider",
+              "status"
+            ],
             "properties": {
-              "id": { "type": "string" },
-              "condition_id": { "type": "string" },
-              "provider": { "type": "string" },
-              "title": { "type": "string", "nullable": true },
-              "slug": { "type": "string", "nullable": true },
-              "page_slug": { "type": "string", "nullable": true },
-              "event_slug": { "type": "string", "nullable": true },
-              "category": { "type": "string", "nullable": true },
-              "status": { "type": "string", "enum": ["active", "closed"] },
-              "description": { "type": "string", "nullable": true },
-              "image": { "type": "string", "nullable": true },
-              "series_slug": { "type": "string", "nullable": true },
-              "kalshi_series_slug": { "type": "string", "nullable": true },
-              "market_type": { "type": "string", "nullable": true },
-              "market_result": { "type": "string", "nullable": true },
-              "created_at": { "type": "string", "format": "date-time", "nullable": true },
-              "end_date": { "type": "string", "format": "date-time", "nullable": true },
-              "resolved_at": { "type": "string", "format": "date-time", "nullable": true }
+              "id": {
+                "type": "string"
+              },
+              "condition_id": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string",
+                "nullable": true
+              },
+              "slug": {
+                "type": "string",
+                "nullable": true
+              },
+              "page_slug": {
+                "type": "string",
+                "nullable": true
+              },
+              "event_slug": {
+                "type": "string",
+                "nullable": true
+              },
+              "category": {
+                "type": "string",
+                "nullable": true
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "active",
+                  "closed"
+                ]
+              },
+              "description": {
+                "type": "string",
+                "nullable": true
+              },
+              "image": {
+                "type": "string",
+                "nullable": true
+              },
+              "series_slug": {
+                "type": "string",
+                "nullable": true
+              },
+              "kalshi_series_slug": {
+                "type": "string",
+                "nullable": true
+              },
+              "market_type": {
+                "type": "string",
+                "nullable": true
+              },
+              "market_result": {
+                "type": "string",
+                "nullable": true
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              },
+              "end_date": {
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              },
+              "resolved_at": {
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              }
             }
           },
           "outcomes": {
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["side", "label", "top_of_book"],
+              "required": [
+                "side",
+                "label",
+                "top_of_book"
+              ],
               "properties": {
-                "side": { "type": "string", "enum": ["yes", "no"] },
-                "label": { "type": "string" },
-                "token_id": { "type": "string", "nullable": true },
-                "current_price": { "type": "number", "nullable": true },
-                "top_of_book": { "$ref": "#/components/schemas/MarketSnapshotTopOfBook" }
+                "side": {
+                  "type": "string",
+                  "enum": [
+                    "yes",
+                    "no"
+                  ]
+                },
+                "label": {
+                  "type": "string"
+                },
+                "token_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "current_price": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "top_of_book": {
+                  "$ref": "#/components/schemas/MarketSnapshotTopOfBook"
+                }
               }
             }
           },
           "liquidity": {
             "type": "object",
-            "required": ["source"],
+            "required": [
+              "source"
+            ],
             "properties": {
-              "source": { "type": "string" },
-              "volume_usd": { "type": "number", "nullable": true },
-              "liquidity_usd": { "type": "number", "nullable": true },
-              "volume_24h_usd": { "type": "number", "nullable": true },
-              "last_price": { "type": "number", "nullable": true }
+              "source": {
+                "type": "string"
+              },
+              "volume_usd": {
+                "type": "number",
+                "nullable": true
+              },
+              "liquidity_usd": {
+                "type": "number",
+                "nullable": true
+              },
+              "volume_24h_usd": {
+                "type": "number",
+                "nullable": true
+              },
+              "last_price": {
+                "type": "number",
+                "nullable": true
+              }
             }
           },
           "sports": {
             "type": "object",
-            "required": ["status", "source"],
+            "required": [
+              "status",
+              "source"
+            ],
             "properties": {
-              "status": { "type": "string", "enum": ["fresh", "stale", "not_live", "unavailable"] },
-              "source": { "type": "string" },
-              "live_match_key": { "type": "string", "nullable": true },
-              "live_league_key": { "type": "string", "nullable": true },
-              "live_score": { "type": "object", "nullable": true },
-              "reason": { "type": "string", "nullable": true }
+              "status": {
+                "type": "string",
+                "enum": [
+                  "fresh",
+                  "stale",
+                  "not_live",
+                  "unavailable"
+                ]
+              },
+              "source": {
+                "type": "string"
+              },
+              "live_match_key": {
+                "type": "string",
+                "nullable": true
+              },
+              "live_league_key": {
+                "type": "string",
+                "nullable": true
+              },
+              "live_score": {
+                "type": "object",
+                "nullable": true
+              },
+              "reason": {
+                "type": "string",
+                "nullable": true
+              }
             }
           },
           "freshness": {
             "type": "object",
-            "required": ["market_data", "top_of_book", "live_sports"],
+            "required": [
+              "market_data",
+              "top_of_book",
+              "live_sports"
+            ],
             "properties": {
-              "market_data": { "$ref": "#/components/schemas/MarketSnapshotFreshness" },
-              "top_of_book": { "$ref": "#/components/schemas/MarketSnapshotFreshness" },
-              "live_sports": { "$ref": "#/components/schemas/MarketSnapshotFreshness" }
+              "market_data": {
+                "$ref": "#/components/schemas/MarketSnapshotFreshness"
+              },
+              "top_of_book": {
+                "$ref": "#/components/schemas/MarketSnapshotFreshness"
+              },
+              "live_sports": {
+                "$ref": "#/components/schemas/MarketSnapshotFreshness"
+              }
             }
           }
         }
@@ -3599,11 +6516,17 @@
           },
           "severity": {
             "type": "string",
-            "enum": ["flag", "watch"]
+            "enum": [
+              "flag",
+              "watch"
+            ]
           },
           "trader": {
             "type": "object",
-            "required": ["id", "address"],
+            "required": [
+              "id",
+              "address"
+            ],
             "properties": {
               "id": {
                 "type": "string"
@@ -3619,7 +6542,11 @@
           },
           "market": {
             "type": "object",
-            "required": ["id", "condition_id", "title"],
+            "required": [
+              "id",
+              "condition_id",
+              "title"
+            ],
             "properties": {
               "id": {
                 "type": "string"
@@ -3664,62 +6591,155 @@
       },
       "ApiErrorBody": {
         "type": "object",
-        "required": ["code", "message"],
+        "required": [
+          "code",
+          "message"
+        ],
         "properties": {
-          "code": { "type": "string" },
-          "message": { "type": "string" },
-          "doc_url": { "type": "string", "nullable": true },
-          "param": { "type": "string", "nullable": true }
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "doc_url": {
+            "type": "string",
+            "nullable": true
+          },
+          "param": {
+            "type": "string",
+            "nullable": true
+          }
         }
       },
       "BatchRateLimitMeta": {
         "type": "object",
-        "required": ["basis", "limit", "remaining", "reset"],
+        "required": [
+          "basis",
+          "limit",
+          "remaining",
+          "reset"
+        ],
         "properties": {
-          "basis": { "type": "string", "const": "batch_items_per_minute" },
-          "limit": { "type": "integer" },
-          "remaining": { "type": "integer" },
-          "reset": { "type": "integer", "description": "Unix timestamp when the batch item window resets." }
+          "basis": {
+            "type": "string",
+            "const": "batch_items_per_minute"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "remaining": {
+            "type": "integer"
+          },
+          "reset": {
+            "type": "integer",
+            "description": "Unix timestamp when the batch item window resets."
+          }
         }
       },
       "BatchResponseMeta": {
         "type": "object",
-        "required": ["request_id", "cached", "total_items", "successful_items", "failed_items", "request_cost", "rate_limit"],
+        "required": [
+          "request_id",
+          "cached",
+          "total_items",
+          "successful_items",
+          "failed_items",
+          "request_cost",
+          "rate_limit"
+        ],
         "properties": {
-          "request_id": { "type": "string" },
-          "cached": { "type": "boolean" },
-          "total_items": { "type": "integer" },
-          "successful_items": { "type": "integer" },
-          "failed_items": { "type": "integer" },
-          "request_cost": { "type": "integer", "description": "Number of batch item units reserved before execution." },
-          "rate_limit": { "$ref": "#/components/schemas/BatchRateLimitMeta" }
+          "request_id": {
+            "type": "string"
+          },
+          "cached": {
+            "type": "boolean"
+          },
+          "total_items": {
+            "type": "integer"
+          },
+          "successful_items": {
+            "type": "integer"
+          },
+          "failed_items": {
+            "type": "integer"
+          },
+          "request_cost": {
+            "type": "integer",
+            "description": "Number of batch item units reserved before execution."
+          },
+          "rate_limit": {
+            "$ref": "#/components/schemas/BatchRateLimitMeta"
+          }
         }
       },
       "BatchTraderItem": {
         "type": "object",
-        "required": ["index", "input", "status"],
+        "required": [
+          "index",
+          "input",
+          "status"
+        ],
         "properties": {
-          "index": { "type": "integer", "description": "Zero-based request index. Duplicate inputs keep separate result rows." },
-          "input": { "type": "string" },
-          "status": { "type": "string", "enum": ["ok", "error"] },
-          "data": { "$ref": "#/components/schemas/Trader" },
-          "error": { "$ref": "#/components/schemas/ApiErrorBody" }
+          "index": {
+            "type": "integer",
+            "description": "Zero-based request index. Duplicate inputs keep separate result rows."
+          },
+          "input": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "error"
+            ]
+          },
+          "data": {
+            "$ref": "#/components/schemas/Trader"
+          },
+          "error": {
+            "$ref": "#/components/schemas/ApiErrorBody"
+          }
         }
       },
       "BatchMarketIntelItem": {
         "type": "object",
-        "required": ["index", "input", "status"],
+        "required": [
+          "index",
+          "input",
+          "status"
+        ],
         "properties": {
-          "index": { "type": "integer", "description": "Zero-based request index. Duplicate inputs keep separate result rows." },
-          "input": { "type": "string" },
-          "status": { "type": "string", "enum": ["ok", "error"] },
-          "data": { "$ref": "#/components/schemas/MarketIntel" },
-          "error": { "$ref": "#/components/schemas/ApiErrorBody" }
+          "index": {
+            "type": "integer",
+            "description": "Zero-based request index. Duplicate inputs keep separate result rows."
+          },
+          "input": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "error"
+            ]
+          },
+          "data": {
+            "$ref": "#/components/schemas/MarketIntel"
+          },
+          "error": {
+            "$ref": "#/components/schemas/ApiErrorBody"
+          }
         }
       },
       "ApiError": {
         "type": "object",
-        "required": ["object", "error", "meta"],
+        "required": [
+          "object",
+          "error",
+          "meta"
+        ],
         "properties": {
           "object": {
             "type": "string",
@@ -3727,10 +6747,24 @@
           },
           "error": {
             "type": "object",
-            "required": ["code", "message"],
+            "required": [
+              "code",
+              "message"
+            ],
             "properties": {
               "code": {
-                "type": "string"
+                "type": "string",
+                "enum": [
+                  "bad_request",
+                  "invalid_api_key",
+                  "subscription_required",
+                  "forbidden",
+                  "not_found",
+                  "account_locked",
+                  "rate_limited",
+                  "rate_limit_unavailable",
+                  "internal_error"
+                ]
               },
               "message": {
                 "type": "string"
@@ -3764,7 +6798,11 @@
         "properties": {
           "kind": {
             "type": "string",
-            "enum": ["daily", "weekly", "monthly"]
+            "enum": [
+              "daily",
+              "weekly",
+              "monthly"
+            ]
           },
           "generated_at": {
             "type": "string",
@@ -3789,7 +6827,11 @@
       },
       "ReportSourceRange": {
         "type": "object",
-        "required": ["start_date", "end_date", "timezone"],
+        "required": [
+          "start_date",
+          "end_date",
+          "timezone"
+        ],
         "properties": {
           "start_date": {
             "type": "string",
@@ -3807,11 +6849,17 @@
       },
       "SnapshotState": {
         "type": "object",
-        "required": ["status", "generated_at"],
+        "required": [
+          "status",
+          "generated_at"
+        ],
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["final", "rolling"]
+            "enum": [
+              "final",
+              "rolling"
+            ]
           },
           "generated_at": {
             "type": "string",
@@ -3835,7 +6883,11 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["complete", "partial", "empty"]
+            "enum": [
+              "complete",
+              "partial",
+              "empty"
+            ]
           },
           "reason": {
             "type": "string"
@@ -3850,7 +6902,11 @@
       },
       "ReportReconciliation": {
         "type": "object",
-        "required": ["volume_kind", "whale_volume_source", "notes"],
+        "required": [
+          "volume_kind",
+          "whale_volume_source",
+          "notes"
+        ],
         "properties": {
           "volume_kind": {
             "type": "string",
@@ -3970,11 +7026,19 @@
       },
       "ExportCompleteness": {
         "type": "object",
-        "required": ["status", "reason", "sync_coverage"],
+        "required": [
+          "status",
+          "reason",
+          "sync_coverage"
+        ],
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["complete", "partial", "empty"]
+            "enum": [
+              "complete",
+              "partial",
+              "empty"
+            ]
           },
           "reason": {
             "type": "string"
@@ -3987,7 +7051,10 @@
       },
       "ExportVolumeReconciliation": {
         "type": "object",
-        "required": ["exported_activity_volume", "exported_market_cost_basis"],
+        "required": [
+          "exported_activity_volume",
+          "exported_market_cost_basis"
+        ],
         "properties": {
           "provider_lifetime_volume": {
             "type": "number",
@@ -4059,6 +7126,103 @@
             "type": "object"
           }
         }
+      },
+      "Usage": {
+        "type": "object",
+        "required": [
+          "object",
+          "data",
+          "meta"
+        ],
+        "properties": {
+          "object": {
+            "type": "string",
+            "const": "usage"
+          },
+          "data": {
+            "type": "object",
+            "required": [
+              "rate_limit",
+              "daily_usage"
+            ],
+            "properties": {
+              "rate_limit": {
+                "type": "object",
+                "required": [
+                  "used",
+                  "limit",
+                  "remaining",
+                  "reset_at",
+                  "window_seconds"
+                ],
+                "properties": {
+                  "used": {
+                    "type": "integer",
+                    "example": 7
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "example": 100
+                  },
+                  "remaining": {
+                    "type": "integer",
+                    "example": 93
+                  },
+                  "reset_at": {
+                    "type": "integer",
+                    "example": 1710772860
+                  },
+                  "window_seconds": {
+                    "type": "integer",
+                    "example": 60
+                  }
+                }
+              },
+              "daily_usage": {
+                "type": "object",
+                "required": [
+                  "used",
+                  "limit",
+                  "remaining",
+                  "reset_at",
+                  "window_seconds"
+                ],
+                "properties": {
+                  "used": {
+                    "type": "integer",
+                    "example": 42
+                  },
+                  "limit": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "example": null
+                  },
+                  "remaining": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "example": null
+                  },
+                  "reset_at": {
+                    "type": "integer",
+                    "example": 1710806400
+                  },
+                  "window_seconds": {
+                    "type": "integer",
+                    "example": 86400
+                  }
+                },
+                "description": "UTC-day usage count. Current V1 has no daily hard cap, so limit and remaining are null rather than synthesized."
+              }
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ResponseMeta"
+          }
+        }
       }
     },
     "responses": {
@@ -4068,11 +7232,22 @@
           "application/json": {
             "schema": {
               "type": "object",
-              "required": ["object", "data", "meta"],
+              "required": [
+                "object",
+                "data",
+                "meta"
+              ],
               "properties": {
-                "object": { "type": "string", "const": "webhook" },
-                "data": { "$ref": "#/components/schemas/WebhookEndpoint" },
-                "meta": { "$ref": "#/components/schemas/ResponseMeta" }
+                "object": {
+                  "type": "string",
+                  "const": "webhook"
+                },
+                "data": {
+                  "$ref": "#/components/schemas/WebhookEndpoint"
+                },
+                "meta": {
+                  "$ref": "#/components/schemas/ResponseMeta"
+                }
               }
             }
           }
@@ -4084,17 +7259,37 @@
           "application/json": {
             "schema": {
               "type": "object",
-              "required": ["object", "data", "has_more", "meta"],
+              "required": [
+                "object",
+                "data",
+                "has_more",
+                "meta"
+              ],
               "properties": {
-                "object": { "type": "string", "const": "list" },
+                "object": {
+                  "type": "string",
+                  "const": "list"
+                },
                 "data": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/WebhookEndpoint" }
+                  "items": {
+                    "$ref": "#/components/schemas/WebhookEndpoint"
+                  }
                 },
-                "has_more": { "type": "boolean" },
-                "next_cursor": { "type": "string", "nullable": true },
-                "total": { "type": "integer", "nullable": true },
-                "meta": { "$ref": "#/components/schemas/ResponseMeta" }
+                "has_more": {
+                  "type": "boolean"
+                },
+                "next_cursor": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "total": {
+                  "type": "integer",
+                  "nullable": true
+                },
+                "meta": {
+                  "$ref": "#/components/schemas/ResponseMeta"
+                }
               }
             }
           }
@@ -4233,7 +7428,148 @@
             }
           }
         }
+      },
+      "IdempotencyInProgress": {
+        "description": "An Idempotency-Key request with the same body is still in progress. Retry shortly with the same key and body.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ApiError"
+            },
+            "examples": {
+              "in_progress": {
+                "summary": "Idempotency request still in progress",
+                "value": {
+                  "object": "error",
+                  "error": {
+                    "code": "bad_request",
+                    "message": "Idempotency-Key request is still in progress; retry shortly",
+                    "param": "Idempotency-Key"
+                  },
+                  "meta": {
+                    "request_id": "req_example",
+                    "cached": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "IdempotencyConflict": {
+        "description": "The Idempotency-Key was already used with a different request body.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ApiError"
+            },
+            "examples": {
+              "different_body": {
+                "summary": "Idempotency key reused with a different body",
+                "value": {
+                  "object": "error",
+                  "error": {
+                    "code": "bad_request",
+                    "message": "Idempotency-Key already used with a different request body",
+                    "param": "Idempotency-Key"
+                  },
+                  "meta": {
+                    "request_id": "req_example",
+                    "cached": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "headers": {
+      "X-RateLimit-Limit": {
+        "description": "Authenticated V1 per-user request limit for the current sliding window.",
+        "schema": {
+          "type": "integer",
+          "example": 100
+        }
+      },
+      "X-RateLimit-Remaining": {
+        "description": "Authenticated V1 requests remaining in the current sliding window after this response.",
+        "schema": {
+          "type": "integer",
+          "example": 84
+        }
+      },
+      "X-RateLimit-Reset": {
+        "description": "Unix timestamp when the authenticated V1 request window resets.",
+        "schema": {
+          "type": "integer",
+          "example": 1710772860
+        }
+      },
+      "X-Request-Id": {
+        "description": "Server-generated request identifier for support and tracing.",
+        "schema": {
+          "type": "string",
+          "example": "req_550e8400"
+        }
+      },
+      "ETag": {
+        "description": "Strong validator for conditional GET. Send as If-None-Match to receive 304 when unchanged.",
+        "schema": {
+          "type": "string",
+          "example": "\"8f14e45fceea167a5a36dedd4bea2543\""
+        }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Traders",
+      "description": "Trader intelligence, batch lookups, timelines, and export readiness."
+    },
+    {
+      "name": "Positions",
+      "description": "Current prediction-market position snapshots from backend-owned mirrors."
+    },
+    {
+      "name": "Whale Trades",
+      "description": "Recent and historical large trade intelligence."
+    },
+    {
+      "name": "Leaderboard",
+      "description": "Ranked trader discovery and category/strategy leaderboards."
+    },
+    {
+      "name": "Markets",
+      "description": "Market search, discovery, snapshots, and smart-score flow."
+    },
+    {
+      "name": "Insider Radar",
+      "description": "Suspicious trading pattern detection."
+    },
+    {
+      "name": "Events",
+      "description": "Durable public event replay streams."
+    },
+    {
+      "name": "Webhooks",
+      "description": "Signed builder webhook destinations and delivery controls."
+    },
+    {
+      "name": "Usage",
+      "description": "Developer API budget and usage introspection."
+    },
+    {
+      "name": "System",
+      "description": "Health and operational status checks."
+    },
+    {
+      "name": "MCP",
+      "description": "Remote Model Context Protocol transport."
+    },
+    {
+      "name": "Reports",
+      "description": "Daily, weekly, monthly, and trader export report snapshots."
+    }
+  ]
 }

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -22,6 +22,110 @@
     }
   ],
   "paths": {
+    "/api/v1": {
+      "get": {
+        "operationId": "getApiDiscovery",
+        "summary": "API discovery",
+        "description": "Unauthenticated API-origin discovery document pointing agents to the canonical API base URL, full docs, web-origin OpenAPI spec, health check, and representative authenticated data routes.",
+        "tags": ["System"],
+        "security": [],
+        "x-codeSamples": [
+          {
+            "lang": "Shell",
+            "label": "cURL",
+            "source": "curl 'https://api.0xinsider.com/api/v1'"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "API discovery document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["object", "data", "meta"],
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "const": "api_discovery"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/ApiDiscovery"
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/ResponseMeta"
+                    }
+                  }
+                },
+                "example": {
+                  "object": "api_discovery",
+                  "data": {
+                    "api_base_url": "https://api.0xinsider.com",
+                    "docs_url": "https://0xinsider.com/llms-full.txt",
+                    "openapi_url": "https://0xinsider.com/api/v1/openapi.json",
+                    "health_url": "https://api.0xinsider.com/api/v1/health",
+                    "authentication": "Bearer API key required for data endpoints; discovery and health are public.",
+                    "authenticated_routes": ["GET /api/v1/markets/search"]
+                  },
+                  "meta": {
+                    "request_id": "req_550e8400-e29b-41d4-a716-446655440000",
+                    "cached": false,
+                    "cache_age_s": null
+                  }
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/api/v1/openapi.json": {
+      "get": {
+        "operationId": "redirectApiOpenapiSpec",
+        "summary": "Redirect to the canonical OpenAPI spec",
+        "description": "Unauthenticated API-origin compatibility redirect to the canonical web-origin OpenAPI JSON document at https://0xinsider.com/api/v1/openapi.json.",
+        "tags": ["System"],
+        "security": [],
+        "x-codeSamples": [
+          {
+            "lang": "Shell",
+            "label": "cURL",
+            "source": "curl -I 'https://api.0xinsider.com/api/v1/openapi.json'"
+          }
+        ],
+        "responses": {
+          "307": {
+            "description": "Temporary redirect to the canonical web-origin OpenAPI spec.",
+            "headers": {
+              "Location": {
+                "description": "Canonical OpenAPI spec URL.",
+                "schema": {
+                  "type": "string",
+                  "format": "uri",
+                  "const": "https://0xinsider.com/api/v1/openapi.json"
+                },
+                "example": "https://0xinsider.com/api/v1/openapi.json"
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/api/v1/trader/{address}": {
       "get": {
         "operationId": "getTrader",
@@ -4745,6 +4849,50 @@
             "type": "integer",
             "nullable": true,
             "description": "Cache age in seconds, null if not cached."
+          }
+        }
+      },
+      "ApiDiscovery": {
+        "type": "object",
+        "required": [
+          "api_base_url",
+          "docs_url",
+          "openapi_url",
+          "health_url",
+          "authentication",
+          "authenticated_routes"
+        ],
+        "properties": {
+          "api_base_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Canonical API origin for public V1 requests."
+          },
+          "docs_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Full agent-readable API reference."
+          },
+          "openapi_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Canonical web-origin OpenAPI JSON document."
+          },
+          "health_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Unauthenticated API health endpoint."
+          },
+          "authentication": {
+            "type": "string",
+            "const": "Bearer API key required for data endpoints; discovery and health are public."
+          },
+          "authenticated_routes": {
+            "type": "array",
+            "description": "Representative authenticated data routes. Full route coverage lives in OpenAPI and llms-full.txt.",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -2966,22 +2966,26 @@
           {
             "lang": "curl",
             "label": "cURL",
-            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"name\":\"Production webhook\",\"url\":\"https://example.com/0xinsider/webhook\",\"event_types\":[\"whale_trades_inserted\"]}' \\\n  'https://api.0xinsider.com/api/v1/webhooks'"
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/webhooks'"
           }
         ],
         "x-examples": {
           "success": {
-            "object": "webhook",
-            "data": {
-              "id": 1,
-              "object": "webhook",
-              "name": "Production webhook",
-              "url": "https://example.com/0xinsider/webhook",
-              "event_types": [
-                "whale_trades_inserted"
-              ],
-              "status": "pending_verification"
-            },
+            "object": "list",
+            "data": [
+              {
+                "id": 1,
+                "object": "webhook",
+                "name": "Production webhook",
+                "url": "https://example.com/0xinsider/webhook",
+                "event_types": [
+                  "whale_trades_inserted"
+                ],
+                "status": "pending_verification"
+              }
+            ],
+            "has_more": false,
+            "next_cursor": null,
             "meta": {
               "request_id": "req_example",
               "cached": false

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -4504,8 +4504,8 @@
           "Usage"
         ],
         "operationId": "getUsage",
-        "summary": "Inspect current API usage without spending a request",
-        "description": "Returns the authenticated caller sliding-window request budget and UTC-day usage. This endpoint is authenticated but does not increment the Redis rate-limit counter or log itself into the API usage table.",
+        "summary": "Inspect current API usage without spending primary request quota",
+        "description": "Returns the authenticated caller sliding-window request budget and UTC-day usage. This endpoint is authenticated and does not increment the primary Redis rate-limit counter or log itself into the API usage table; it is separately throttled at 100 reads/minute per user to protect the usage-count query.",
         "security": [
           {
             "bearerAuth": []
@@ -4575,6 +4575,9 @@
           },
           "423": {
             "$ref": "#/components/responses/Locked"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
           },
           "503": {
             "$ref": "#/components/responses/RateLimitUnavailable"

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,6 +7,12 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
+<Update label="June 1, 2026" description="API DX hardening adds usage, ETags, idempotent webhooks, and richer OpenAPI">
+  Added [`GET /api/v1/usage`](/api-reference/endpoint/get-usage), a zero-cost authenticated budget peek for the current per-minute limiter window and UTC-day usage.
+
+  Deterministic reads now document `ETag` / `If-None-Match` conditional GETs, webhook create/update/delete/rotate support `Idempotency-Key`, and OpenAPI operation IDs are codegen-friendly camel-style identifiers with examples, code samples, and response-header metadata.
+</Update>
+
 <Update label="May 8, 2026" description="Remote MCP exposes position and market discovery tools">
   [`POST /api/v1/mcp`](/api-reference/endpoint/remote-mcp) now exposes nine read-only tools through `tools/list`.
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -10,7 +10,7 @@ This changelog tracks externally visible REST API changes only. Documentation-on
 <Update label="June 1, 2026" description="API DX hardening adds usage, ETags, idempotent webhooks, and richer OpenAPI">
   Added [`GET /api/v1`](/api-reference/endpoint/get-api-discovery), a public API-origin discovery document, and [`GET /api/v1/openapi.json`](/api-reference/endpoint/redirect-api-openapi-spec), a redirect to the canonical web-origin OpenAPI spec.
 
-  Added [`GET /api/v1/usage`](/api-reference/endpoint/get-usage), a zero-cost authenticated budget peek for the current per-minute limiter window and UTC-day usage.
+  Added [`GET /api/v1/usage`](/api-reference/endpoint/get-usage), an authenticated budget peek for the current per-minute limiter window and UTC-day usage. It does not spend primary quota, but has its own 100 reads/minute guard.
 
   Deterministic reads now document `ETag` / `If-None-Match` conditional GETs, webhook create/update/delete/rotate support `Idempotency-Key`, and OpenAPI operation IDs are codegen-friendly camel-style identifiers with examples, code samples, and response-header metadata.
 </Update>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -8,6 +8,8 @@ rss: true
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
 <Update label="June 1, 2026" description="API DX hardening adds usage, ETags, idempotent webhooks, and richer OpenAPI">
+  Added [`GET /api/v1`](/api-reference/endpoint/get-api-discovery), a public API-origin discovery document, and [`GET /api/v1/openapi.json`](/api-reference/endpoint/redirect-api-openapi-spec), a redirect to the canonical web-origin OpenAPI spec.
+
   Added [`GET /api/v1/usage`](/api-reference/endpoint/get-usage), a zero-cost authenticated budget peek for the current per-minute limiter window and UTC-day usage.
 
   Deterministic reads now document `ETag` / `If-None-Match` conditional GETs, webhook create/update/delete/rotate support `Idempotency-Key`, and OpenAPI operation IDs are codegen-friendly camel-style identifiers with examples, code samples, and response-header metadata.

--- a/docs.json
+++ b/docs.json
@@ -45,6 +45,13 @@
             ]
           },
           {
+            "group": "Discovery",
+            "pages": [
+              "api-reference/endpoint/get-api-discovery",
+              "api-reference/endpoint/redirect-api-openapi-spec"
+            ]
+          },
+          {
             "group": "Traders",
             "pages": [
               "api-reference/endpoint/get-trader",

--- a/docs.json
+++ b/docs.json
@@ -91,6 +91,12 @@
             ]
           },
           {
+            "group": "Usage",
+            "pages": [
+              "api-reference/endpoint/get-usage"
+            ]
+          },
+          {
             "group": "Webhooks",
             "pages": [
               "api-reference/endpoint/list-webhooks",

--- a/rate-limits.mdx
+++ b/rate-limits.mdx
@@ -7,9 +7,12 @@ The API allows **100 requests per minute** on a sliding window. The limit is **p
 
 Batch read endpoints (e.g. `POST /api/v1/traders/batch`, `POST /api/v1/markets/intel/batch`) have a **separate** budget measured in *item units*, also 100 per minute. A 25-item batch reserves 25 item units before it executes.
 
+`GET /api/v1/usage` does not spend primary request quota or log itself into daily usage. It has a separate 100 reads/minute per-user guard so quota introspection cannot create unbounded usage-count load.
+
 | Setting | Value |
 |---|---|
 | Requests per minute | 100 |
+| Usage reads per minute | 100 |
 | Batch item units per minute | 100 |
 | Window type | Sliding (not bucket-of-60-seconds) |
 | Scope | Per user (sum of all keys) |
@@ -109,7 +112,7 @@ body = get_with_backoff(
 - **Ask for more per request.** Bump `limit` up to 100 instead of making 10 calls of `limit=10`.
 - **Use batch endpoints when you already know your IDs.** One batch call for 25 traders costs 25 batch-item units, but only one regular request.
 - **Watch `X-RateLimit-Remaining`.** If it crosses below 10, pause your polling for the next reset.
-- **Use `/usage` for budget checks.** `GET /api/v1/usage` reads the current limiter window without incrementing it.
+- **Use `/usage` for budget checks.** `GET /api/v1/usage` reads the current primary limiter window without incrementing it. Respect its own 100 reads/minute cap instead of using another endpoint as a quota probe.
 - **One process owns the polling.** Avoid every container in a fleet polling the same endpoint with the same key.
 
 ## Conditional GETs

--- a/rate-limits.mdx
+++ b/rate-limits.mdx
@@ -24,6 +24,7 @@ Every authenticated response carries:
 X-RateLimit-Limit:     100
 X-RateLimit-Remaining: 87
 X-RateLimit-Reset:     1774450631
+X-Request-Id:          req_550e8400
 ```
 
 | Header | Meaning |
@@ -31,6 +32,7 @@ X-RateLimit-Reset:     1774450631
 | `X-RateLimit-Limit` | Max requests per minute. |
 | `X-RateLimit-Remaining` | Remaining slots in the current window. |
 | `X-RateLimit-Reset` | Unix timestamp (seconds) when the window resets. |
+| `X-Request-Id` | Request identifier to include when reporting a support issue. |
 
 Batch responses additionally carry:
 
@@ -107,4 +109,11 @@ body = get_with_backoff(
 - **Ask for more per request.** Bump `limit` up to 100 instead of making 10 calls of `limit=10`.
 - **Use batch endpoints when you already know your IDs.** One batch call for 25 traders costs 25 batch-item units, but only one regular request.
 - **Watch `X-RateLimit-Remaining`.** If it crosses below 10, pause your polling for the next reset.
+- **Use `/usage` for budget checks.** `GET /api/v1/usage` reads the current limiter window without incrementing it.
 - **One process owns the polling.** Avoid every container in a fleet polling the same endpoint with the same key.
+
+## Conditional GETs
+
+Deterministic read endpoints return an `ETag` header. Re-send it as `If-None-Match` to receive `304 Not Modified` with an empty body when the payload is unchanged.
+
+This applies to trader, positions, whale-trades, whale-trades/history, leaderboard, markets/explore, market intel, market snapshot, insider-radar, position-timeline, and health responses. Report snapshot endpoints are not conditional yet because their body includes request-time `generated_at`.


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/usage` docs and navigation entry
- Document webhook `Idempotency-Key` retry semantics
- Sync OpenAPI, rate-limit headers, conditional GET coverage, and API changelog for the API DX hardening slice

## Verification
- `python3 scripts/check-openapi-parity.py`
- `python3 -m json.tool api-reference/openapi.json >/dev/null && python3 -m json.tool docs.json >/dev/null`
- `mint broken-links`

Companion app PR: 0xinsider/0xinsider#4995