### PR TITLE
docs(api): document round-trippable v1 IDs

### DIFF
--- a/api-reference/endpoint/get-insider-radar-flag.mdx
+++ b/api-reference/endpoint/get-insider-radar-flag.mdx
@@ -1,0 +1,13 @@
+---
+title: "Get Insider Radar Flag"
+openapi: "GET /api/v1/insider-radar/{id}"
+---
+
+Fetch one radar flag by ID. Use either the raw `radar_flags.id` or the `rf_...` ID returned by insider-radar list responses.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/insider-radar/rf_123"
+```
+
+The response is a single `radar_flag` envelope with the same item shape as [Get Insider Radar](/api-reference/endpoint/get-insider-radar).

--- a/api-reference/endpoint/get-insider-radar.mdx
+++ b/api-reference/endpoint/get-insider-radar.mdx
@@ -12,4 +12,4 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/insider-radar?limit=20"
 ```
 
-Cursor-paginated by score. See [Pagination](/concepts/pagination).
+Cursor-paginated by score. See [Pagination](/concepts/pagination). To fetch one returned `rf_...` item again, use [Get Insider Radar Flag](/api-reference/endpoint/get-insider-radar-flag).

--- a/api-reference/endpoint/get-market-intel.mdx
+++ b/api-reference/endpoint/get-market-intel.mdx
@@ -5,7 +5,7 @@ openapi: "GET /api/v1/market/{condition_id}/intel"
 
 Smart-money breakdown for one market: buy vs sell volume from graded traders, top positions, and which side has conviction.
 
-Pass the on-chain `condition_id` in the path, **not** the prefixed `mkt_...` form. A `mkt_...` value returns `400 bad_request`. Raw condition IDs appear in whale trades and in `search` and `explore` responses.
+Pass either the raw provider-backed `condition_id` or the `mkt_...` market ID emitted by V1 responses. The API returns `400 bad_request` for known non-market prefixes such as `trd_`, `wt_`, or `rf_`.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \

--- a/api-reference/endpoint/get-market-snapshot.mdx
+++ b/api-reference/endpoint/get-market-snapshot.mdx
@@ -5,7 +5,7 @@ openapi: "GET /api/v1/market/{condition_id}/snapshot"
 
 One-shot view of a single market: price, volume, status, recent activity. Trust-metadata fields tell you which values are live and provider-backed and which are cached, partial, or unavailable.
 
-Pass the raw on-chain `condition_id` in the path.
+Pass either the raw provider-backed `condition_id` or the `mkt_...` market ID emitted by V1 responses.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \

--- a/api-reference/endpoint/get-whale-trade.mdx
+++ b/api-reference/endpoint/get-whale-trade.mdx
@@ -1,0 +1,13 @@
+---
+title: "Get Whale Trade"
+openapi: "GET /api/v1/whale-trades/{id}"
+---
+
+Fetch one whale trade by ID. Use either the raw `whale_alerts.id` or the `wt_...` ID returned by whale-trade list and history responses.
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/whale-trades/wt_123"
+```
+
+The response is a single `whale_trade` envelope with the same item shape as [Get Whale Trades](/api-reference/endpoint/get-whale-trades).

--- a/api-reference/endpoint/get-whale-trades.mdx
+++ b/api-reference/endpoint/get-whale-trades.mdx
@@ -17,4 +17,4 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&category=crypto&side=buy&limit=50"
 ```
 
-Cursor-paginated by timestamp. For a fixed time range, use [Whale Trades History](/api-reference/endpoint/get-whale-trades-history).
+Cursor-paginated by timestamp. For a fixed time range (backtests, recap reports), use [Whale Trades History](/api-reference/endpoint/get-whale-trades-history). To fetch one returned `wt_...` item again, use [Get Whale Trade](/api-reference/endpoint/get-whale-trade).

--- a/api-reference/endpoint/search-markets.mdx
+++ b/api-reference/endpoint/search-markets.mdx
@@ -10,4 +10,4 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/markets/search?q=trump&category=politics&status=active"
 ```
 
-Pass the returned `condition_id` (raw on-chain, not the `mkt_...` form) into [Market Intel](/api-reference/endpoint/get-market-intel) or [Market Snapshot](/api-reference/endpoint/get-market-snapshot). To browse instead of search, use [Explore Markets](/api-reference/endpoint/explore-markets).
+Pass the returned `condition_id` or returned `mkt_...` market ID into [Market Intel](/api-reference/endpoint/get-market-intel) or [Market Snapshot](/api-reference/endpoint/get-market-snapshot). For browsing rather than searching, use [Explore Markets](/api-reference/endpoint/explore-markets).

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -66,7 +66,7 @@ Every ID is prefixed with its type, so it's self-describing in logs and chat tra
 | Radar flag | `rf_` | `rf_67890` |
 | Request | `req_` | `req_550e8400` |
 
-When an endpoint takes an address in the path (`/trader/{address}`), strip the `trd_` prefix and pass the raw address. When it takes a `condition_id` (`/market/{condition_id}/intel`), pass the raw on-chain condition ID, not the prefixed `mkt_...` form.
+Trader path endpoints accept raw addresses and valid `trd_...` wallet IDs. Market path endpoints such as `/market/{condition_id}/intel` and `/market/{condition_id}/snapshot` accept either raw provider-backed condition IDs or the `mkt_...` IDs emitted by V1 responses. Single-record whale trade and radar endpoints accept raw integer IDs or their `wt_...` / `rf_...` forms.
 
 ## Rate limits
 

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -221,8 +221,28 @@
                   "success": {
                     "summary": "Successful response",
                     "value": {
-                      "object": "traders",
-                      "data": {},
+                      "object": "trader",
+                      "data": {
+                                              "id": "trd_0x863134d00841b2e200492805a01e1e2f5defaa53",
+                                              "address": "0x863134d00841b2e200492805a01e1e2f5defaa53",
+                                              "username": "RepTrump",
+                                              "grade": "S",
+                                              "score": 97.94,
+                                              "rank": 1,
+                                              "pnl": {
+                                                "total": 7532409.67,
+                                                "realized": 7401234.56,
+                                                "unrealized": 131175.11,
+                                                "last_7d": 84210.5,
+                                                "last_30d": 512033.18
+                                              },
+                                              "stats": {
+                                                "markets_traded": 28,
+                                                "win_rate": 1.0,
+                                                "daily_win_rate": 0.92,
+                                                "total_volume": 18400000.0
+                                              }
+                                            },
                       "meta": {
                         "request_id": "req_example",
                         "cached": false
@@ -292,8 +312,28 @@
         ],
         "x-examples": {
           "success": {
-            "object": "traders",
-            "data": {},
+            "object": "trader",
+            "data": {
+                          "id": "trd_0x863134d00841b2e200492805a01e1e2f5defaa53",
+                          "address": "0x863134d00841b2e200492805a01e1e2f5defaa53",
+                          "username": "RepTrump",
+                          "grade": "S",
+                          "score": 97.94,
+                          "rank": 1,
+                          "pnl": {
+                            "total": 7532409.67,
+                            "realized": 7401234.56,
+                            "unrealized": 131175.11,
+                            "last_7d": 84210.5,
+                            "last_30d": 512033.18
+                          },
+                          "stats": {
+                            "markets_traded": 28,
+                            "win_rate": 1.0,
+                            "daily_win_rate": 0.92,
+                            "total_volume": 18400000.0
+                          }
+                        },
             "meta": {
               "request_id": "req_example",
               "cached": false
@@ -424,8 +464,35 @@
                   "success": {
                     "summary": "Successful response",
                     "value": {
-                      "object": "traders",
-                      "data": {},
+                      "object": "trader_batch",
+                      "data": [
+                                              {
+                                                "index": 0,
+                                                "input": "0x863134d00841b2e200492805a01e1e2f5defaa53",
+                                                "status": "ok",
+                                                "data": {
+                                                  "id": "trd_0x863134d00841b2e200492805a01e1e2f5defaa53",
+                                                  "address": "0x863134d00841b2e200492805a01e1e2f5defaa53",
+                                                  "username": "RepTrump",
+                                                  "grade": "S",
+                                                  "score": 97.94,
+                                                  "rank": 1,
+                                                  "pnl": {
+                                                    "total": 7532409.67,
+                                                    "realized": 7401234.56,
+                                                    "unrealized": 131175.11,
+                                                    "last_7d": 84210.5,
+                                                    "last_30d": 512033.18
+                                                  },
+                                                  "stats": {
+                                                    "markets_traded": 28,
+                                                    "win_rate": 1.0,
+                                                    "daily_win_rate": 0.92,
+                                                    "total_volume": 18400000.0
+                                                  }
+                                                }
+                                              }
+                                            ],
                       "meta": {
                         "request_id": "req_example",
                         "cached": false
@@ -473,8 +540,35 @@
         ],
         "x-examples": {
           "success": {
-            "object": "traders",
-            "data": {},
+            "object": "trader_batch",
+            "data": [
+                          {
+                            "index": 0,
+                            "input": "0x863134d00841b2e200492805a01e1e2f5defaa53",
+                            "status": "ok",
+                            "data": {
+                              "id": "trd_0x863134d00841b2e200492805a01e1e2f5defaa53",
+                              "address": "0x863134d00841b2e200492805a01e1e2f5defaa53",
+                              "username": "RepTrump",
+                              "grade": "S",
+                              "score": 97.94,
+                              "rank": 1,
+                              "pnl": {
+                                "total": 7532409.67,
+                                "realized": 7401234.56,
+                                "unrealized": 131175.11,
+                                "last_7d": 84210.5,
+                                "last_30d": 512033.18
+                              },
+                              "stats": {
+                                "markets_traded": 28,
+                                "win_rate": 1.0,
+                                "daily_win_rate": 0.92,
+                                "total_volume": 18400000.0
+                              }
+                            }
+                          }
+                        ],
             "meta": {
               "request_id": "req_example",
               "cached": false
@@ -4706,8 +4800,42 @@
                   "success": {
                     "summary": "Successful response",
                     "value": {
-                      "object": "traders",
-                      "data": {},
+                      "object": "trader_export_snapshot",
+                      "data": {
+                                              "address": "0x863134d00841b2e200492805a01e1e2f5defaa53",
+                                              "generated_at": "2026-06-01T00:00:00Z",
+                                              "source_range": {
+                                                "first_pnl_date": "2025-01-04",
+                                                "last_pnl_date": "2026-05-31",
+                                                "latest_trade_at": "2026-05-31T18:22:05Z",
+                                                "latest_market_activity_at": "2026-05-31T18:22:05Z"
+                                              },
+                                              "completeness": {
+                                                "status": "complete",
+                                                "reason": "fully_synced",
+                                                "sync_coverage": 1.0
+                                              },
+                                              "reconciliation": {
+                                                "provider_lifetime_volume": 18650000.0,
+                                                "exported_activity_volume": 18400000.0,
+                                                "exported_market_cost_basis": 9200000.0,
+                                                "provider_activity_volume_gap": 250000.0,
+                                                "activity_volume_coverage": 0.9866
+                                              },
+                                              "counts": {
+                                                "pnl_days": 513,
+                                                "exported_markets": 28,
+                                                "estimated_trade_rows": 1420,
+                                                "estimated_size_mb": 2.4
+                                              },
+                                              "large_export_policy": {
+                                                "mode": "direct_streaming",
+                                                "current_internal_route": "stream",
+                                                "direct_streaming": {},
+                                                "async_job": {},
+                                                "rate_limit": {}
+                                              }
+                                            },
                       "meta": {
                         "request_id": "req_example",
                         "cached": false
@@ -4772,8 +4900,42 @@
         ],
         "x-examples": {
           "success": {
-            "object": "traders",
-            "data": {},
+            "object": "trader_export_snapshot",
+            "data": {
+                          "address": "0x863134d00841b2e200492805a01e1e2f5defaa53",
+                          "generated_at": "2026-06-01T00:00:00Z",
+                          "source_range": {
+                            "first_pnl_date": "2025-01-04",
+                            "last_pnl_date": "2026-05-31",
+                            "latest_trade_at": "2026-05-31T18:22:05Z",
+                            "latest_market_activity_at": "2026-05-31T18:22:05Z"
+                          },
+                          "completeness": {
+                            "status": "complete",
+                            "reason": "fully_synced",
+                            "sync_coverage": 1.0
+                          },
+                          "reconciliation": {
+                            "provider_lifetime_volume": 18650000.0,
+                            "exported_activity_volume": 18400000.0,
+                            "exported_market_cost_basis": 9200000.0,
+                            "provider_activity_volume_gap": 250000.0,
+                            "activity_volume_coverage": 0.9866
+                          },
+                          "counts": {
+                            "pnl_days": 513,
+                            "exported_markets": 28,
+                            "estimated_trade_rows": 1420,
+                            "estimated_size_mb": 2.4
+                          },
+                          "large_export_policy": {
+                            "mode": "direct_streaming",
+                            "current_internal_route": "stream",
+                            "direct_streaming": {},
+                            "async_job": {},
+                            "rate_limit": {}
+                          }
+                        },
             "meta": {
               "request_id": "req_example",
               "cached": false
@@ -4849,7 +5011,7 @@
             }
           },
           "401": {
-            "$ref": "#/components/responses/InvalidApiKey"
+            "$ref": "#/components/responses/Unauthorized"
           },
           "402": {
             "$ref": "#/components/responses/SubscriptionRequired"

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1510,6 +1510,147 @@
         }
       }
     },
+    "/api/v1/whale-trades/{id}": {
+      "get": {
+        "operationId": "getWhaleTrade",
+        "summary": "Get whale trade by ID",
+        "description": "Returns one whale trade by raw whale_alerts.id or the wt_-prefixed id emitted by list and history responses.",
+        "tags": [
+          "Whale Trades"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Raw whale_alerts.id or wt_-prefixed whale trade id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "Conditional GET validator from a previous ETag. Matching values return 304 Not Modified with an empty body.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Whale trade",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "object",
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "const": "whale_trade"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/WhaleTrade"
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/ResponseMeta"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "whale_trade",
+                      "data": {},
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified. Returned when If-None-Match matches the current payload.",
+            "headers": {
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/SubscriptionRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "423": {
+            "$ref": "#/components/responses/Locked"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "503": {
+            "$ref": "#/components/responses/RateLimitUnavailable"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/whale-trades/wt_123'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "whale_trade",
+            "data": {},
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
+        }
+      }
+    },
     "/api/v1/leaderboard": {
       "get": {
         "operationId": "listLeaderboard",
@@ -2136,7 +2277,7 @@
             "name": "condition_id",
             "in": "path",
             "required": true,
-            "description": "Market condition ID. Use the condition_id returned by /api/v1/markets/search, not the prefixed market.id value (mkt_...).",
+            "description": "Market condition ID. Accepts the raw provider-backed condition_id returned by /api/v1/markets/search or the mkt_-prefixed market.id emitted by V1 responses.",
             "schema": {
               "type": "string"
             }
@@ -2474,7 +2615,7 @@
             "name": "condition_id",
             "in": "path",
             "required": true,
-            "description": "Market condition ID. Use the condition_id returned by /api/v1/markets/search or /api/v1/markets/explore, not the prefixed market.id value (mkt_...).",
+            "description": "Market condition ID. Accepts the raw provider-backed condition_id returned by /api/v1/markets/search or /api/v1/markets/explore, or the mkt_-prefixed market.id emitted by V1 responses.",
             "schema": {
               "type": "string"
             }
@@ -2772,6 +2913,147 @@
         "x-examples": {
           "success": {
             "object": "insider_radar",
+            "data": {},
+            "meta": {
+              "request_id": "req_example",
+              "cached": false
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/insider-radar/{id}": {
+      "get": {
+        "operationId": "getInsiderRadarFlag",
+        "summary": "Get insider radar flag by ID",
+        "description": "Returns one suspicious-trading radar flag by raw radar_flags.id or the rf_-prefixed id emitted by list responses.",
+        "tags": [
+          "Insider Radar"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Raw radar_flags.id or rf_-prefixed radar flag id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "Conditional GET validator from a previous ETag. Matching values return 304 Not Modified with an empty body.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Radar flag",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "object",
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "const": "radar_flag"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/RadarFlag"
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/ResponseMeta"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "object": "radar_flag",
+                      "data": {},
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              },
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified. Returned when If-None-Match matches the current payload.",
+            "headers": {
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/SubscriptionRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
+          "423": {
+            "$ref": "#/components/responses/Locked"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "503": {
+            "$ref": "#/components/responses/RateLimitUnavailable"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "curl",
+            "label": "cURL",
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/insider-radar/rf_123'"
+          }
+        ],
+        "x-examples": {
+          "success": {
+            "object": "radar_flag",
             "data": {},
             "meta": {
               "request_id": "req_example",
@@ -5381,7 +5663,7 @@
             ],
             "nullable": true
           },
-          "form_tier": {
+          "streak_tier": {
             "type": "string",
             "enum": [
               "hot",
@@ -5391,7 +5673,7 @@
               "cold"
             ],
             "nullable": true,
-            "description": "Recent-form tier (trailing-7d cross-sectional percentile); a separate axis from the all-time grade. Null when no recent activity."
+            "description": "Hot-streak tier (trailing-7d cross-sectional percentile); a separate axis from the all-time grade. Null when no recent activity."
           },
           "score": {
             "type": "number",
@@ -5786,7 +6068,7 @@
             "type": "string",
             "nullable": true
           },
-          "form_tier": {
+          "streak_tier": {
             "type": "string",
             "enum": [
               "hot",
@@ -5796,7 +6078,7 @@
               "cold"
             ],
             "nullable": true,
-            "description": "Recent-form tier (trailing-7d cross-sectional percentile); a separate axis from the all-time grade. Null when no recent activity."
+            "description": "Hot-streak tier (trailing-7d cross-sectional percentile); a separate axis from the all-time grade. Null when no recent activity."
           },
           "score": {
             "type": "number",

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -130,7 +130,7 @@
       "get": {
         "operationId": "getTrader",
         "summary": "Get trader intelligence",
-        "description": "Returns a trader's grade (S through F), P&L, win rate, and optional strategy/category data. The path accepts either an Ethereum wallet address or a known trader username. Unknown lookups return sync_status \"unknown\" instead of 404.",
+        "description": "Returns a trader's grade (S through F), P&L, win rate, and optional strategy/category data. The path accepts either an Ethereum wallet address, a known trader username, or a trd_-prefixed trader ID emitted by this API. Unknown lookups return sync_status \"unknown\" instead of 404.",
         "tags": [
           "Traders"
         ],
@@ -139,7 +139,7 @@
             "name": "address",
             "in": "path",
             "required": true,
-            "description": "Ethereum wallet address (0x...) or known trader username",
+            "description": "Ethereum wallet address (0x...), known trader username, or trd_-prefixed trader ID emitted by this API.",
             "schema": {
               "type": "string"
             }
@@ -496,7 +496,7 @@
             "name": "address",
             "in": "path",
             "required": true,
-            "description": "Trader wallet address (0x...). Case-insensitive — addresses are lowercased server-side.",
+            "description": "Trader wallet address (0x...) or trd_-prefixed trader ID emitted by this API. Case-insensitive wallet addresses are lowercased server-side.",
             "schema": {
               "type": "string"
             }
@@ -4671,7 +4671,7 @@
             "name": "address",
             "in": "path",
             "required": true,
-            "description": "Trader wallet address (0x...) or known trader username-style lookup accepted by the export read model.",
+            "description": "Trader wallet address (0x...), known trader username-style lookup, or trd_-prefixed trader ID emitted by this API.",
             "schema": {
               "type": "string"
             }
@@ -5866,7 +5866,7 @@
             "properties": {
               "id": {
                 "type": "string",
-                "description": "Prefixed ID (`trd_0x...`)."
+                "description": "Prefixed ID (`trd_...`)."
               },
               "address": {
                 "type": "string"

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,7 +7,7 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
-<Update label="June 1, 2026" description="Remote MCP read parity, usage and caching headers, and easier discovery">
+<Update label="June 1, 2026" description="Remote MCP read parity, round-trippable IDs, usage and caching headers, and easier discovery">
   **Remote MCP read parity.** [`POST /api/v1/mcp`](/api-reference/endpoint/remote-mcp) now exposes 21 read-only tools through `tools/list`, covering the public V1 reads: batch reads, history, event replay, webhook reads, reports, market snapshots, and trader exports. Webhook mutations stay REST-only, and the endpoint is tools-only (no resources or prompts).
 
   **See your usage.** Added [`GET /api/v1/usage`](/api-reference/endpoint/get-usage), an authenticated peek at your current per-minute limiter window and UTC-day usage. It doesn't spend primary quota, but has its own 100 reads/minute guard.
@@ -15,6 +15,8 @@ This changelog tracks externally visible REST API changes only. Documentation-on
   **Cheaper polling, safe retries.** Deterministic reads now support `ETag` / `If-None-Match` conditional GETs, so an unchanged read returns `304` with no body. Webhook create/update/delete/rotate accept an `Idempotency-Key`.
 
   **Easier discovery.** Added [`GET /api/v1`](/api-reference/endpoint/get-api-discovery) (an API discovery document) and [`GET /api/v1/openapi.json`](/api-reference/endpoint/redirect-api-openapi-spec) (a redirect to the canonical OpenAPI spec). Operation IDs are now codegen-friendly, with examples, code samples, and response-header metadata.
+
+  **Round-trippable IDs.** Market Intel and Market Snapshot now accept the `mkt_...` market ID or the raw `condition_id`. New [`GET /api/v1/whale-trades/{id}`](/api-reference/endpoint/get-whale-trade) and [`GET /api/v1/insider-radar/{id}`](/api-reference/endpoint/get-insider-radar-flag) dereference a single `wt_...` / `rf_...` record. Non-market prefixes return `400 bad_request`.
 </Update>
 
 <Update label="May 8, 2026" description="Remote MCP exposes position and market discovery tools">

--- a/docs.json
+++ b/docs.json
@@ -82,13 +82,15 @@
             "group": "Whale Trades",
             "pages": [
               "api-reference/endpoint/get-whale-trades",
+              "api-reference/endpoint/get-whale-trade",
               "api-reference/endpoint/get-whale-trades-history"
             ]
           },
           {
             "group": "Insider Radar",
             "pages": [
-              "api-reference/endpoint/get-insider-radar"
+              "api-reference/endpoint/get-insider-radar",
+              "api-reference/endpoint/get-insider-radar-flag"
             ]
           },
           {

--- a/errors.mdx
+++ b/errors.mdx
@@ -103,8 +103,8 @@ Batch endpoints (e.g. `POST /api/v1/traders/batch`) return `200 OK` even when in
   <Accordion title="429 rate_limited">
     Sleep `Retry-After` seconds, then retry. See the backoff example in [Rate Limits](/rate-limits).
   </Accordion>
-  <Accordion title="400 bad_request on Market Intel with mkt_... prefix">
-    Market Intel takes the raw `condition_id`, not the prefixed `mkt_...` ID. Look up the market via [`/markets/search`](/api-reference/endpoint/search-markets) and pass the returned `condition_id`.
+  <Accordion title="400 bad_request on Market Intel with a prefixed ID">
+    Market Intel takes the raw `condition_id` or the `mkt_...` market ID from V1 responses. It rejects non-market prefixes (`trd_`, `wt_`, `rf_`) with `400 bad_request`. If you only have one of those, resolve the market first via [`/markets/search`](/api-reference/endpoint/search-markets).
   </Accordion>
   <Accordion title="500 internal_error">
     Retry once. If it persists, email [support@0xinsider.com](mailto:support@0xinsider.com) with the `meta.request_id` from the response.


### PR DESCRIPTION
Companion docs for 0xinsider/0xinsider#4981.

## What

- Sync `api-reference/openapi.json` with the V1 round-trippable ID contract.
- Add docs pages for `GET /api/v1/whale-trades/{id}` and `GET /api/v1/insider-radar/{id}`.
- Update market/trader ID guidance so docs no longer say `mkt_...` must be stripped before market intel/snapshot requests.

## Verification

```
python3 -m json.tool api-reference/openapi.json >/dev/null
git diff --check
```

---

**Agent note (Codex review addressed; rebase decision needed):**
- Fixed Codex **P1** (the lone dangling `$ref`: `/usage` 401 now points to the existing `Unauthorized` component) and **P2** (the six trader-family success examples in `trader`, `traders/batch`, and `trader/export` had `object: "traders"` + empty `data` {}; now set to the correct const and valid, schema-matching payloads). JSON validates; `mint broken-links` passes.
- This branch predates the merge of `#20` ("document API DX hardening"), which squashed this branch's earlier commits. The branch therefore still carries duplicate API-DX commits and conflicts heavily with `main`. The **true net-new** content vs current `main` is ~500 lines: the round-trippable-v1-ID feature, the new `get-whale-trade` and `get-insider-radar-flag` endpoint pages, and the ID-guidance edits.
- To ship cleanly I would reconstruct the branch on top of current `main` with just that net-new delta (a history rewrite / force-push of this PR). Holding for your go-ahead since it is your PR and depends on exactly what `#20` already shipped.
