### PR TITLE
docs: simplify copy sitewide (tighter voice, no AI-slop)

### DIFF
--- a/api-reference/endpoint/batch-get-market-intel.mdx
+++ b/api-reference/endpoint/batch-get-market-intel.mdx
@@ -3,7 +3,7 @@ title: "Batch Get Market Intel"
 openapi: "POST /api/v1/markets/intel/batch"
 ---
 
-Fetch market intel for up to 25 markets in one round trip. Same payload shape per item as [Get Market Intel](/api-reference/endpoint/get-market-intel), plus a per-item `error` field when one condition ID fails.
+Fetch market intel for up to 25 markets in one call. Each item has the same shape as [Get Market Intel](/api-reference/endpoint/get-market-intel), plus a per-item `error` field when a condition ID fails.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -12,4 +12,4 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/markets/intel/batch"
 ```
 
-Costs item units against the batch budget: a 25-market batch reserves 25 item units. The top-level HTTP status is `200` even when some items fail — check `data[i].error` per item. See [Rate Limits](/rate-limits).
+Each item costs one unit against the batch budget: a 25-market batch reserves 25 units. The top-level status stays `200` even when some items fail, so check `data[i].error` per item. See [Rate Limits](/rate-limits).

--- a/api-reference/endpoint/batch-get-traders.mdx
+++ b/api-reference/endpoint/batch-get-traders.mdx
@@ -3,7 +3,7 @@ title: "Batch Get Traders"
 openapi: "POST /api/v1/traders/batch"
 ---
 
-Fetch up to 25 trader profiles in one round trip. Each item in the response carries the same shape as [Get Trader](/api-reference/endpoint/get-trader), plus a per-item `error` field if that specific address failed.
+Fetch up to 25 trader profiles in one call. Each item has the same shape as [Get Trader](/api-reference/endpoint/get-trader), plus a per-item `error` field when an address fails.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -12,4 +12,4 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/traders/batch"
 ```
 
-Costs item units against the batch budget: a 25-address batch reserves 25 item units. The top-level HTTP status is `200` even when some items fail — check `data[i].error` per item. See [Rate Limits](/rate-limits).
+Each item costs one unit against the batch budget: a 25-address batch reserves 25 units. The top-level status stays `200` even when some items fail, so check `data[i].error` per item. See [Rate Limits](/rate-limits).

--- a/api-reference/endpoint/create-webhook.mdx
+++ b/api-reference/endpoint/create-webhook.mdx
@@ -3,7 +3,7 @@ title: "Create Webhook"
 openapi: "POST /api/v1/webhooks"
 ---
 
-Register a webhook endpoint to receive whale trade and radar events as they happen.
+Register an endpoint to receive whale-trade and radar events as they happen.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -17,6 +17,6 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/webhooks"
 ```
 
-The response includes a one-time signing secret. **Copy it immediately** — you cannot retrieve it later. Use it to verify the `X-0xinsider-Signature` header on every delivery; see [Verify Webhook](/api-reference/endpoint/verify-webhook). If the secret leaks, [rotate it](/api-reference/endpoint/rotate-webhook-secret).
+The response includes a one-time signing secret. **Copy it now**. You can't retrieve it later. Use it to verify the `X-0xinsider-Signature` header on every delivery; see [Verify Webhook](/api-reference/endpoint/verify-webhook). If it leaks, [rotate it](/api-reference/endpoint/rotate-webhook-secret).
 
-Use `Idempotency-Key` when retrying create after a timeout. Reusing the same key with the same body returns the original webhook; reusing it with a different body returns `422`.
+Send `Idempotency-Key` when retrying after a timeout. The same key with the same body returns the original webhook; the same key with a different body returns `422`.

--- a/api-reference/endpoint/delete-webhook.mdx
+++ b/api-reference/endpoint/delete-webhook.mdx
@@ -3,7 +3,7 @@ title: "Delete Webhook"
 openapi: "DELETE /api/v1/webhooks/{id}"
 ---
 
-Permanently remove a webhook registration. After deletion no further events are delivered to that URL and the signing secret is invalidated.
+Permanently remove a webhook. No further events are delivered to that URL, and the signing secret is invalidated.
 
 ```bash
 curl -X DELETE \
@@ -12,6 +12,6 @@ curl -X DELETE \
   "https://api.0xinsider.com/api/v1/webhooks/wh_abc123"
 ```
 
-To temporarily stop deliveries without losing the registration, [update](/api-reference/endpoint/update-webhook) the webhook to `enabled: false` instead.
+To pause deliveries without losing the webhook, [update](/api-reference/endpoint/update-webhook) it to `enabled: false` instead.
 
-Use `Idempotency-Key` when retrying a delete. A matching retry returns the original disabled webhook response instead of a second delete attempt.
+Send `Idempotency-Key` when retrying a delete. A matching retry returns the original response instead of deleting again.

--- a/api-reference/endpoint/explore-markets.mdx
+++ b/api-reference/endpoint/explore-markets.mdx
@@ -3,16 +3,16 @@ title: "Explore Markets"
 openapi: "GET /api/v1/markets/explore"
 ---
 
-Browse whale-active markets. Unlike `search`, this is the "show me what is going on" feed — already filtered to titled, user-facing markets with real activity.
+Browse whale-active markets. This is the "what's going on right now" feed, already filtered to titled, user-facing markets with real activity. Unlike `search`, you don't supply a query.
 
-Cluster behaviour: grouped events (e.g. "Next US president — by candidate") return one row per event with a primary market injected so you have something to link to.
+Grouped events (e.g. "Next US president by candidate") return one row per event with a primary market injected, so you always have something to link to.
 
 Common filters:
 
-- `category=crypto` — restrict to a category.
-- `platform=polymarket` or `platform=kalshi`.
-- `status=active` — exclude resolved markets.
-- `sort=volume` — sort by recent volume.
+- `category=crypto`: restrict to a category.
+- `platform=polymarket` or `platform=kalshi`: restrict to one platform.
+- `status=active`: exclude resolved markets.
+- `sort=volume`: sort by recent volume.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \

--- a/api-reference/endpoint/explore-markets.mdx
+++ b/api-reference/endpoint/explore-markets.mdx
@@ -3,12 +3,13 @@ title: "Explore Markets"
 openapi: "GET /api/v1/markets/explore"
 ---
 
-Browse whale-active markets. This is the "what's going on right now" feed, already filtered to titled, user-facing markets with real activity. Unlike `search`, you don't supply a query.
+Browse whale-active markets. This is the "what's going on right now" feed, already filtered to titled, user-facing markets with real activity. Omit `q` for the full feed, or pass it to narrow by keyword.
 
 Grouped events (e.g. "Next US president by candidate") return one row per event with a primary market injected, so you always have something to link to.
 
 Common filters:
 
+- `q=bitcoin`: keyword search against market titles.
 - `category=crypto`: restrict to a category.
 - `platform=polymarket` or `platform=kalshi`: restrict to one platform.
 - `status=active`: exclude resolved markets.

--- a/api-reference/endpoint/get-api-discovery.mdx
+++ b/api-reference/endpoint/get-api-discovery.mdx
@@ -3,12 +3,12 @@ title: "Get API Discovery"
 openapi: "GET /api/v1"
 ---
 
-Discover the public V1 API surface without an API key.
+Discover the public V1 API surface without a key.
 
-`GET /api/v1` returns the canonical API base URL, full docs URL, OpenAPI URL, unauthenticated health URL, and representative authenticated data routes.
+`GET /api/v1` returns the API base URL, docs URL, OpenAPI URL, unauthenticated health URL, and representative authenticated data routes.
 
 ```bash
 curl "https://api.0xinsider.com/api/v1"
 ```
 
-Use this endpoint as the first API-origin probe for agents, SDK setup flows, and uptime checks that need to find the docs and health endpoints before authenticating.
+Use it as the first probe for agents, SDK setup, and uptime checks that need the docs and health endpoints before authenticating.

--- a/api-reference/endpoint/get-daily-report-snapshot.mdx
+++ b/api-reference/endpoint/get-daily-report-snapshot.mdx
@@ -3,11 +3,11 @@ title: "Get Daily Report Snapshot"
 openapi: "GET /api/v1/reports/daily"
 ---
 
-The daily recap snapshot — top traders, biggest whale trades, smart-money rotations — pre-baked for the requested date. Use this to power morning-email digests, Slack briefs, or dashboard "what happened yesterday?" panels without recomputing each query.
+The daily recap for a given date: top traders, biggest whale trades, smart-money rotations, pre-baked. Power morning-email digests, Slack briefs, or "what happened yesterday?" panels without rerunning every query.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/reports/daily?date=2026-05-08"
 ```
 
-For longer windows, use [Weekly](/api-reference/endpoint/get-weekly-report-snapshot) or [Monthly](/api-reference/endpoint/get-monthly-report-snapshot). Snapshot payloads carry trust metadata so partial or unavailable sections are explicit.
+For longer windows, use [Weekly](/api-reference/endpoint/get-weekly-report-snapshot) or [Monthly](/api-reference/endpoint/get-monthly-report-snapshot). Snapshots carry trust metadata, so partial or unavailable sections are explicit.

--- a/api-reference/endpoint/get-event-replay-since.mdx
+++ b/api-reference/endpoint/get-event-replay-since.mdx
@@ -3,11 +3,11 @@ title: "Get Event Replay Since"
 openapi: "GET /api/v1/events/feed/since"
 ---
 
-Replay feed events your subscription missed during a disconnection. Pass the timestamp (or event ID) of the last event you successfully processed; the response is everything that came after.
+Replay feed events you missed during a disconnection. Pass the timestamp (or event ID) of the last event you processed, and the response is everything after it.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/events/feed/since?since=2026-05-08T12:34:56Z&limit=100"
 ```
 
-Cursor-paginated. Use this to catch your worker back up after a crash or deploy — no need to back-fill from the live feed. Pair with [Webhooks](/api-reference/endpoint/list-webhooks) when you would rather not poll at all.
+Cursor-paginated. Catch a worker back up after a crash or deploy without back-filling from the live feed. Pair with [Webhooks](/api-reference/endpoint/list-webhooks) if you'd rather not poll at all.

--- a/api-reference/endpoint/get-insider-radar.mdx
+++ b/api-reference/endpoint/get-insider-radar.mdx
@@ -3,9 +3,9 @@ title: "Get Insider Radar"
 openapi: "GET /api/v1/insider-radar"
 ---
 
-Flags wallets behaving like they know something the market does not — pre-resolution accumulation, unusually well-timed entries, or one-sided conviction with no offsetting hedges.
+Flags wallets that look like they know something the market doesn't: pre-resolution accumulation, well-timed entries, or one-sided conviction with no hedges.
 
-Each flag carries a `suspicion_score` and a reason. High scores are worth a closer look; they are not proof of wrongdoing.
+Each flag carries a `suspicion_score` and a reason. A high score is worth a closer look, not proof of wrongdoing.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \

--- a/api-reference/endpoint/get-leaderboard.mdx
+++ b/api-reference/endpoint/get-leaderboard.mdx
@@ -3,9 +3,9 @@ title: "Get Leaderboard"
 openapi: "GET /api/v1/leaderboard"
 ---
 
-Top-ranked traders by composite score. Only S, A, and B grades appear — see [Trader Grades](/concepts/grades).
+Top traders by composite score. Only S, A, and B grades appear; see [Trader Grades](/concepts/grades).
 
-Filter by category (e.g. `crypto`, `politics`, `sports`) or by strategy (`swing_trader`, etc.). Some traders rank but have no detected strategy; `strategy_type` is nullable.
+Filter by category (`crypto`, `politics`, `sports`) or strategy (`swing_trader`, and others). Some traders rank with no detected strategy, so `strategy_type` is nullable.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \

--- a/api-reference/endpoint/get-market-intel.mdx
+++ b/api-reference/endpoint/get-market-intel.mdx
@@ -3,9 +3,9 @@ title: "Get Market Intel"
 openapi: "GET /api/v1/market/{condition_id}/intel"
 ---
 
-Smart-money breakdown for a single market: buy vs sell volume from graded traders, top positions, and which side conviction is on.
+Smart-money breakdown for one market: buy vs sell volume from graded traders, top positions, and which side has conviction.
 
-Pass the on-chain `condition_id` in the path — **not** the prefixed `mkt_...` form. The API returns `400 bad_request` if you pass `mkt_...`. You can find raw condition IDs in whale trades and in `search` / `explore` responses.
+Pass the on-chain `condition_id` in the path, **not** the prefixed `mkt_...` form. A `mkt_...` value returns `400 bad_request`. Raw condition IDs appear in whale trades and in `search` and `explore` responses.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \

--- a/api-reference/endpoint/get-market-snapshot.mdx
+++ b/api-reference/endpoint/get-market-snapshot.mdx
@@ -3,7 +3,7 @@ title: "Get Market Snapshot"
 openapi: "GET /api/v1/market/{condition_id}/snapshot"
 ---
 
-One-shot view of a single market — price, volume, status, recent activity — with trust-metadata fields so you can tell which values are live provider-backed and which are cached, partial, or unavailable.
+One-shot view of a single market: price, volume, status, recent activity. Trust-metadata fields tell you which values are live and provider-backed and which are cached, partial, or unavailable.
 
 Pass the raw on-chain `condition_id` in the path.
 
@@ -12,4 +12,4 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/market/0xabc.../snapshot"
 ```
 
-If a field comes back marked `unavailable`, treat it as missing — do not flatten to `0`. See [Trust metadata](/api-reference/introduction#trust-metadata).
+If a field comes back `unavailable`, treat it as missing. Don't flatten it to `0`. See [Trust metadata](/api-reference/introduction#trust-metadata).

--- a/api-reference/endpoint/get-monthly-report-snapshot.mdx
+++ b/api-reference/endpoint/get-monthly-report-snapshot.mdx
@@ -3,7 +3,7 @@ title: "Get Monthly Report Snapshot"
 openapi: "GET /api/v1/reports/monthly"
 ---
 
-The monthly recap snapshot — rolling-30-day leaderboard, category-rotation summary, biggest realized P&L by trader and by market. Use this for end-of-month digests and longer-form newsletters.
+The monthly recap: rolling-30-day leaderboard, category-rotation summary, and biggest realized P&L by trader and by market. Use it for end-of-month digests and longer newsletters.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \

--- a/api-reference/endpoint/get-position-timeline-by-id.mdx
+++ b/api-reference/endpoint/get-position-timeline-by-id.mdx
@@ -4,4 +4,4 @@ sidebarTitle: "Position timeline by ID"
 openapi: "GET /api/v1/traders/{id}/position-timeline"
 ---
 
-Same data as [Get Position Timeline](/api-reference/endpoint/get-position-timeline), keyed on the prefixed trader ID (`trd_...`) instead of a raw wallet address. Use it when you're paging through other API responses and already hold the prefixed ID.
+Same data as [Get Position Timeline](/api-reference/endpoint/get-position-timeline), keyed on the integer internal `traders.id` instead of a wallet address. Use it when you're paging through other API responses and already hold that numeric ID.

--- a/api-reference/endpoint/get-position-timeline-by-id.mdx
+++ b/api-reference/endpoint/get-position-timeline-by-id.mdx
@@ -4,4 +4,4 @@ sidebarTitle: "Position timeline by ID"
 openapi: "GET /api/v1/traders/{id}/position-timeline"
 ---
 
-Same data as [Get Position Timeline](/api-reference/endpoint/get-position-timeline) but keyed on the internal prefixed trader ID (`trd_...`) instead of a raw wallet address. Use this when you are paging through entities returned by other API responses and you already have the prefixed ID.
+Same data as [Get Position Timeline](/api-reference/endpoint/get-position-timeline), keyed on the prefixed trader ID (`trd_...`) instead of a raw wallet address. Use it when you're paging through other API responses and already hold the prefixed ID.

--- a/api-reference/endpoint/get-position-timeline.mdx
+++ b/api-reference/endpoint/get-position-timeline.mdx
@@ -4,11 +4,11 @@ sidebarTitle: "Position timeline"
 openapi: "GET /api/v1/trader/{address}/position-timeline"
 ---
 
-Per-market fill history for one trader. Each fill carries a server-computed running amount and average entry price, so you can see how a trader built or unwound a position over time without recomputing it client-side.
+Per-market fill history for one trader. Each fill carries a server-computed running amount and average entry price, so you can see how a position was built or unwound without recomputing it client-side.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53/position-timeline?condition_id=0xabc..."
 ```
 
-If you have the internal position ID instead of the trader + market combo, use [Get Position Timeline by ID](/api-reference/endpoint/get-position-timeline-by-id).
+If you have the prefixed trader ID instead of the trader-plus-market combo, use [Get Position Timeline by ID](/api-reference/endpoint/get-position-timeline-by-id).

--- a/api-reference/endpoint/get-position-timeline.mdx
+++ b/api-reference/endpoint/get-position-timeline.mdx
@@ -11,4 +11,4 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53/position-timeline?condition_id=0xabc..."
 ```
 
-If you have the prefixed trader ID instead of the trader-plus-market combo, use [Get Position Timeline by ID](/api-reference/endpoint/get-position-timeline-by-id).
+If you have the integer internal trader ID instead of the wallet address, use [Get Position Timeline by ID](/api-reference/endpoint/get-position-timeline-by-id).

--- a/api-reference/endpoint/get-positions.mdx
+++ b/api-reference/endpoint/get-positions.mdx
@@ -4,11 +4,11 @@ sidebarTitle: "Positions"
 openapi: "GET /api/v1/positions"
 ---
 
-Current positions across traders or markets. Each row carries the trader, the market, the current position value, the side, and trust-metadata fields (source, freshness, completeness) so you can tell the difference between a live provider-backed value and a cached or partial one.
+Current positions across traders or markets. Each row carries the trader, market, current value, side, and trust-metadata fields (source, freshness, completeness) so you can tell a live provider-backed value from a cached or partial one.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/positions?trader=0x863134d00841b2e200492805a01e1e2f5defaa53&limit=50"
 ```
 
-For per-fill history (running amount and average entry price), use [Position Timeline](/api-reference/endpoint/get-position-timeline). When a position value is unavailable from the provider, do not flatten it to `0` — see [Trust metadata](/api-reference/introduction#trust-metadata).
+For per-fill history (running amount and average entry price), use [Position Timeline](/api-reference/endpoint/get-position-timeline). When a value is unavailable from the provider, don't flatten it to `0`. See [Trust metadata](/api-reference/introduction#trust-metadata).

--- a/api-reference/endpoint/get-trader-export-snapshot.mdx
+++ b/api-reference/endpoint/get-trader-export-snapshot.mdx
@@ -3,11 +3,11 @@ title: "Get Trader Export Snapshot"
 openapi: "GET /api/v1/trader/{address}/export"
 ---
 
-One-shot export of everything 0xinsider knows about a trader — profile, positions, recent trades, category breakdown — bundled for offline analysis or for stuffing into an LLM prompt.
+One-shot export of everything 0xinsider knows about a trader: profile, positions, recent trades, category breakdown. Built for offline analysis or feeding into an LLM prompt.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53/export"
 ```
 
-The export carries trust metadata per section so you can tell which fields are live provider-backed and which are cached or partial.
+Each section carries trust metadata, so you can tell which fields are live provider-backed and which are cached or partial.

--- a/api-reference/endpoint/get-trader.mdx
+++ b/api-reference/endpoint/get-trader.mdx
@@ -3,13 +3,13 @@ title: "Get Trader"
 openapi: "GET /api/v1/trader/{address}"
 ---
 
-Full profile for a single wallet — grade, realized P&L, win rate, strategy classification, category strengths, and current open positions.
+Full profile for a single wallet: grade, realized P&L, win rate, strategy classification, category strengths, and current open positions.
 
-The path accepts either a raw wallet address (strip the `trd_` prefix) or a known trader username. Heavy fields can be opted into with repeated `expand` query params (`expand=strategy&expand=categories`). The legacy `expand[]` form remains supported.
+The path takes a raw wallet address (strip the `trd_` prefix) or a known trader username. Opt into heavy fields with repeated `expand` query params (`expand=strategy&expand=categories`). The legacy `expand[]` form still works.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53?expand=strategy&expand=categories"
 ```
 
-Use this when you already have an address (from the leaderboard or a whale trade) and want the full story behind it. For multiple traders in one call, see [Batch Get Traders](/api-reference/endpoint/batch-get-traders).
+Use this when you have an address (from the leaderboard or a whale trade) and want the full story. For multiple traders in one call, see [Batch Get Traders](/api-reference/endpoint/batch-get-traders).

--- a/api-reference/endpoint/get-usage.mdx
+++ b/api-reference/endpoint/get-usage.mdx
@@ -3,15 +3,15 @@ title: "Get Usage"
 openapi: "GET /api/v1/usage"
 ---
 
-Read your current request budget without spending primary request quota.
+Read your current request budget without spending primary quota.
 
-`GET /api/v1/usage` returns the live per-minute primary limiter window plus UTC-day usage. It does not increment the primary request counter and does not log itself into daily usage. To protect the usage-count query, the endpoint has its own 100 reads/minute per-user guard; a 429 from this endpoint is a backoff signal, not evidence that primary quota was spent.
+Returns the live per-minute primary limiter window plus UTC-day usage. It does not increment the primary request counter and does not log itself into daily usage. The endpoint has its own 100 reads/minute per-user guard; a 429 here is a backoff signal, not proof you spent primary quota.
 
-The daily `limit` and `remaining` fields are `null` because V1 does not have a daily hard cap.
+The daily `limit` and `remaining` fields are `null` because V1 has no daily hard cap.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/usage"
 ```
 
-Use this endpoint for quota introspection instead of polling another data endpoint just to infer remaining budget.
+Check quota here instead of polling a data endpoint to guess your remaining budget.

--- a/api-reference/endpoint/get-webhook.mdx
+++ b/api-reference/endpoint/get-webhook.mdx
@@ -3,7 +3,7 @@ title: "Get Webhook"
 openapi: "GET /api/v1/webhooks/{id}"
 ---
 
-Inspect a single registered webhook — its URL, subscribed events, active flag, and recent delivery status. The signing secret is not returned (it is only shown once at create time).
+Inspect a single registered webhook: its URL, subscribed events, active flag, and recent delivery status. The signing secret is not returned; it is shown once at create time.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \

--- a/api-reference/endpoint/get-weekly-report-snapshot.mdx
+++ b/api-reference/endpoint/get-weekly-report-snapshot.mdx
@@ -3,7 +3,7 @@ title: "Get Weekly Report Snapshot"
 openapi: "GET /api/v1/reports/weekly"
 ---
 
-The weekly recap snapshot — top movers, sustained-flow markets, leaderboard shifts — pre-baked for the requested week. Same shape as the [daily report](/api-reference/endpoint/get-daily-report-snapshot), rolled up over seven days.
+The weekly recap snapshot: top movers, sustained-flow markets, leaderboard shifts, pre-baked for the requested week. Same shape as the [daily report](/api-reference/endpoint/get-daily-report-snapshot), rolled up over seven days.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \

--- a/api-reference/endpoint/get-whale-trades-history.mdx
+++ b/api-reference/endpoint/get-whale-trades-history.mdx
@@ -3,11 +3,11 @@ title: "Get Whale Trades History"
 openapi: "GET /api/v1/whale-trades/history"
 ---
 
-Bounded historical whale-trade ranges. Built for backtests, recap reports, and warming a cache after a deploy. The live "what is happening now?" feed is [Get Whale Trades](/api-reference/endpoint/get-whale-trades).
+Bounded historical whale-trade ranges. Built for backtests, recap reports, and warming a cache after a deploy. For the live feed, use [Get Whale Trades](/api-reference/endpoint/get-whale-trades).
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/whale-trades/history?from=2026-04-01T00:00:00Z&to=2026-04-30T23:59:59Z&min_grade=A&limit=100"
 ```
 
-History responses carry trust metadata so you can distinguish provider-backed vs reconciled vs partial trade ranges. See [Trust metadata](/api-reference/introduction#trust-metadata).
+Responses carry trust metadata, so you can tell provider-backed from reconciled or partial ranges. See [Trust metadata](/api-reference/introduction#trust-metadata).

--- a/api-reference/endpoint/get-whale-trades.mdx
+++ b/api-reference/endpoint/get-whale-trades.mdx
@@ -3,18 +3,18 @@ title: "Get Whale Trades"
 openapi: "GET /api/v1/whale-trades"
 ---
 
-Recent large trades, sorted newest first, with the trader's grade and a signal score attached to each.
+Recent large trades, newest first, each with the trader's grade and a signal score.
 
-The most useful filters:
+Useful filters:
 
-- `min_grade=A` — only show trades from S/A-grade traders (set to `B` to widen).
-- `category=crypto` — restrict to a market category.
-- `side=buy` — `buy` or `sell`.
-- `min_size_usd=10000` — floor on trade size.
+- `min_grade=A`: only trades from S/A-grade traders (set `B` to widen).
+- `category=crypto`: restrict to a market category.
+- `side=buy`: `buy` or `sell`.
+- `min_size_usd=10000`: floor on trade size.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&category=crypto&side=buy&limit=50"
 ```
 
-Cursor-paginated by timestamp. For a fixed time range (backtests, recap reports), use [Whale Trades History](/api-reference/endpoint/get-whale-trades-history).
+Cursor-paginated by timestamp. For a fixed time range, use [Whale Trades History](/api-reference/endpoint/get-whale-trades-history).

--- a/api-reference/endpoint/health.mdx
+++ b/api-reference/endpoint/health.mdx
@@ -3,7 +3,7 @@ title: "Health Check"
 openapi: "GET /api/v1/health"
 ---
 
-A liveness probe. Returns `200` with database and cache status when the API is up. No authentication required — handy as a smoke test from CI or a status dashboard.
+A liveness probe. Returns `200` with database and cache status when the API is up. No auth required, so it works as a smoke test from CI or a status dashboard.
 
 ```bash
 curl https://api.0xinsider.com/api/v1/health

--- a/api-reference/endpoint/list-webhooks.mdx
+++ b/api-reference/endpoint/list-webhooks.mdx
@@ -3,7 +3,7 @@ title: "List Webhooks"
 openapi: "GET /api/v1/webhooks"
 ---
 
-List every webhook endpoint registered on your account. Each entry includes the destination URL, the events it subscribes to, its delivery status, and metadata for signature verification.
+List every webhook registered on your account. Each entry has the destination URL, subscribed events, delivery status, and signature-verification metadata.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \

--- a/api-reference/endpoint/redirect-api-openapi-spec.mdx
+++ b/api-reference/endpoint/redirect-api-openapi-spec.mdx
@@ -5,7 +5,7 @@ openapi: "GET /api/v1/openapi.json"
 
 Resolve the canonical OpenAPI document from the API origin.
 
-`GET /api/v1/openapi.json` returns a temporary redirect to the web-origin spec at `https://0xinsider.com/api/v1/openapi.json`. The redirect avoids duplicating OpenAPI ownership while still letting API-origin probes discover the spec.
+Returns a temporary redirect to the web-origin spec at `https://0xinsider.com/api/v1/openapi.json`. One spec, one owner, still discoverable from the API origin.
 
 ```bash
 curl -I "https://api.0xinsider.com/api/v1/openapi.json"

--- a/api-reference/endpoint/remote-mcp-stream.mdx
+++ b/api-reference/endpoint/remote-mcp-stream.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Remote MCP stream"
 openapi: "GET /api/v1/mcp"
 ---
 
-Open the server-to-client streaming channel for [Remote MCP](/api-reference/endpoint/remote-mcp). Pass the `Mcp-Session-Id` returned by the `initialize` call to attach to your session, plus `Authorization: Bearer ...` if your client supports headers.
+Open the server-to-client streaming channel for [Remote MCP](/api-reference/endpoint/remote-mcp). Pass the `Mcp-Session-Id` from the `initialize` call to attach to your session, plus `Authorization: Bearer ...` if your client supports headers.
 
 ```bash
 curl -N \
@@ -13,4 +13,4 @@ curl -N \
   https://api.0xinsider.com/api/v1/mcp
 ```
 
-This is the stdio analog over HTTP. Hold the connection open to receive tool responses, progress events, and resource updates streamed from the server.
+This is the stdio analog over HTTP. Hold the connection open to receive streamed tool responses, progress events, and resource updates.

--- a/api-reference/endpoint/remote-mcp.mdx
+++ b/api-reference/endpoint/remote-mcp.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Remote MCP"
 openapi: "POST /api/v1/mcp"
 ---
 
-Hosted, streamable HTTP MCP endpoint. Use this when your agent runs in an environment that cannot spawn a local `npx` subprocess — for example, a serverless function, a browser-based agent, or a hosted automation runtime.
+Hosted, streamable HTTP MCP endpoint. Use it when your agent can't spawn a local `npx` subprocess: a serverless function, a browser-based agent, or a hosted automation runtime.
 
 Remote MCP exposes the 21 read-only V1 data operations below as tools. Each tool dispatches to the matching `/api/v1/*` handler in-process, so auth, rate limits, and payload contracts match direct REST calls. Meta endpoints (`/usage`, `/health`) and webhook mutations are not exposed as tools.
 
@@ -46,6 +46,6 @@ curl -X POST \
   https://api.0xinsider.com/api/v1/mcp
 ```
 
-A `?token=...` query parameter remains available for URL-only clients but is **legacy** — URL secrets leak into shell history, browser history, proxies, and logs. Use headers wherever possible.
+A `?token=...` query parameter is still available for URL-only clients but is **legacy**. URL secrets leak into shell history, browser history, proxies, and logs. Use headers wherever you can.
 
 For the streaming response, see [Remote MCP Stream](/api-reference/endpoint/remote-mcp-stream).

--- a/api-reference/endpoint/rotate-webhook-secret.mdx
+++ b/api-reference/endpoint/rotate-webhook-secret.mdx
@@ -3,7 +3,7 @@ title: "Rotate Webhook Secret"
 openapi: "POST /api/v1/webhooks/{id}/rotate-secret"
 ---
 
-Generate a fresh signing secret for a webhook. The response includes the new secret **once** — copy it immediately. The old secret stops working as soon as this call returns, so deploy the new secret to your verification code before rotating.
+Generate a fresh signing secret for a webhook. The response includes the new secret **once**, so copy it immediately. The old secret stops working the moment this call returns. Deploy the new secret to your verification code before you rotate.
 
 ```bash
 curl -X POST \
@@ -12,6 +12,6 @@ curl -X POST \
   "https://api.0xinsider.com/api/v1/webhooks/wh_abc123/rotate-secret"
 ```
 
-Rotate immediately if a secret has leaked (committed to git, exposed in a log, sent in a screenshot).
+Rotate right away if a secret leaks (committed to git, exposed in a log, sent in a screenshot).
 
-Use `Idempotency-Key` when retrying a rotate after a timeout. A matching retry returns the same one-time signing secret response instead of rotating again.
+Use `Idempotency-Key` when retrying a rotate after a timeout. A matching retry returns the same one-time secret response instead of rotating again.

--- a/api-reference/endpoint/search-markets.mdx
+++ b/api-reference/endpoint/search-markets.mdx
@@ -3,11 +3,11 @@ title: "Search Markets"
 openapi: "GET /api/v1/markets/search"
 ---
 
-Keyword search across Polymarket and Kalshi markets. Best when you already know what you are looking for and need the raw `condition_id` to pass into other endpoints.
+Keyword search across Polymarket and Kalshi markets. Best when you know what you want and need the raw `condition_id` for other endpoints.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/markets/search?q=trump&category=politics&status=active"
 ```
 
-Pass the returned `condition_id` (raw on-chain, not the `mkt_...` prefixed form) into [Market Intel](/api-reference/endpoint/get-market-intel) or [Market Snapshot](/api-reference/endpoint/get-market-snapshot). For browsing rather than searching, use [Explore Markets](/api-reference/endpoint/explore-markets).
+Pass the returned `condition_id` (raw on-chain, not the `mkt_...` form) into [Market Intel](/api-reference/endpoint/get-market-intel) or [Market Snapshot](/api-reference/endpoint/get-market-snapshot). To browse instead of search, use [Explore Markets](/api-reference/endpoint/explore-markets).

--- a/api-reference/endpoint/update-webhook.mdx
+++ b/api-reference/endpoint/update-webhook.mdx
@@ -3,7 +3,7 @@ title: "Update Webhook"
 openapi: "PATCH /api/v1/webhooks/{id}"
 ---
 
-Change a webhook's destination URL, subscribed events, or active flag without recreating it. Useful for promoting a staging URL to production, or for pausing delivery during maintenance without losing the registration.
+Change a webhook's destination URL, subscribed events, or active flag without recreating it. Promote a staging URL to production, or pause delivery during maintenance without losing the registration.
 
 ```bash
 curl -X PATCH \

--- a/api-reference/endpoint/verify-webhook.mdx
+++ b/api-reference/endpoint/verify-webhook.mdx
@@ -3,7 +3,7 @@ title: "Verify Webhook"
 openapi: "POST /api/v1/webhooks/{id}/verify"
 ---
 
-Send a signed test payload to your webhook URL so you can confirm signature verification on your side before relying on live deliveries.
+Send a signed test payload to your webhook URL to confirm signature verification on your side before live deliveries start.
 
 ```bash
 curl -X POST \

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -12,7 +12,7 @@ https://api.0xinsider.com/api/v1/
 
 ## Authentication
 
-Every endpoint except `/health` requires a Bearer token:
+Every endpoint except `/health` needs a Bearer token:
 
 ```bash
 Authorization: Bearer oxi_sk_live_...
@@ -47,8 +47,8 @@ List endpoints add pagination fields:
 | Field | Meaning |
 |---|---|
 | `object` | Shape of `data`. A singular type (`trader`, `market`, `health`, ...) or `list`. |
-| `data` | The actual payload — an object or an array. |
-| `meta.request_id` | Give us this when you write to support. |
+| `data` | The payload: an object or an array. |
+| `meta.request_id` | Give us this when you contact support. |
 | `meta.cached` | `true` when the response came from cache. |
 | `has_more` / `next_cursor` | Present on list responses. See [Pagination](/concepts/pagination). |
 
@@ -56,7 +56,7 @@ Errors share the same envelope, with `"object": "error"`. See [Errors](/errors).
 
 ## Prefixed IDs
 
-Every ID is prefixed with its type, so an ID is self-describing in logs and chat transcripts.
+Every ID is prefixed with its type, so it's self-describing in logs and chat transcripts.
 
 | Entity | Prefix | Example |
 |---|---|---|
@@ -66,7 +66,7 @@ Every ID is prefixed with its type, so an ID is self-describing in logs and chat
 | Radar flag | `rf_` | `rf_67890` |
 | Request | `req_` | `req_550e8400` |
 
-When an endpoint accepts an address in the path (`/trader/{address}`), pass the raw address — strip the `trd_` prefix. When an endpoint accepts a `condition_id` in the path (`/market/{condition_id}/intel`), pass the raw on-chain condition ID — not the prefixed `mkt_...` form.
+When an endpoint takes an address in the path (`/trader/{address}`), strip the `trd_` prefix and pass the raw address. When it takes a `condition_id` (`/market/{condition_id}/intel`), pass the raw on-chain condition ID, not the prefixed `mkt_...` form.
 
 ## Rate limits
 
@@ -87,13 +87,13 @@ See [Rate Limits](/rate-limits) for backoff patterns.
 
 ## Trust metadata
 
-Newer builder endpoints (snapshots, history ranges, batch reads, reports) attach metadata to provider-owned values so clients can distinguish provider-backed, cached, partial, stale, and unavailable data.
+Newer builder endpoints (snapshots, history ranges, batch reads, reports) attach metadata to provider-owned values so you can tell provider-backed, cached, partial, stale, and unavailable data apart.
 
-The shape per value is:
+Per value:
 
-- `source` — where the value came from (`provider`, `cache`, `computed`).
-- `freshness` — how stale the value is (e.g. an ISO timestamp or `live`).
-- `reconciliation` — whether the value has been cross-checked against the source of truth.
-- `completeness` — `full`, `partial`, or `unavailable`.
+- `source`: where the value came from (`provider`, `cache`, `computed`).
+- `freshness`: how stale it is (an ISO timestamp or `live`).
+- `reconciliation`: whether it's been cross-checked against the source of truth.
+- `completeness`: `full`, `partial`, or `unavailable`.
 
-Rule of thumb: **do not flatten unavailable values into `0`, `[]`, or `{}`.** Read the metadata, and surface "unavailable" to your consumer instead of inventing a zero. Provider data that quietly turns into `0` produces silent bugs downstream.
+Rule of thumb: **don't flatten unavailable values into `0`, `[]`, or `{}`.** Read the metadata and surface "unavailable" to your consumer instead of inventing a zero. Provider data that quietly becomes `0` causes silent bugs downstream.

--- a/authentication.mdx
+++ b/authentication.mdx
@@ -39,7 +39,7 @@ The key shows **once**, at generation. After that the dashboard shows only the p
     ```
     Authorization: Bearer oxi_sk_live_...
     ```
-    Either form returns `401 invalid_api_key`.
+    Without the `Bearer` prefix you get `401 invalid_api_key`.
   </Accordion>
   <Accordion title="Pasting only part of the key">
     The full key is 76 characters. Anything shorter is a partial copy.

--- a/authentication.mdx
+++ b/authentication.mdx
@@ -3,7 +3,7 @@ title: "Authentication"
 description: "API keys, headers, and what to do if a key leaks."
 ---
 
-Every request (except `/health`) authenticates with a Bearer token:
+Every request except `/health` uses a Bearer token:
 
 ```bash
 Authorization: Bearer oxi_sk_live_...
@@ -14,11 +14,11 @@ Authorization: Bearer oxi_sk_live_...
 | Property | Value |
 |---|---|
 | Format | `oxi_sk_live_` + 64 hex chars (76 chars total) |
-| Storage on our side | HMAC-SHA256 hash. Plaintext is never stored. |
+| Storage on our side | HMAC-SHA256 hash. We never store plaintext. |
 | Active keys per account | 1. Regenerating revokes the old key. |
 | Where to generate | [0xinsider.com/developers](https://0xinsider.com/developers) |
 
-The key is shown **once**, at generation time. After that the dashboard only shows the prefix (`oxi_sk_live_XXXX`) for identification.
+The key shows **once**, at generation. After that the dashboard shows only the prefix (`oxi_sk_live_XXXX`) so you can identify it.
 
 ## Generate a key
 
@@ -39,16 +39,16 @@ The key is shown **once**, at generation time. After that the dashboard only sho
     ```
     Authorization: Bearer oxi_sk_live_...
     ```
-    The API returns `401 invalid_api_key` for either malformed format.
+    Either form returns `401 invalid_api_key`.
   </Accordion>
   <Accordion title="Pasting only part of the key">
     The full key is 76 characters. Anything shorter is a partial copy.
   </Accordion>
   <Accordion title="Hitting an authenticated endpoint without a subscription">
-    Valid key, expired subscription returns `402 subscription_required`. Re-subscribe at [pricing](https://0xinsider.com/pricing); the same key resumes working.
+    A valid key with an expired subscription returns `402 subscription_required`. Re-subscribe at [pricing](https://0xinsider.com/pricing); the same key resumes.
   </Accordion>
   <Accordion title="Reusing an old key after regenerating">
-    Regenerating revokes the previous key in the same call. Update every place the old key lives — `.env` files, deployed secrets, MCP configs.
+    Regenerating revokes the old key in the same call. Update every place it lives: `.env` files, deployed secrets, MCP configs.
   </Accordion>
 </AccordionGroup>
 
@@ -57,12 +57,12 @@ The key is shown **once**, at generation time. After that the dashboard only sho
 Treat it like any production secret:
 
 1. Go to [Developers](https://0xinsider.com/developers).
-2. Click **Regenerate Key**. The old key stops working immediately.
-3. Roll the new key into every consumer (bots, MCP configs, CI secrets, dashboards).
+2. Click **Regenerate Key**. The old key dies immediately.
+3. Roll the new key into every consumer: bots, MCP configs, CI secrets, dashboards.
 
 ## Key management endpoints
 
-These manage *your own* keys from the dashboard. They authenticate with the session cookie (JWT), not with an API key, so you cannot call them from a script using `oxi_sk_live_...`.
+These manage *your own* keys from the dashboard. They use the session cookie (JWT), not an API key, so you can't call them from a script with `oxi_sk_live_...`.
 
 | Action | Method | Endpoint |
 |---|---|---|
@@ -71,7 +71,7 @@ These manage *your own* keys from the dashboard. They authenticate with the sess
 | Revoke key | `DELETE` | `/api/keys/{id}` |
 | Regenerate | `POST` | `/api/keys/regenerate` |
 
-## What a subscription-blocked response looks like
+## A subscription-blocked response
 
 ```json
 {

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,7 +5,7 @@ description: "Externally visible changes to the 0xinsider REST API."
 rss: true
 ---
 
-Externally visible REST API changes only. Docs-only edits are excluded.
+This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
 <Update label="June 1, 2026" description="Remote MCP reaches read parity with public V1 reads">
   [`POST /api/v1/mcp`](/api-reference/endpoint/remote-mcp) now exposes 21 read-only tools through `tools/list`, covering the public V1 read operations including batch reads, history, event replay, webhook reads, reports, market snapshots, and trader exports.
@@ -16,7 +16,7 @@ Externally visible REST API changes only. Docs-only edits are excluded.
 <Update label="June 1, 2026" description="API DX hardening adds usage, ETags, idempotent webhooks, and richer OpenAPI">
   Added [`GET /api/v1`](/api-reference/endpoint/get-api-discovery), a public API-origin discovery document, and [`GET /api/v1/openapi.json`](/api-reference/endpoint/redirect-api-openapi-spec), a redirect to the canonical web-origin OpenAPI spec.
 
-  Added [`GET /api/v1/usage`](/api-reference/endpoint/get-usage), an authenticated peek at your current per-minute limiter window and UTC-day usage. It doesn't spend primary quota, but has its own 100 reads/minute guard.
+  Added [`GET /api/v1/usage`](/api-reference/endpoint/get-usage), an authenticated budget peek for the current per-minute limiter window and UTC-day usage. It does not spend primary quota, but has its own 100 reads/minute guard.
 
   Deterministic reads now document `ETag` / `If-None-Match` conditional GETs, webhook create/update/delete/rotate support `Idempotency-Key`, and OpenAPI operation IDs are codegen-friendly camel-style identifiers with examples, code samples, and response-header metadata.
 </Update>
@@ -24,7 +24,7 @@ Externally visible REST API changes only. Docs-only edits are excluded.
 <Update label="May 8, 2026" description="Remote MCP exposes position and market discovery tools">
   [`POST /api/v1/mcp`](/api-reference/endpoint/remote-mcp) now exposes nine read-only tools through `tools/list`.
 
-  The new tools are `get_positions`, `get_position_timeline`, and `explore_markets`. Each calls the existing public REST handler, so MCP clients get the same auth, pagination, and payload contracts as direct REST callers.
+  The new tools are `get_positions`, `get_position_timeline`, and `explore_markets`. Each dispatches to the existing public REST handler, so MCP clients receive the same auth, pagination, and payload contracts as direct REST callers.
 </Update>
 
 <Update label="May 8, 2026" description="Builder API expansion adds batch, history, events, webhooks, reports, and market snapshots">
@@ -45,7 +45,7 @@ Externally visible REST API changes only. Docs-only edits are excluded.
 <Update label="May 8, 2026" description="TypeScript client source added">
   Added [TypeScript client guidance](/integrations/typescript-client) for the repo-owned client source in `web/src/lib/api-client`.
 
-  Drift-tested against OpenAPI. It handles bearer auth, path params, repeated query params, JSON bodies, and V1 error envelopes. Not a published npm package yet.
+  The client source is drift-tested against OpenAPI and handles bearer auth, path params, repeated query params, JSON bodies, and V1 error envelopes. It is not a published npm package yet.
 </Update>
 
 <Update label="May 7, 2026" description="Market Intel rejects prefixed market IDs">

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,7 +5,7 @@ description: "Externally visible changes to the 0xinsider REST API."
 rss: true
 ---
 
-This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
+Externally visible REST API changes only. Docs-only edits are excluded.
 
 <Update label="June 1, 2026" description="Remote MCP reaches read parity with public V1 reads">
   [`POST /api/v1/mcp`](/api-reference/endpoint/remote-mcp) now exposes 21 read-only tools through `tools/list`, covering the public V1 read operations including batch reads, history, event replay, webhook reads, reports, market snapshots, and trader exports.
@@ -16,7 +16,7 @@ This changelog tracks externally visible REST API changes only. Documentation-on
 <Update label="June 1, 2026" description="API DX hardening adds usage, ETags, idempotent webhooks, and richer OpenAPI">
   Added [`GET /api/v1`](/api-reference/endpoint/get-api-discovery), a public API-origin discovery document, and [`GET /api/v1/openapi.json`](/api-reference/endpoint/redirect-api-openapi-spec), a redirect to the canonical web-origin OpenAPI spec.
 
-  Added [`GET /api/v1/usage`](/api-reference/endpoint/get-usage), an authenticated budget peek for the current per-minute limiter window and UTC-day usage. It does not spend primary quota, but has its own 100 reads/minute guard.
+  Added [`GET /api/v1/usage`](/api-reference/endpoint/get-usage), an authenticated peek at your current per-minute limiter window and UTC-day usage. It doesn't spend primary quota, but has its own 100 reads/minute guard.
 
   Deterministic reads now document `ETag` / `If-None-Match` conditional GETs, webhook create/update/delete/rotate support `Idempotency-Key`, and OpenAPI operation IDs are codegen-friendly camel-style identifiers with examples, code samples, and response-header metadata.
 </Update>
@@ -24,7 +24,7 @@ This changelog tracks externally visible REST API changes only. Documentation-on
 <Update label="May 8, 2026" description="Remote MCP exposes position and market discovery tools">
   [`POST /api/v1/mcp`](/api-reference/endpoint/remote-mcp) now exposes nine read-only tools through `tools/list`.
 
-  The new tools are `get_positions`, `get_position_timeline`, and `explore_markets`. Each dispatches to the existing public REST handler, so MCP clients receive the same auth, pagination, and payload contracts as direct REST callers.
+  The new tools are `get_positions`, `get_position_timeline`, and `explore_markets`. Each calls the existing public REST handler, so MCP clients get the same auth, pagination, and payload contracts as direct REST callers.
 </Update>
 
 <Update label="May 8, 2026" description="Builder API expansion adds batch, history, events, webhooks, reports, and market snapshots">
@@ -45,7 +45,7 @@ This changelog tracks externally visible REST API changes only. Documentation-on
 <Update label="May 8, 2026" description="TypeScript client source added">
   Added [TypeScript client guidance](/integrations/typescript-client) for the repo-owned client source in `web/src/lib/api-client`.
 
-  The client source is drift-tested against OpenAPI and handles bearer auth, path params, repeated query params, JSON bodies, and V1 error envelopes. It is not a published npm package yet.
+  Drift-tested against OpenAPI. It handles bearer auth, path params, repeated query params, JSON bodies, and V1 error envelopes. Not a published npm package yet.
 </Update>
 
 <Update label="May 7, 2026" description="Market Intel rejects prefixed market IDs">

--- a/concepts/grades.mdx
+++ b/concepts/grades.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Trader Grades"
-description: "What S, A, B, C, D, F mean — with real profile examples."
+description: "What S, A, B, C, D, F mean, with real profile examples."
 ---
 
-Every trader 0xinsider tracks gets a single letter grade. The grade is the short, opinionated answer to "should I pay attention to this wallet?"
+Every trader gets one letter grade. It answers one question: should you pay attention to this wallet?
 
-You will see grades on the leaderboard, on every trader profile, and inside every whale trade object.
+Grades show up on the leaderboard, on every trader profile, and inside every whale trade object.
 
 ## The scale
 
@@ -18,19 +18,19 @@ You will see grades on the leaderboard, on every trader profile, and inside ever
 | **D** | Net losing across the sample. | No |
 | **F** | Persistently losing. Often coin-flip or chasing resolved markets. | No |
 
-The leaderboard only ranks S, A, and B — those are the wallets worth following.
+The leaderboard ranks only S, A, and B. Those are the wallets worth following.
 
 ## What goes into the grade
 
 The score is a composite (0-100) of five inputs:
 
-1. **Realized P&L** — actual profit from closed positions, not unrealized markings.
-2. **Win rate** — share of markets that resolved in their favor.
-3. **Volume** — total traded size. More volume = more signal per trade.
-4. **Market count** — how many distinct markets they have touched (diversification).
-5. **Recency** — penalizes wallets that have not traded in a long time.
+1. **Realized P&L**: actual profit from closed positions, not unrealized markings.
+2. **Win rate**: share of markets that resolved in their favor.
+3. **Volume**: total traded size. More volume means more signal per trade.
+4. **Market count**: distinct markets they have touched (diversification).
+5. **Recency**: penalizes wallets that have not traded in a long time.
 
-The letter is then assigned by score thresholds, with leaderboard eligibility capped at B or better.
+Score thresholds assign the letter. Only B or better makes the leaderboard.
 
 ## Two real profiles, side by side
 
@@ -53,7 +53,7 @@ The letter is then assigned by score thresholds, with leaderboard eligibility ca
 }
 ```
 
-Signals: very high realized P&L, perfect or near-perfect win rate, classifiable strategy, an identifiable category strength.
+Very high realized P&L, near-perfect win rate, a classifiable strategy, a clear category strength.
 
 ### C-grade: noisy and small
 
@@ -74,7 +74,7 @@ Signals: very high realized P&L, perfect or near-perfect win rate, classifiable 
 }
 ```
 
-Signals: P&L around breakeven, a coin-flip win rate, no detectable strategy. Visible in the API, but not in the leaderboard.
+P&L near breakeven, a coin-flip win rate, no detectable strategy. Visible in the API, but not on the leaderboard.
 
 ## Using grades in the API
 
@@ -98,7 +98,7 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/leaderboard?strategy=swing_trader"
 ```
 
-Some traders are good enough to make the leaderboard but lack a classifiable strategy. In that case `strategy_type` is `null` — treat it as nullable when filtering client-side.
+Some traders make the leaderboard but lack a classifiable strategy. Their `strategy_type` is `null`, so treat the field as nullable when filtering client-side.
 
 ### Combine grade + category
 
@@ -111,4 +111,4 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
 
 ## A note on null strategies
 
-A trader on the leaderboard without a strategy classification just means we have not detected a stable pattern. They are still a graded trader. Do not filter them out unless your use case actually requires a labeled strategy.
+A leaderboard trader without a strategy classification just means we haven't detected a stable pattern yet. They are still a graded trader. Don't filter them out unless you actually need a labeled strategy.

--- a/concepts/number-formatting.mdx
+++ b/concepts/number-formatting.mdx
@@ -3,7 +3,7 @@ title: "Number Formatting"
 description: "How numeric values are formatted in API responses."
 ---
 
-Numbers come back as plain JSON numbers (not strings). Floating-point values are **truncated** (not rounded) at the API edge so the displayed value never overstates the underlying value.
+Numbers come back as plain JSON numbers, not strings. Floating-point values are **truncated**, not rounded, at the API edge. The displayed value never overstates the real one.
 
 ## Precision
 
@@ -18,11 +18,11 @@ Numbers come back as plain JSON numbers (not strings). Floating-point values are
 
 `97.9488...` becomes `97.94`, not `97.95`. `-12.345` becomes `-12.34`. Always toward zero.
 
-If you need stricter precision for accounting, compute from the source data. The API edge value is the display-safe value.
+Need stricter precision for accounting? Compute from the source data. The edge value is display-safe, not accounting-grade.
 
 ## Integer fields
 
-These are exact integers — no decimals, no truncation:
+These are exact integers. No decimals, no truncation:
 
 - `markets_traded`
 - `rank`
@@ -30,6 +30,6 @@ These are exact integers — no decimals, no truncation:
 
 ## Nulls and `unavailable`
 
-Many fields are nullable (e.g. `strategy_type`, `best_category`). Treat them as nullable in your client even when a particular endpoint usually populates them.
+Many fields are nullable (e.g. `strategy_type`, `best_category`). Treat them as nullable even when an endpoint usually populates them.
 
-Newer builder endpoints additionally surface **trust metadata** — explicit `unavailable` or `partial` markers when a provider-owned value cannot be returned at request time. Do not convert these into `0`, `[]`, or `{}`. Read the metadata field and treat the value as missing.
+Newer builder endpoints also return **trust metadata**: explicit `unavailable` or `partial` markers when a provider-owned value can't be returned at request time. Don't convert these into `0`, `[]`, or `{}`. Read the metadata field and treat the value as missing.

--- a/concepts/pagination.mdx
+++ b/concepts/pagination.mdx
@@ -3,7 +3,7 @@ title: "Pagination"
 description: "Cursor-based pagination, with a full loop in JS and Python."
 ---
 
-Every list endpoint uses **cursor pagination**. There is no `offset` and no `page` number. Cursors are stable while a sort order keeps the same — much more reliable than offsets when data is live.
+Every list endpoint uses **cursor pagination**. No `offset`, no `page` number. Cursors stay stable as long as the sort order holds, so they beat offsets on live data.
 
 ## The shape
 
@@ -37,7 +37,7 @@ Repeat until `has_more` is `false`.
 
 ## Full loop, end to end
 
-This pulls every page of the leaderboard until exhausted.
+This pulls every page of the leaderboard.
 
 <CodeGroup>
 ```javascript JavaScript
@@ -92,19 +92,19 @@ print(f"Fetched {len(leaders)} traders")
 
 ## Cursors are opaque
 
-Do not parse, construct, or store cursors long-term. Always use the `next_cursor` from the response you just received.
+Don't parse, construct, or store cursors long-term. Always use the `next_cursor` from the response you just got.
 
-Internally, different endpoints use different cursor encodings:
+Different endpoints encode cursors differently:
 
 - **Leaderboard**: `{score}_{address}`
 - **Whale trades**: `{timestamp}_{id}` (ISO 8601)
 - **Insider radar**: `{score}_{id}`
 
-You do not need to know this to use the API — just pass the string back.
+You don't need to know this. Just pass the string back.
 
 ## Gotchas
 
-- **Don't mix cursors across filters.** A cursor from `?category=crypto` is not valid on `?category=politics`. Restart pagination when filters change.
-- **Don't mix cursors across endpoints.** A leaderboard cursor will not work on whale trades.
-- **`400 Invalid cursor format` means the cursor came from a different filter set, a different endpoint, or has been mangled.** Drop the cursor and start over.
-- **Stale cursors expire.** If you pause for hours, the underlying sort can shift; expect to restart.
+- **Don't mix cursors across filters.** A cursor from `?category=crypto` won't work on `?category=politics`. Restart pagination when filters change.
+- **Don't mix cursors across endpoints.** A leaderboard cursor won't work on whale trades.
+- **`400 Invalid cursor format`** means the cursor came from a different filter set, a different endpoint, or got mangled. Drop it and start over.
+- **Stale cursors expire.** Pause for hours and the underlying sort can shift. Expect to restart.

--- a/errors.mdx
+++ b/errors.mdx
@@ -3,7 +3,7 @@ title: "Errors"
 description: "How errors come back, what each code means, and how to recover."
 ---
 
-Errors are returned with a non-2xx HTTP status and a consistent JSON envelope:
+Errors come back with a non-2xx HTTP status and the same JSON envelope every time:
 
 ```json
 {
@@ -20,7 +20,7 @@ Errors are returned with a non-2xx HTTP status and a consistent JSON envelope:
 }
 ```
 
-The two fields to read in production: `error.code` (machine-readable) and `meta.request_id` (the ID you give us when you write to support).
+Two fields matter in production: `error.code` (machine-readable) and `meta.request_id` (the ID you give us when you contact support).
 
 ## Error codes
 
@@ -87,26 +87,26 @@ def call(path, **params):
 
 ## Per-item batch errors
 
-Batch endpoints (e.g. `POST /api/v1/traders/batch`) return `200 OK` even when individual items fail. Each item carries its own `error` field — read `data[i].error` per item, not just the top-level status.
+Batch endpoints (e.g. `POST /api/v1/traders/batch`) return `200 OK` even when individual items fail. Each item carries its own `error` field. Read `data[i].error` per item, not just the top-level status.
 
 ## Quick troubleshooting
 
 <AccordionGroup>
   <Accordion title="401 invalid_api_key">
-    - Header literally needs `Authorization: Bearer oxi_sk_live_...`.
-    - Key is 76 characters end to end — confirm you copied the full string.
-    - If you regenerated, the previous key is dead. Update every consumer.
+    - The header needs `Authorization: Bearer oxi_sk_live_...`.
+    - The key is 76 characters. Confirm you copied the full string.
+    - If you regenerated, the old key is dead. Update every consumer.
   </Accordion>
   <Accordion title="402 subscription_required">
-    Key is fine; billing is not. Re-subscribe at [pricing](https://0xinsider.com/pricing) and the same key resumes.
+    The key is fine; billing is not. Re-subscribe at [pricing](https://0xinsider.com/pricing) and the same key resumes.
   </Accordion>
   <Accordion title="429 rate_limited">
     Sleep `Retry-After` seconds, then retry. See the backoff example in [Rate Limits](/rate-limits).
   </Accordion>
   <Accordion title="400 bad_request on Market Intel with mkt_... prefix">
-    Market Intel takes the raw `condition_id`, not the prefixed `mkt_...` ID. Look up the market via [`/markets/search`](/api-reference/endpoint/search-markets) and use the returned `condition_id`.
+    Market Intel takes the raw `condition_id`, not the prefixed `mkt_...` ID. Look up the market via [`/markets/search`](/api-reference/endpoint/search-markets) and pass the returned `condition_id`.
   </Accordion>
   <Accordion title="500 internal_error">
-    Retry once. If it keeps happening, email [support@0xinsider.com](mailto:support@0xinsider.com) with the `meta.request_id` from the response.
+    Retry once. If it persists, email [support@0xinsider.com](mailto:support@0xinsider.com) with the `meta.request_id` from the response.
   </Accordion>
 </AccordionGroup>

--- a/index.mdx
+++ b/index.mdx
@@ -14,6 +14,10 @@ Three ways in:
 
 One [Insider subscription](https://0xinsider.com/pricing) covers all three.
 
+<Tip>
+  Working in Claude Code, Cursor, or another AI agent? Feed it [llms-full.txt](https://docs.0xinsider.com/llms-full.txt), the whole docs site as one plain-text file. Drop it into context and ask the model to wire up calls, draft a bot, or surface ideas you can build on the data.
+</Tip>
+
 ## What it solves
 
 Polymarket and Kalshi publish raw trades. They don't publish grades, signal scores, smart-money breakdowns, position timelines, or pattern detection. 0xinsider builds that layer. The API exposes it.

--- a/index.mdx
+++ b/index.mdx
@@ -4,39 +4,39 @@ sidebarTitle: "Introduction"
 description: "Prediction market intelligence for AI agents, trading bots, and research tools."
 ---
 
-The 0xinsider API gives your code access to the same intelligence layer powering the [0xinsider terminal](https://0xinsider.com) — trader grades, whale trade signals, smart-money flow, positions, and insider detection across Polymarket and Kalshi.
+Trader grades, whale-trade signals, smart-money flow, positions, and insider detection for Polymarket and Kalshi. The same data behind the [0xinsider terminal](https://0xinsider.com), as an API.
 
-Same data, three ways in:
+Three ways in:
 
-- **REST API** — `https://api.0xinsider.com/api/v1/` for bots, dashboards, and research code.
-- **Local MCP server** — [`@0xinsider/mcp`](https://www.npmjs.com/package/@0xinsider/mcp) on stdio for Claude Code, Cursor, Codex, Gemini CLI.
-- **Remote MCP** — streamable HTTP MCP for agents that cannot run a local subprocess.
+- **REST API**: `https://api.0xinsider.com/api/v1/` for bots, dashboards, and research code.
+- **Local MCP server**: [`@0xinsider/mcp`](https://www.npmjs.com/package/@0xinsider/mcp) on stdio for Claude Code, Cursor, Codex, Gemini CLI.
+- **Remote MCP**: streamable HTTP for agents that can't run a local subprocess.
 
 One [Insider subscription](https://0xinsider.com/pricing) covers all three.
 
-## What problem this solves
+## What it solves
 
-You want to answer questions like:
+Polymarket and Kalshi publish raw trades. They don't publish grades, signal scores, smart-money breakdowns, position timelines, or pattern detection. 0xinsider builds that layer. The API exposes it.
 
-- "Which traders consistently beat the market on crypto resolution events?"
-- "Did anyone buy big into this market in the last hour, and are they sharp money?"
-- "Has someone been accumulating shares in a market that hasn't resolved yet — is this insider behavior?"
-- "Where is smart money flowing this week?"
-- "When that S-grade trader took their position, what price did they get filled at?"
+So you can answer:
 
-Polymarket and Kalshi publish raw trades. They do not publish grades, signal scores, smart-money breakdowns, position timelines, or pattern detection. That layer is what 0xinsider builds. The API exposes it.
+- Which traders consistently beat the market on crypto resolution events?
+- Did anyone buy big into this market in the last hour, and are they sharp?
+- Is someone accumulating shares in a market that hasn't resolved yet?
+- Where is smart money flowing this week?
+- What price did that S-grade trader get filled at?
 
 ## What you can build
 
-- **Trading bots** that fire on whale buys from S-grade traders in a chosen category.
-- **AI agents** that summarize who is winning, what they hold, and at what cost basis.
-- **Research tools** that pull leaderboards, batch trader profiles, history ranges, and category performance.
-- **Dashboards** that visualize where capital is rotating across prediction markets.
+- **Trading bots** that fire on whale buys from S-grade traders in a category.
+- **AI agents** that summarize who's winning, what they hold, and at what cost.
+- **Research tools** that pull leaderboards, trader profiles, history ranges, and category performance.
+- **Dashboards** that show where capital is rotating across prediction markets.
 - **Webhooks** that push whale-trade and radar events to your stack in real time.
 
 ## A real response
 
-Top 1 trader by composite score, right now:
+The top trader by composite score, right now:
 
 ```bash
 curl -H "Authorization: Bearer oxi_sk_live_..." \
@@ -63,13 +63,13 @@ curl -H "Authorization: Bearer oxi_sk_live_..." \
 }
 ```
 
-That is one trader. The leaderboard ranks thousands.
+One trader. The leaderboard ranks thousands.
 
 ## Endpoints
 
 <CardGroup cols={2}>
   <Card title="Get Trader" icon="user" href="/api-reference/endpoint/get-trader">
-    Full profile for a wallet — grade, P&L, win rate, strategy, category strengths.
+    Full profile for a wallet: grade, P&L, win rate, strategy, category strengths.
   </Card>
   <Card title="Batch Get Traders" icon="layer-group" href="/api-reference/endpoint/batch-get-traders">
     Up to 25 trader profiles in one round trip.
@@ -102,7 +102,7 @@ That is one trader. The leaderboard ranks thousands.
     Keyword search across markets with filters.
   </Card>
   <Card title="Insider Radar" icon="radar" href="/api-reference/endpoint/get-insider-radar">
-    Suspicious patterns — pre-resolution accumulation, unusual timing.
+    Suspicious patterns: pre-resolution accumulation, unusual timing.
   </Card>
   <Card title="Event Replay" icon="rotate-right" href="/api-reference/endpoint/get-event-replay-since">
     Replay missed feed events after a disconnection.
@@ -122,7 +122,7 @@ That is one trader. The leaderboard ranks thousands.
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/quickstart">
-    Generate a key, fire your first request, and walk through a real "follow the whales" workflow.
+    Generate a key, fire your first request, and follow the whales end to end.
   </Card>
   <Card title="Local MCP Server" icon="terminal" href="/integrations/mcp">
     Plug 0xinsider into Claude Code, Cursor, Codex, or Gemini CLI in two minutes.
@@ -131,6 +131,6 @@ That is one trader. The leaderboard ranks thousands.
     Drift-tested source client with typed errors and repeated `expand` params.
   </Card>
   <Card title="Trader Grades" icon="medal" href="/concepts/grades">
-    What S, A, B, C, D, F actually mean — with real profile examples.
+    What S, A, B, C, D, F actually mean, with real profile examples.
   </Card>
 </CardGroup>

--- a/integrations/mcp.mdx
+++ b/integrations/mcp.mdx
@@ -3,23 +3,23 @@ title: "Local MCP Server"
 description: "Give your AI agent direct, read-only access to 0xinsider intelligence over stdio."
 ---
 
-[`@0xinsider/mcp`](https://www.npmjs.com/package/@0xinsider/mcp) is the official local Model Context Protocol server. It exposes the same intelligence as the REST API — trader grades, whale trades, smart-money flow, positions, insider detection — as MCP tools your agent can call directly.
+[`@0xinsider/mcp`](https://www.npmjs.com/package/@0xinsider/mcp) is the official local Model Context Protocol server. It exposes the same data as the REST API (trader grades, whale trades, smart-money flow, positions, insider detection) as MCP tools your agent calls directly.
 
-Works with **Claude Code, Cursor, Codex, Gemini CLI**, and any client that speaks stdio MCP.
+Works with **Claude Code, Cursor, Codex, Gemini CLI**, and any stdio MCP client.
 
 <Note>
   Need a hosted HTTP endpoint instead of a local subprocess? See [Remote MCP](/api-reference/endpoint/remote-mcp).
 </Note>
 
-## Install — one command
+## Install in one command
 
 ```bash
 npx -y @0xinsider/mcp init
 ```
 
-`init` auto-detects which clients you have installed and writes the right config block in the right place. You will be asked for your API key once.
+`init` detects your installed clients and writes the right config in the right place. It asks for your API key once.
 
-If you prefer to edit configs by hand, the per-client paths and snippets are below.
+Prefer to edit configs by hand? The per-client paths and snippets are below.
 
 ## Manual install per client
 
@@ -104,7 +104,7 @@ If you prefer to edit configs by hand, the per-client paths and snippets are bel
 
 | Tool | What it does |
 |---|---|
-| `get_trader` | Wallet profile — grade, P&L, win rate, strategy, category strengths. |
+| `get_trader` | Wallet profile: grade, P&L, win rate, strategy, category strengths. |
 | `get_whale_trades` | Recent large trades, filterable by size, category, grade. |
 | `get_leaderboard` | Top-ranked traders (S/A/B) with optional category/strategy filter. |
 | `get_positions` | Current positions across traders or markets. |
@@ -114,14 +114,14 @@ If you prefer to edit configs by hand, the per-client paths and snippets are bel
 | `get_market_intel` | Smart-money breakdown for a single market. |
 | `get_insider_radar` | Suspicious accumulation and timing patterns. |
 
-All tools advertise `readOnlyHint: true`. The server cannot place trades or write data.
+Every tool advertises `readOnlyHint: true`. The server can't place trades or write data.
 
 ### Resources (auto-attached context)
 
 | URI | What you get |
 |---|---|
 | `oxinsider://docs/api` | Full API reference, ready for the model to read. |
-| `oxinsider://docs/agents` | Decision tree for agents — when to use which tool. |
+| `oxinsider://docs/agents` | Decision tree for agents: when to use which tool. |
 | `oxinsider://data/leaderboard` | Live top 20 traders. |
 | `oxinsider://data/whale-trades` | Live latest 20 whale trades. |
 
@@ -135,15 +135,15 @@ All tools advertise `readOnlyHint: true`. The server cannot place trades or writ
 
 ## Try it
 
-After install, ask your agent things like:
+After install, ask your agent:
 
 - "Who are the top prediction-market traders right now?"
 - "What are A-grade or better whales buying in crypto markets today?"
-- "Analyze trader `0x863134d00841b2e200492805a01e1e2f5defaa53` — is their strategy worth following?"
+- "Analyze trader `0x863134d00841b2e200492805a01e1e2f5defaa53`. Is their strategy worth following?"
 - "Are there suspicious accumulation patterns on the Trump election market?"
 - "Show me the position timeline for that whale on the Ethereum market."
 
-The agent will pick the right tool and call it for you.
+The agent picks the right tool and calls it for you.
 
 ## Environment variables
 
@@ -153,5 +153,5 @@ The agent will pick the right tool and call it for you.
 | `OXINSIDER_API_URL` | No | Override the base URL (mostly for self-hosted dev). |
 
 <Note>
-  The MCP server uses your normal API key and shares the 100 req/min rate limit with direct API access. One key, one budget. Get yours at [0xinsider.com/developers](https://0xinsider.com/developers).
+  The MCP server uses your normal API key and shares the 100 req/min rate limit with direct API calls. One key, one budget. Get yours at [0xinsider.com/developers](https://0xinsider.com/developers).
 </Note>

--- a/integrations/typescript-client.mdx
+++ b/integrations/typescript-client.mdx
@@ -3,19 +3,19 @@ title: "TypeScript Client"
 description: "Drift-tested source client for the 0xinsider API."
 ---
 
-A typed TypeScript client lives in the app repo at `web/src/lib/api-client`. It is drift-tested against the checked-in OpenAPI spec — when the spec moves, the client either moves with it or its test suite fails.
+A typed TypeScript client lives in the app repo at `web/src/lib/api-client`. It's drift-tested against the checked-in OpenAPI spec: when the spec moves, the client moves with it or the test suite fails.
 
-It is **not** published to npm yet. Use it as source or as a reference implementation.
+It's **not** on npm yet. Use it as source or as a reference implementation.
 
 <Note>
-  Want a package release? That needs a separate decision on package name, semver policy, changelog ownership, and npm access. Open an issue if you depend on it.
+  Want a package release? That needs decisions on package name, semver policy, changelog ownership, and npm access. Open an issue if you depend on it.
 </Note>
 
 ## What it handles
 
 - `Authorization: Bearer` header injection.
 - Path parameter interpolation (`/trader/{address}`, `/market/{condition_id}/intel`).
-- Repeated query parameters such as `expand=strategy&expand=categories`. The legacy `expand[]` form is also accepted by the API.
+- Repeated query parameters like `expand=strategy&expand=categories`. The API also accepts the legacy `expand[]` form.
 - JSON request bodies for batch and webhook endpoints.
 - V1 error envelopes as typed exceptions (`code`, `message`, `param`, `request_id`).
 
@@ -41,7 +41,7 @@ const markets = await client.searchMarkets("NBA", {
 
 ## Handling errors
 
-The client raises typed exceptions instead of returning a generic error object, so you can match on `error.code` directly:
+The client throws typed exceptions instead of a generic error object, so you match on `error.code` directly:
 
 ```ts
 import { OxinsiderApiError } from "./api-client";
@@ -65,4 +65,4 @@ try {
 
 ## Keep OpenAPI as the source of truth
 
-The client operation table is regenerated from [`api-reference/openapi.json`](https://github.com/0xinsider/docs/blob/main/api-reference/openapi.json). When you change the OpenAPI spec, the client moves with it. Do not edit the client by hand to add new operations without updating the spec.
+The client operation table regenerates from [`api-reference/openapi.json`](https://github.com/0xinsider/docs/blob/main/api-reference/openapi.json). Change the spec and the client follows. Don't hand-edit the client to add operations without updating the spec.

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -3,11 +3,7 @@ title: "Quickstart"
 description: "From zero to your first whale-trade signal in two minutes."
 ---
 
-In this quickstart you will:
-
-1. Generate an API key.
-2. Confirm it works.
-3. Pull a real "follow the smartest traders" workflow end to end.
+Generate a key, confirm it works, then run a real "follow the smartest traders" workflow.
 
 ## 1. Generate your API key
 
@@ -21,7 +17,7 @@ API access is bundled with the [Insider subscription](https://0xinsider.com/pric
     Pick the Insider plan on [Pricing](https://0xinsider.com/pricing).
   </Step>
   <Step title="Generate your key">
-    On [Developers](https://0xinsider.com/developers), click **Generate Key**. The key is shown once — copy it now. Lost keys can be regenerated, but the old key stops working.
+    On [Developers](https://0xinsider.com/developers), click **Generate Key**. It's shown once, so copy it now. You can regenerate a lost key, but the old one stops working.
   </Step>
 </Steps>
 
@@ -49,11 +45,11 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
 }
 ```
 
-If you see `status: "ok"`, you are wired up.
+`status: "ok"` means you're wired up.
 
 ## 3. Follow the smartest traders
 
-The interesting question is rarely "who is #1." It is "what are the best traders doing right now, and am I early?"
+Not "who's #1," but "what are the best traders doing right now, and am I early?"
 
 ### Step A: Pull the top 5 S-grade traders
 
@@ -62,47 +58,47 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/leaderboard?limit=5"
 ```
 
-Each entry includes the trader's wallet address (`id`), grade, score, P&L, and strategy. Pick one to follow.
+Each entry has the wallet address (`id`), grade, score, P&L, and strategy. Pick one to follow.
 
 ### Step B: Look up that trader's full profile
 
-The trader endpoint accepts either a wallet address or a known username:
+The trader endpoint takes a wallet address or a known username:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53"
 ```
 
-The response gives you their realized P&L, win rate, category strengths, and current open positions.
+You get their realized P&L, win rate, category strengths, and current open positions.
 
-### Step C: See what whales are buying right now
+### Step C: See what whales are buying now
 
-Filter to A-grade or better, last 50 trades:
+A-grade or better, last 50 trades:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&limit=50"
 ```
 
-You can layer filters. For example, A-grade or better, crypto markets only, BUY side:
+Layer filters. A-grade or better, crypto only, buy side:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&category=crypto&side=buy&limit=50"
 ```
 
-### Step D: Drill into one of those markets
+### Step D: Drill into one market
 
-Grab the `condition_id` from a whale trade you find interesting (raw hex — not the prefixed `mkt_...` form), then:
+Grab the `condition_id` from a trade you like (raw hex, not the prefixed `mkt_...` form), then:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/market/<condition_id>/intel"
 ```
 
-Market Intel returns the smart-money breakdown: buy volume vs sell volume from graded traders, top positions, and which side conviction is on.
+Market Intel returns the smart-money breakdown: buy volume vs sell volume from graded traders, top positions, and which side has conviction.
 
-That is the loop: **leaderboard -> trader profile -> whale trades -> market intel**. Bolt it onto a cron, a chatbot, or a dashboard.
+The loop: **leaderboard -> trader profile -> whale trades -> market intel**. Wire it to a cron, a chatbot, or a dashboard.
 
 ## Same workflow, in code
 
@@ -152,9 +148,9 @@ print(top["data"][0], trader["data"]["grade"], len(whales["data"]))
 ```
 </CodeGroup>
 
-## Want the call count even lower? Use a batch endpoint
+## Lower the call count with a batch endpoint
 
-If you already have the wallet addresses or usernames you care about, fetch them all in one call:
+Already have the wallet addresses or usernames you care about? Fetch them in one call:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -163,13 +159,13 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/traders/batch"
 ```
 
-Batch reads return the same per-item shape, with per-item error fields when one address fails. They count against a separate batch-item rate-limit budget — see [Rate Limits](/rate-limits).
+Batch reads return the same per-item shape, with per-item error fields when an address fails. They count against a separate batch-item rate-limit budget. See [Rate Limits](/rate-limits).
 
 ## Next
 
 <CardGroup cols={2}>
   <Card title="Local MCP Server" icon="terminal" href="/integrations/mcp">
-    Skip the HTTP plumbing — give your AI agent the same tools directly.
+    Skip the HTTP plumbing. Give your AI agent the same tools directly.
   </Card>
   <Card title="TypeScript Client" icon="code" href="/integrations/typescript-client">
     Use the repo-owned source client with typed errors and `expand` helpers.

--- a/rate-limits.mdx
+++ b/rate-limits.mdx
@@ -3,11 +3,11 @@ title: "Rate Limits"
 description: "How many requests you can make, and how to back off cleanly."
 ---
 
-The API allows **100 requests per minute** on a sliding window. The limit is **per user**, shared across every key and every endpoint.
+You get **100 requests per minute** on a sliding window. The limit is **per user**, shared across every key and every endpoint.
 
-Batch read endpoints (e.g. `POST /api/v1/traders/batch`, `POST /api/v1/markets/intel/batch`) have a **separate** budget measured in *item units*, also 100 per minute. A 25-item batch reserves 25 item units before it executes.
+Batch read endpoints (e.g. `POST /api/v1/traders/batch`, `POST /api/v1/markets/intel/batch`) get a **separate** budget in *item units*, also 100 per minute. A 25-item batch reserves 25 item units before it runs.
 
-`GET /api/v1/usage` does not spend primary request quota or log itself into daily usage. It has a separate 100 reads/minute per-user guard so quota introspection cannot create unbounded usage-count load.
+`GET /api/v1/usage` does not spend primary quota or log into daily usage. It has its own 100 reads/minute per-user guard so checking quota can't itself blow up usage-count load.
 
 | Setting | Value |
 |---|---|
@@ -46,7 +46,7 @@ Batch responses additionally carry:
 | `X-Batch-RateLimit-Remaining` | Item units remaining in the window. |
 | `X-Batch-RateLimit-Reset` | Unix timestamp when the batch window resets. |
 
-If you go over either budget, you get a `429` plus a `Retry-After` header in seconds:
+Go over either budget and you get a `429` plus a `Retry-After` header in seconds:
 
 ```
 HTTP/1.1 429 Too Many Requests
@@ -64,7 +64,7 @@ Retry-After: 12
 }
 ```
 
-## A real "respect the retry" client
+## A client that respects the retry
 
 <CodeGroup>
 ```javascript JavaScript
@@ -107,16 +107,16 @@ body = get_with_backoff(
 
 ## Staying well under the limit
 
-- **Cache.** Most of this data updates every 30-120 seconds. Re-fetching every second is wasted budget.
-- **Paginate, do not re-list.** Use cursors instead of refetching the full leaderboard each loop.
-- **Ask for more per request.** Bump `limit` up to 100 instead of making 10 calls of `limit=10`.
-- **Use batch endpoints when you already know your IDs.** One batch call for 25 traders costs 25 batch-item units, but only one regular request.
-- **Watch `X-RateLimit-Remaining`.** If it crosses below 10, pause your polling for the next reset.
-- **Use `/usage` for budget checks.** `GET /api/v1/usage` reads the current primary limiter window without incrementing it. Respect its own 100 reads/minute cap instead of using another endpoint as a quota probe.
-- **One process owns the polling.** Avoid every container in a fleet polling the same endpoint with the same key.
+- **Cache.** Most of this data updates every 30-120 seconds. Re-fetching every second wastes budget.
+- **Paginate, don't re-list.** Use cursors instead of refetching the full leaderboard each loop.
+- **Ask for more per request.** Bump `limit` to 100 instead of making 10 calls of `limit=10`.
+- **Batch when you know your IDs.** One batch call for 25 traders costs 25 batch-item units but only one regular request.
+- **Watch `X-RateLimit-Remaining`.** Below 10, pause polling until the next reset.
+- **Use `/usage` for budget checks.** `GET /api/v1/usage` reads the current primary limiter window without incrementing it. Respect its own 100 reads/minute cap; don't probe quota with another endpoint.
+- **One process owns the polling.** Don't have every container in a fleet poll the same endpoint with the same key.
 
 ## Conditional GETs
 
-Deterministic read endpoints return an `ETag` header. Re-send it as `If-None-Match` to receive `304 Not Modified` with an empty body when the payload is unchanged.
+Deterministic read endpoints return an `ETag` header. Send it back as `If-None-Match` to get `304 Not Modified` with an empty body when nothing changed.
 
-This applies to trader, positions, whale-trades, whale-trades/history, leaderboard, markets/explore, market intel, market snapshot, insider-radar, position-timeline, and health responses. Report snapshot endpoints are not conditional yet because their body includes request-time `generated_at`.
+This covers trader, positions, whale-trades, whale-trades/history, leaderboard, markets/explore, market intel, market snapshot, insider-radar, position-timeline, and health responses. Report snapshots aren't conditional yet because their body includes a request-time `generated_at`.


### PR DESCRIPTION
Fixes #24

## What

Copywriting sweep across all 43 content pages: `index`, `quickstart`, `authentication`, `errors`, `rate-limits`, `changelog`, `api-reference/introduction`, `concepts/` (3), `integrations/` (2), and 32 endpoint reference pages.

Voice = a smart practitioner messaging a peer:
- Short declarative sentences, lead with the point.
- Cut narration and throat-clearing ("In this quickstart you will...", "The interesting question is rarely...", "That is the loop").
- Removed every AI-slop word (leverage, utilize, streamline, robust, seamless, comprehensive, crucial, furthermore, moreover, notably, etc.).
- Replaced em-dash crutches with colons/periods. Converted "term — definition" bullets to "term: definition".

## Preserved verbatim

All frontmatter keys, `openapi:` lines, code/JSON/curl blocks, MDX components, URLs, endpoint paths, headers, field names, numbers, rate-limit figures, grade thresholds, and links. Every technical fact and caveat retained. `mint broken-links` passes; zero slop words; the only remaining em dashes are in a code comment and a table placeholder cell.

## Honest note on "drastically simplify"

You picked the "tighten hard, ~30-40% shorter" option. I want to flag the reality before you review: these docs were **already tight**, and the word count is dominated by API tables, JSON config, and code samples, not prose fat. Realistic prose reduction landed at **~5-10%** (index/quickstart more, reference pages less).

Getting to a literal 30-40% word cut would mean **deleting reference content**: the error-code table, the rate-limit header tables, the per-client config snippets, troubleshooting accordions, or code examples. That removes value, not fat. I did not do that.

If you want it more aggressive, the safe levers are narrative-only and I can do them in this PR on your call:
- Merge or drop `index.mdx`'s "What it solves" + "What you can build" into one shorter section.
- Cut the duplicate JS/Python "same workflow in code" block in `quickstart.mdx` (keep curl only).
- Merge the three `concepts/` pages into one.

Tell me how far to go and I'll push to this branch.

## Why not merged

Merging auto-deploys to the live docs site, and "how drastic" is your taste call. Holding for your review.

---

**Update (6bed6b9):** Addressed Codex P2 on `get-position-timeline-by-id` — corrected the id descriptor to the integer internal `traders.id` per the OpenAPI contract (fixed a pre-existing `trd_...` inaccuracy on both timeline pages).

---

**Update (c94d448):** Added a Tip on `index.mdx` pointing AI-agent users (Claude Code, Cursor, etc.) to `llms-full.txt` as a single-file copy of the docs to feed into context.

---

**Rebased onto main after #19 merged (05f1fab):** resolved the `quickstart.mdx` batch-section conflict (kept #19's "wallet addresses or usernames" accuracy in the tightened voice). All earlier fixes intact; `changelog.mdx` unchanged vs main; links pass.

---

**Update (abfcbff):** Fixed Codex P2 on `explore-markets` — the sweep wrongly said explore takes no query; reworded and documented the `q` keyword param per the OpenAPI.
