### PR TITLE
docs(api): fix phantom whale-trades query params (side / min_size_usd)

### DIFF
--- a/api-reference/endpoint/get-whale-trades.mdx
+++ b/api-reference/endpoint/get-whale-trades.mdx
@@ -9,12 +9,13 @@ Useful filters:
 
 - `min_grade=A`: only trades from S/A-grade traders (set `B` to widen).
 - `category=crypto`: restrict to a market category.
-- `side=buy`: `buy` or `sell`.
-- `min_size_usd=10000`: floor on trade size.
+- `min_size=10000`: floor on trade notional in USD.
+
+Each item carries the trade's `side` (`buy`/`sell`) in the response; there is no `side` request filter.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
-  "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&category=crypto&side=buy&limit=50"
+  "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&category=crypto&min_size=10000&limit=50"
 ```
 
 Cursor-paginated by timestamp. For a fixed time range (backtests, recap reports), use [Whale Trades History](/api-reference/endpoint/get-whale-trades-history). To fetch one returned `wt_...` item again, use [Get Whale Trade](/api-reference/endpoint/get-whale-trade).

--- a/concepts/grades.mdx
+++ b/concepts/grades.mdx
@@ -102,11 +102,11 @@ Some traders make the leaderboard but lack a classifiable strategy. Their `strat
 
 ### Combine grade + category
 
-What are A-grade or better crypto traders buying right now?
+What are A-grade or better crypto traders trading right now? (Each item carries its `side` in the response, so you can split buys from sells client-side.)
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
-  "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&category=crypto&side=buy&limit=50"
+  "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&category=crypto&limit=50"
 ```
 
 ## A note on null strategies

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -92,11 +92,11 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&limit=50"
 ```
 
-Layer filters. A-grade or better, crypto only, buy side:
+Layer filters. A-grade or better, crypto only, $10k+ notional:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
-  "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&category=crypto&side=buy&limit=50"
+  "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&category=crypto&min_size=10000&limit=50"
 ```
 
 ### Step D: Drill into one market


### PR DESCRIPTION
## What

The `/api/v1/whale-trades` docs documented two query filters the API does not accept:
- `side=buy` — there is **no** `side` request filter. `side` is a per-item **response** field (buy/sell). A copy-pasted `?side=buy` is silently ignored (serde drops the unknown param), so a first-time integrator's "buy side" filter quietly returns both sides.
- `min_size_usd` — the real param is `min_size`.

Verified against the backend handler `WhaleTradesParams` (`backend/src/api_v1/handlers/whale_trades.rs:49`): accepts only `limit, cursor, min_size, category, min_grade`.

## Changes
- `api-reference/endpoint/get-whale-trades.mdx`: drop the phantom `side` filter row, fix `min_size_usd` -> `min_size`, note `side` is a response field, fix the curl example.
- `quickstart.mdx` + `concepts/grades.mdx`: drop `&side=buy` from the two curl examples (replaced with the real `min_size` filter / grade+category).

## Scope
Refs 0xinsider/0xinsider#4972 (the param-table slice). The `addresses`->`traders` batch-body fix from that issue is **already on main** (quickstart.mdx:170). The rest of #4972 (concept pages, recipes, webhooks guide, OpenAPI parity) is a separate larger effort.

No code, copy-only. Renders in Mintlify; no structural/schema change.