### PR TITLE
docs(changelog): consolidate June 1 into one user-facing entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,7 +7,7 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
-<Update label="June 1, 2026" description="Remote MCP read parity, usage and caching headers, easier discovery, and clearer docs">
+<Update label="June 1, 2026" description="Remote MCP read parity, usage and caching headers, and easier discovery">
   **Remote MCP read parity.** [`POST /api/v1/mcp`](/api-reference/endpoint/remote-mcp) now exposes 21 read-only tools through `tools/list`, covering the public V1 reads: batch reads, history, event replay, webhook reads, reports, market snapshots, and trader exports. Webhook mutations stay REST-only, and the endpoint is tools-only (no resources or prompts).
 
   **See your usage.** Added [`GET /api/v1/usage`](/api-reference/endpoint/get-usage), an authenticated peek at your current per-minute limiter window and UTC-day usage. It doesn't spend primary quota, but has its own 100 reads/minute guard.
@@ -15,8 +15,6 @@ This changelog tracks externally visible REST API changes only. Documentation-on
   **Cheaper polling, safe retries.** Deterministic reads now support `ETag` / `If-None-Match` conditional GETs, so an unchanged read returns `304` with no body. Webhook create/update/delete/rotate accept an `Idempotency-Key`.
 
   **Easier discovery.** Added [`GET /api/v1`](/api-reference/endpoint/get-api-discovery) (an API discovery document) and [`GET /api/v1/openapi.json`](/api-reference/endpoint/redirect-api-openapi-spec) (a redirect to the canonical OpenAPI spec). Operation IDs are now codegen-friendly, with examples, code samples, and response-header metadata.
-
-  **Clearer docs.** Added [llms-full.txt](https://docs.0xinsider.com/llms-full.txt), the whole docs site as one plain-text file you can feed into Claude Code, Cursor, or any AI agent. The rest of the docs got a clarity and concision pass.
 </Update>
 
 <Update label="May 8, 2026" description="Remote MCP exposes position and market discovery tools">

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,18 +7,16 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
-<Update label="June 1, 2026" description="Remote MCP reaches read parity with public V1 reads">
-  [`POST /api/v1/mcp`](/api-reference/endpoint/remote-mcp) now exposes 21 read-only tools through `tools/list`, covering the public V1 read operations including batch reads, history, event replay, webhook reads, reports, market snapshots, and trader exports.
+<Update label="June 1, 2026" description="Remote MCP read parity, usage and caching headers, easier discovery, and clearer docs">
+  **Remote MCP read parity.** [`POST /api/v1/mcp`](/api-reference/endpoint/remote-mcp) now exposes 21 read-only tools through `tools/list`, covering the public V1 reads: batch reads, history, event replay, webhook reads, reports, market snapshots, and trader exports. Webhook mutations stay REST-only, and the endpoint is tools-only (no resources or prompts).
 
-  Webhook mutation operations remain REST-only, and the remote MCP endpoint remains tools-only: it does not implement resources or prompts.
-</Update>
+  **See your usage.** Added [`GET /api/v1/usage`](/api-reference/endpoint/get-usage), an authenticated peek at your current per-minute limiter window and UTC-day usage. It doesn't spend primary quota, but has its own 100 reads/minute guard.
 
-<Update label="June 1, 2026" description="API DX hardening adds usage, ETags, idempotent webhooks, and richer OpenAPI">
-  Added [`GET /api/v1`](/api-reference/endpoint/get-api-discovery), a public API-origin discovery document, and [`GET /api/v1/openapi.json`](/api-reference/endpoint/redirect-api-openapi-spec), a redirect to the canonical web-origin OpenAPI spec.
+  **Cheaper polling, safe retries.** Deterministic reads now support `ETag` / `If-None-Match` conditional GETs, so an unchanged read returns `304` with no body. Webhook create/update/delete/rotate accept an `Idempotency-Key`.
 
-  Added [`GET /api/v1/usage`](/api-reference/endpoint/get-usage), an authenticated budget peek for the current per-minute limiter window and UTC-day usage. It does not spend primary quota, but has its own 100 reads/minute guard.
+  **Easier discovery.** Added [`GET /api/v1`](/api-reference/endpoint/get-api-discovery) (an API discovery document) and [`GET /api/v1/openapi.json`](/api-reference/endpoint/redirect-api-openapi-spec) (a redirect to the canonical OpenAPI spec). Operation IDs are now codegen-friendly, with examples, code samples, and response-header metadata.
 
-  Deterministic reads now document `ETag` / `If-None-Match` conditional GETs, webhook create/update/delete/rotate support `Idempotency-Key`, and OpenAPI operation IDs are codegen-friendly camel-style identifiers with examples, code samples, and response-header metadata.
+  **Clearer docs.** Added [llms-full.txt](https://docs.0xinsider.com/llms-full.txt), the whole docs site as one plain-text file you can feed into Claude Code, Cursor, or any AI agent. The rest of the docs got a clarity and concision pass.
 </Update>
 
 <Update label="May 8, 2026" description="Remote MCP exposes position and market discovery tools">


### PR DESCRIPTION
Fixes #25

Bundles today's two changelog entries (Remote MCP read parity, API DX hardening) into one entry framed around what API users get, and adds the shipped `llms-full.txt` artifact. Every endpoint link preserved. Round-trippable IDs intentionally excluded (backend #4981 still open). `mint broken-links` passes.

---

**Update (29e1e23):** Removed the docs-only `llms-full.txt`/clarity bullet (Codex P1) — that belongs in the product changelog, not the API changelog. Remaining items are all shipped API changes.
