### PR TITLE
docs(api): concept pages, recipes, webhooks guide, objects reference (#4972)

### DIFF
--- a/api-reference/endpoint/create-webhook.mdx
+++ b/api-reference/endpoint/create-webhook.mdx
@@ -3,7 +3,7 @@ title: "Create Webhook"
 openapi: "POST /api/v1/webhooks"
 ---
 
-Register an endpoint to receive whale-trade and radar events as they happen.
+Register an HTTPS endpoint to receive [webhook events](/guides/webhooks#event-types) as they happen. The endpoint starts in `pending_verification` and must be verified before deliveries begin.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -17,6 +17,6 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/webhooks"
 ```
 
-The response includes a one-time signing secret. **Copy it now**. You can't retrieve it later. Use it to verify the `X-0xinsider-Signature` header on every delivery; see [Verify Webhook](/api-reference/endpoint/verify-webhook). If it leaks, [rotate it](/api-reference/endpoint/rotate-webhook-secret).
+The response includes a one-time `signing_secret` and a `verification.token`. **Copy the secret now**. You can't retrieve it later. Use it to verify the `x-0xinsider-signature` header on every delivery (see the [Webhooks guide](/guides/webhooks)), and send the verification token to [Verify Webhook](/api-reference/endpoint/verify-webhook) to activate the endpoint. If the secret leaks, [rotate it](/api-reference/endpoint/rotate-webhook-secret).
 
 Send `Idempotency-Key` when retrying after a timeout. The same key with the same body returns the original webhook; the same key with a different body returns `422`.

--- a/api-reference/endpoint/delete-webhook.mdx
+++ b/api-reference/endpoint/delete-webhook.mdx
@@ -9,7 +9,7 @@ Permanently remove a webhook. No further events are delivered to that URL, and t
 curl -X DELETE \
   -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   -H "Idempotency-Key: webhook-delete-2026-06-01" \
-  "https://api.0xinsider.com/api/v1/webhooks/wh_abc123"
+  "https://api.0xinsider.com/api/v1/webhooks/42"
 ```
 
 To pause deliveries without losing the webhook, [update](/api-reference/endpoint/update-webhook) it to `enabled: false` instead.

--- a/api-reference/endpoint/get-webhook.mdx
+++ b/api-reference/endpoint/get-webhook.mdx
@@ -7,5 +7,5 @@ Inspect a single registered webhook: its URL, subscribed events, active flag, an
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
-  "https://api.0xinsider.com/api/v1/webhooks/wh_abc123"
+  "https://api.0xinsider.com/api/v1/webhooks/42"
 ```

--- a/api-reference/endpoint/list-webhooks.mdx
+++ b/api-reference/endpoint/list-webhooks.mdx
@@ -16,5 +16,7 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
 - [Get](/api-reference/endpoint/get-webhook) one to inspect its current state.
 - [Update](/api-reference/endpoint/update-webhook) to change URL, events, or active flag.
 - [Delete](/api-reference/endpoint/delete-webhook) when you no longer need it.
-- [Verify](/api-reference/endpoint/verify-webhook) signed delivery on your side using HMAC.
+- [Verify](/api-reference/endpoint/verify-webhook) the endpoint with its token to activate deliveries.
 - [Rotate secret](/api-reference/endpoint/rotate-webhook-secret) if a signing secret leaks.
+
+For event types, the signature scheme, and verification code, see the [Webhooks guide](/guides/webhooks).

--- a/api-reference/endpoint/rotate-webhook-secret.mdx
+++ b/api-reference/endpoint/rotate-webhook-secret.mdx
@@ -9,7 +9,7 @@ Generate a fresh signing secret for a webhook. The response includes the new sec
 curl -X POST \
   -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   -H "Idempotency-Key: webhook-rotate-2026-06-01" \
-  "https://api.0xinsider.com/api/v1/webhooks/wh_abc123/rotate-secret"
+  "https://api.0xinsider.com/api/v1/webhooks/42/rotate-secret"
 ```
 
 Rotate right away if a secret leaks (committed to git, exposed in a log, sent in a screenshot).

--- a/api-reference/endpoint/update-webhook.mdx
+++ b/api-reference/endpoint/update-webhook.mdx
@@ -11,7 +11,7 @@ curl -X PATCH \
   -H "Idempotency-Key: webhook-update-2026-06-01" \
   -H "Content-Type: application/json" \
   -d '{"enabled": false}' \
-  "https://api.0xinsider.com/api/v1/webhooks/wh_abc123"
+  "https://api.0xinsider.com/api/v1/webhooks/42"
 ```
 
 The signing secret is not affected by `PATCH`. To change it, use [Rotate Webhook Secret](/api-reference/endpoint/rotate-webhook-secret).

--- a/api-reference/endpoint/verify-webhook.mdx
+++ b/api-reference/endpoint/verify-webhook.mdx
@@ -3,12 +3,16 @@ title: "Verify Webhook"
 openapi: "POST /api/v1/webhooks/{id}/verify"
 ---
 
-Send a signed test payload to your webhook URL to confirm signature verification on your side before live deliveries start.
+Activate a webhook by returning the `verification_token` you received when you created it. A new endpoint stays in `pending_verification` and receives no deliveries until it is verified. The token expires 24 hours after create.
 
 ```bash
 curl -X POST \
   -H "Authorization: Bearer $OXINSIDER_API_KEY" \
-  "https://api.0xinsider.com/api/v1/webhooks/wh_abc123/verify"
+  -H "Content-Type: application/json" \
+  -d '{"verification_token": "whv_3c2e...redacted"}' \
+  "https://api.0xinsider.com/api/v1/webhooks/42/verify"
 ```
 
-The webhook receives a `verify.test` event with an `X-0xinsider-Signature` header. Compute `HMAC_SHA256(secret, raw_body)` on your side and compare in constant time. Reject deliveries with mismatched signatures.
+On success the endpoint flips to `active` and deliveries begin. This call does not send a test delivery; it activates the endpoint by matching the token. The webhook `id` is the integer returned at create.
+
+For the signature scheme and copy-pasteable verification code, see the [Webhooks guide](/guides/webhooks).

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -124,11 +124,13 @@ endpoints remain restricted to configured 0xinsider origins.
 
 Newer builder endpoints (snapshots, history ranges, batch reads, reports) attach metadata to provider-owned values so you can tell provider-backed, cached, partial, stale, and unavailable data apart.
 
-Per value:
+Per value, four dimensions:
 
-- `source`: where the value came from (`provider`, `cache`, `computed`).
-- `freshness`: how stale it is (an ISO timestamp or `live`).
-- `reconciliation`: whether it's been cross-checked against the source of truth.
-- `completeness`: `full`, `partial`, or `unavailable`.
+- `source`: where it came from (`provider`, `database`, `cache`, `computed`, `client_input`, `unavailable`).
+- `freshness`: how current it is (`fresh`, `refreshing`, `stale`, `not_live`, `unknown`, `unavailable`).
+- `reconciliation`: whether it was cross-checked against the source of truth (`provider_backed`, `db_mirror`, `computed`, `partial`, `not_applicable`, `unavailable`).
+- `completeness`: whether it reflects the full picture (`complete`, `partial`, `not_computed`, `not_applicable`, `unavailable`).
+
+See [Trust metadata](/concepts/trust-metadata) for what each value means and how to request field-level trust with `expand=trust`.
 
 Rule of thumb: **don't flatten unavailable values into `0`, `[]`, or `{}`.** Read the metadata and surface "unavailable" to your consumer instead of inventing a zero. Provider data that quietly becomes `0` causes silent bugs downstream.

--- a/api-reference/objects.mdx
+++ b/api-reference/objects.mdx
@@ -1,0 +1,726 @@
+---
+title: "Objects"
+description: "Every object the API returns, generated from the OpenAPI schema."
+---
+
+{/* GENERATED FILE -- do not edit by hand. Run scripts/generate-objects-reference.py. */}
+
+These are the objects the API returns, generated directly from the OpenAPI
+schema so they always match the live contract. Each table lists a field, its
+type, whether it is always present, and what it means.
+
+
+## ApiDiscovery
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `api_base_url` | string | Yes | Canonical API origin for public V1 requests. |
+| `docs_url` | string | Yes | Full agent-readable API reference. |
+| `openapi_url` | string | Yes | Canonical web-origin OpenAPI JSON document. |
+| `health_url` | string | Yes | Unauthenticated API health endpoint. |
+| `authentication` | string | Yes |  |
+| `authenticated_routes` | array of string | Yes | Representative authenticated data routes. Full route coverage lives in OpenAPI and llms-full.txt. |
+
+## ApiError
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `object` | string | Yes |  |
+| `error` | object | Yes |  |
+| `meta` | `ResponseMeta` | Yes |  |
+
+## ApiErrorBody
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `code` | string | Yes |  |
+| `message` | string | Yes |  |
+| `doc_url` | string | No |  |
+| `param` | string | No |  |
+
+## BatchMarketIntelItem
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `index` | integer | Yes | Zero-based request index. Duplicate inputs keep separate result rows. |
+| `input` | string | Yes |  |
+| `status` | `ok` \| `error` | Yes |  |
+| `data` | `MarketIntel` | No |  |
+| `error` | `ApiErrorBody` | No |  |
+
+## BatchRateLimitMeta
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `basis` | string | Yes |  |
+| `limit` | integer | Yes |  |
+| `remaining` | integer | Yes |  |
+| `reset` | integer | Yes | Unix timestamp when the batch item window resets. |
+
+## BatchResponseMeta
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `request_id` | string | Yes |  |
+| `cached` | boolean | Yes |  |
+| `total_items` | integer | Yes |  |
+| `successful_items` | integer | Yes |  |
+| `failed_items` | integer | Yes |  |
+| `request_cost` | integer | Yes | Number of batch item units reserved before execution. |
+| `rate_limit` | `BatchRateLimitMeta` | Yes |  |
+
+## BatchTraderItem
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `index` | integer | Yes | Zero-based request index. Duplicate inputs keep separate result rows. |
+| `input` | string | Yes |  |
+| `status` | `ok` \| `error` | Yes |  |
+| `data` | `Trader` | No |  |
+| `error` | `ApiErrorBody` | No |  |
+
+## CreateWebhookRequest
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes |  |
+| `url` | string | Yes | Public HTTPS callback URL. Local/private/internal targets are rejected. |
+| `event_types` | array of `WebhookEventType` | Yes |  |
+
+## EventReplayEvent
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Opaque event ID; currently identical to cursor for the whale_alerts.id sequence. |
+| `type` | `whale_trades_inserted` | Yes |  |
+| `cursor` | string | Yes | Cursor positioned at this event. |
+| `sequence` | integer | Yes | Global whale_alerts.id sequence. |
+| `published_at` | string | Yes |  |
+| `payload` | object | Yes |  |
+| `source` | `EventReplaySource` | Yes |  |
+| `freshness` | `EventReplayFreshness` | Yes |  |
+
+## EventReplayFreshness
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `status` | string | Yes |  |
+| `observed_at` | string | Yes |  |
+
+## EventReplayMeta
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `request_id` | string | Yes | Unique request ID (req_ prefix). |
+| `cached` | boolean | Yes |  |
+| `cache_age_s` | integer | No |  |
+| `replay` | object | Yes |  |
+| `retention` | object | Yes |  |
+| `completeness` | object | Yes |  |
+
+## EventReplaySource
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `kind` | string | Yes |  |
+| `producer_family` | `whale_trades` | Yes |  |
+| `owner` | string | Yes |  |
+| `provider_fetch_at_request_time` | boolean | Yes |  |
+
+## ExploreEntry
+
+One of: `ExploreGroup`, `ExploreStandalone`. Discriminated by `type`.
+
+## ExploreFacetValue
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `value` | string | Yes |  |
+| `label` | string | Yes |  |
+| `count` | integer | Yes |  |
+
+## ExploreFacets
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `categories` | array of `ExploreFacetValue` | Yes |  |
+| `platforms` | array of `ExploreFacetValue` | Yes |  |
+
+## ExploreGroup
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `type` | string | Yes |  |
+| `event_slug` | string | Yes |  |
+| `parent_title` | string | Yes |  |
+| `image` | string | No |  |
+| `platform` | string | No |  |
+| `category` | string | No |  |
+| `markets` | array of `ExploreMarket` | Yes |  |
+| `rep_volume` | number | No |  |
+| `rep_whales` | integer | No |  |
+
+## ExploreMarket
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes |  |
+| `condition_id` | string | Yes |  |
+| `title` | string | Yes | Non-empty market title. |
+| `slug` | string | No | Provider-native market slug. |
+| `url_slug` | string | No | First-party market page slug used for internal links. |
+| `image` | string | No |  |
+| `icon` | string | No |  |
+| `category` | string | No |  |
+| `platform` | string | No |  |
+| `status` | `active` \| `closed` | Yes |  |
+| `volume` | number | No |  |
+| `liquidity` | number | No |  |
+| `whale_trade_count` | integer | No |  |
+| `whale_distinct_wallets` | integer | No |  |
+| `whale_total_usd` | number | No |  |
+| `whale_last_trade_at` | string | No |  |
+| `end_date` | string | No |  |
+| `created_at` | string | No |  |
+| `outcome_yes` | string | No |  |
+| `outcome_no` | string | No |  |
+| `event_slug` | string | No |  |
+| `kalshi_series_slug` | string | No |  |
+| `smart_score` | number | No |  |
+| `smart_count` | integer | No |  |
+| `smart_label` | string | No |  |
+| `outcome_yes_label` | string | No | Display label for the YES/outcome_index=0 side, enriched from provider outcome metadata when available. |
+| `outcome_no_label` | string | No | Display label for the NO/outcome_index=1 side, enriched from provider outcome metadata when available. |
+| `outcome_yes_provider_id` | integer | No | Provider-owned YES/outcome_index=0 identifier when available for trade-ticket wiring. |
+| `outcome_no_provider_id` | integer | No | Provider-owned NO/outcome_index=1 identifier when available for trade-ticket wiring. |
+| `open_interest` | number | No |  |
+| `oi_change_pct` | number | No |  |
+| `price_points` | array of array of number | No |  |
+| `no_price_points` | array of array of number | No |  |
+| `last_price` | number | No |  |
+| `no_last_price` | number | No |  |
+| `change_pct_24h` | number | No |  |
+| `no_change_pct_24h` | number | No |  |
+| `discover_score` | number | No | Backend-owned deterministic market discovery score used by the hot sort. |
+| `score_components` | object | No |  |
+| `freshness` | object | No |  |
+
+## ExploreStandalone
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `type` | string | Yes |  |
+| `market` | `ExploreMarket` | Yes |  |
+
+## ExportCompleteness
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `status` | `complete` \| `partial` \| `empty` | Yes |  |
+| `reason` | string | Yes |  |
+| `sync_coverage` | number | Yes |  |
+
+## ExportCounts
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `pnl_days` | integer | Yes |  |
+| `exported_markets` | integer | Yes |  |
+| `estimated_trade_rows` | integer | Yes |  |
+| `estimated_size_mb` | number | Yes |  |
+
+## ExportSourceRange
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `first_pnl_date` | string | No |  |
+| `last_pnl_date` | string | No |  |
+| `latest_trade_at` | string | No |  |
+| `latest_market_activity_at` | string | No |  |
+
+## ExportVolumeReconciliation
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `provider_lifetime_volume` | number | No |  |
+| `exported_activity_volume` | number | Yes |  |
+| `exported_market_cost_basis` | number | Yes |  |
+| `provider_activity_volume_gap` | number | No |  |
+| `activity_volume_coverage` | number | No |  |
+
+## LargeExportPolicy
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `mode` | string | Yes |  |
+| `current_internal_route` | string | Yes |  |
+| `direct_streaming` | object | Yes |  |
+| `async_job` | object | Yes |  |
+| `rate_limit` | object | Yes |  |
+
+## LargePosition
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Composite prefixed ID `pos_<wallet>:<condition_id>:<outcome_index>`. |
+| `platform` | `polymarket` \| `kalshi` | Yes | Provider discriminator. Always polymarket today (scanner is Polymarket-only); kept in the shape so Kalshi can land without a breaking change. |
+| `total_size_usd` | number | No | Aggregate provider currentValue for this position leg in USD. |
+| `position_unrealized_pnl` | number | No | Provider per-position unrealized P&L (trader_markets.unrealized_pnl_num, from Polymarket cashPnl). |
+| `share_count` | number | Yes | Live share count for this position. |
+| `avg_entry_price` | number | No | Volume-weighted entry price. |
+| `current_price` | number | No | Latest provider mark price for the position's token. |
+| `outcome_label` | string | No | Backend-resolved outcome label (provider outcome, else Yes/No from the binary index). |
+| `event_leg_count` | integer | Yes | Legs collapsed into this representative row for one (wallet, event, outcome side) group. 1 means standalone. |
+| `event_total_value_usd` | number | No | Aggregate provider currentValue across collapsed sibling legs; equals total_size_usd when event_leg_count = 1. |
+| `first_seen_at` | string | Yes |  |
+| `last_updated_at` | string | Yes |  |
+| `trader` | object | Yes |  |
+| `market` | object | Yes |  |
+
+## LeaderboardEntry
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes |  |
+| `address` | string | Yes |  |
+| `username` | string | No |  |
+| `grade` | string | No |  |
+| `streak_tier` | `hot` \| `rising` \| `neutral` \| `cooling` \| `cold` | No | Hot-streak tier (trailing-7d cross-sectional percentile); a separate axis from the all-time grade. Null when no recent activity. |
+| `score` | number | No |  |
+| `pnl` | number | No |  |
+| `volume` | number | No |  |
+| `markets_traded` | integer | No |  |
+| `win_rate` | number | No |  |
+| `strategy_type` | string | No |  |
+| `platform` | string | Yes |  |
+| `last_active` | string | No |  |
+
+## MarketIntel
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `market` | object | Yes |  |
+| `smart_money` | object | Yes |  |
+| `timeframe` | string | Yes |  |
+
+## MarketSearchResult
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes |  |
+| `condition_id` | string | Yes |  |
+| `title` | string | Yes |  |
+| `slug` | string | No |  |
+| `category` | string | No |  |
+| `platform` | string | No |  |
+| `status` | `active` \| `closed` | Yes |  |
+
+## MarketSnapshot
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `market` | object | Yes |  |
+| `outcomes` | array of object | Yes |  |
+| `liquidity` | object | Yes |  |
+| `sports` | object | Yes |  |
+| `freshness` | object | Yes |  |
+| `trust` | `MarketSnapshotTrust` | No | Price and spread trust metadata. Present only when expand=trust or expand[]=trust is requested. |
+
+## MarketSnapshotFreshness
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `status` | `fresh` \| `stale` \| `available` \| `not_live` \| `unavailable` | Yes |  |
+| `source` | string | Yes |  |
+| `as_of` | string | No |  |
+| `stale_after_s` | integer | No |  |
+| `reason` | string | No |  |
+
+## MarketSnapshotTopOfBook
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `status` | `available` \| `unavailable` | Yes |  |
+| `source` | string | Yes |  |
+| `best_bid` | number | No |  |
+| `best_ask` | number | No |  |
+| `spread_bps` | integer | No |  |
+| `bid_depth_usdc` | number | No |  |
+| `ask_depth_usdc` | number | No |  |
+| `reason` | string | No |  |
+
+## MarketSnapshotTrust
+
+Price and spread trust metadata returned only when GET /api/v1/market/{condition_id}/snapshot includes expand=trust.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `current_price` | `TrustMetadata` | Yes |  |
+| `spread_bps` | `TrustMetadata` | Yes |  |
+
+## PlatformCapabilities
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `grade` | `PlatformCapabilityStatus` | Yes |  |
+| `pnl` | `PlatformCapabilityStatus` | Yes |  |
+| `strategy` | `PlatformCapabilityStatus` | Yes |  |
+| `timeline` | `PlatformCapabilityStatus` | Yes |  |
+| `whale_signal` | `PlatformCapabilityStatus` | Yes |  |
+| `insider_radar` | `PlatformCapabilityStatus` | Yes |  |
+| `market_snapshot` | `PlatformCapabilityStatus` | Yes |  |
+
+## PlatformCapabilityStatus
+
+String enum: `supported`, `partial`, `unsupported`.
+
+## Platforms
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `platforms` | object | Yes |  |
+
+## Position
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Composite prefixed ID `pos_<wallet>:<condition_id>:<outcome_index>`. |
+| `platform` | `polymarket` \| `kalshi` | Yes | Provider discriminator. Slice 5 ships Polymarket only; the field stays in the response shape so Kalshi positions can land without a breaking change. |
+| `wallet` | string | Yes | Lowercased proxy wallet address. |
+| `side` | `YES` \| `NO` | Yes | Binary outcome side. Non-binary positions are not surfaced on V1. |
+| `shares` | number | Yes | Live share count from the wallet_positions mirror. |
+| `avg_price` | number | No | Volume-weighted entry price for this leg. |
+| `current_value_usd` | number | Yes | Current mark-to-market value in USD (always non-null on V1 — pre-reconcile rows are excluded). |
+| `initial_value_usd` | number | No |  |
+| `cash_pnl` | number | No | Unrealized P&L for the open position (Polymarket `cashPnl`). |
+| `realized_pnl` | number | No | Closed-leg P&L rolled up (Polymarket `realizedPnl`). |
+| `last_reconciled_at` | string | No | Max updated_at across mirror legs for this pair. |
+| `freshness` | `fresh` \| `refreshing` \| `stale` \| `unknown` | Yes | Backend-computed staleness bucket derived from last_reconciled_at. |
+| `trader` | object | Yes |  |
+| `market` | object | Yes |  |
+
+## PositionTimelineEvent
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Prefixed ID (pe_...). |
+| `event_timestamp` | string | Yes | ISO 8601 timestamp of the on-chain fill. |
+| `action` | `buy` \| `sell` | Yes | From the taker's perspective. |
+| `outcome_side` | `yes` \| `no` | Yes |  |
+| `amount_delta` | number | Yes | Signed share delta (+ on buy, − on sell). |
+| `price` | number | Yes | Fill price in USDC per share, in [0,1]. |
+| `usdc_notional` | number | Yes | Positive USDC notional of the fill. |
+| `tx_hash` | string | Yes | Polygon transaction hash of the fill. |
+| `running_amount` | number | Yes | Cumulative signed share balance after this fill. |
+| `running_avg_price` | number | Yes | Buy-weighted entry basis (matches Polymarket /positions avgPrice semantics). Sells do not change this value. 0 when no buys have occurred yet. |
+
+## RadarFlag
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Prefixed ID (rf_...). |
+| `suspicion_score` | number | Yes |  |
+| `severity` | `flag` \| `watch` | Yes |  |
+| `trader` | object | Yes |  |
+| `market` | object | Yes |  |
+| `scores` | object | Yes |  |
+| `evidence` | object | Yes | Structured evidence JSON. |
+| `created_at` | string | Yes |  |
+
+## ReportPayload
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `total_whale_trades` | integer | No |  |
+| `total_whale_volume` | number | No |  |
+| `biggest_trade_size` | number | No |  |
+| `active_traders` | integer | No |  |
+| `top_whale_trades` | array of object | No |  |
+| `categories` | array of object | No |  |
+| `grade_distribution` | array of object | No |  |
+
+## ReportReconciliation
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `volume_kind` | string | Yes |  |
+| `whale_volume_source` | string | Yes |  |
+| `notes` | string | Yes |  |
+
+## ReportSnapshot
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `kind` | `daily` \| `weekly` \| `monthly` | Yes |  |
+| `generated_at` | string | Yes |  |
+| `source_range` | `ReportSourceRange` | Yes |  |
+| `snapshot` | `SnapshotState` | Yes |  |
+| `completeness` | `SnapshotCompleteness` | Yes |  |
+| `reconciliation` | `ReportReconciliation` | Yes |  |
+| `report` | `ReportPayload` | Yes |  |
+
+## ReportSourceRange
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `start_date` | string | Yes |  |
+| `end_date` | string | Yes |  |
+| `timezone` | string | Yes |  |
+
+## ResponseMeta
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `request_id` | string | Yes | Unique request ID (req_ prefix). |
+| `cached` | boolean | Yes |  |
+| `cache_age_s` | integer | No | Cache age in seconds, null if not cached. |
+
+## SmartMoneyFlowMarket
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `market` | object | Yes |  |
+| `smart_money` | object | Yes |  |
+| `timeframe` | string | Yes |  |
+
+## SnapshotCompleteness
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `status` | `complete` \| `partial` \| `empty` | Yes |  |
+| `reason` | string | Yes |  |
+| `expected_days` | integer | Yes |  |
+| `covered_days_with_whale_activity` | integer | Yes |  |
+
+## SnapshotState
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `status` | `final` \| `rolling` | Yes |  |
+| `generated_at` | string | Yes |  |
+| `mutable_until` | string | No |  |
+
+## Trader
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Prefixed ID (trd_...). |
+| `address` | string | Yes |  |
+| `username` | string | No |  |
+| `grade` | `S` \| `A` \| `B` \| `C` \| `D` \| `F` | No |  |
+| `streak_tier` | `hot` \| `rising` \| `neutral` \| `cooling` \| `cold` | No | Hot-streak tier (trailing-7d cross-sectional percentile); a separate axis from the all-time grade. Null when no recent activity. |
+| `score` | number | No |  |
+| `rank` | integer | No |  |
+| `pnl` | object | Yes |  |
+| `stats` | object | Yes |  |
+| `strategy` | object | No |  |
+| `category_strengths` | object | No | Per-category performance breakdown (expand=categories or expand[]=categories). Null unless expanded. Object keyed by category name; each value is the precomputed trader_rankings.category_ranks payload (rank, total_in_category, total_pnl, scaled_total_pnl, n_markets, wins, losses, win_rate; scaled_total_pnl is a legacy alias that currently equals total_pnl). Pass-through DB JSON: keys and value shape are DB-owned, so the inner shape is intentionally unconstrained and may carry additional compatibility fields. |
+| `quant_metrics` | object | No | Advanced risk/performance metrics (expand=quant_metrics or expand[]=quant_metrics). Null unless expanded. Pass-through of the advanced_metrics row as JSON (trader_id and id stripped); the metric key-set is DB-owned and additive, so the inner shape is intentionally unconstrained. |
+| `last_active` | string | No |  |
+| `synced_at` | string | No |  |
+| `sync_status` | string | No | synced, unknown, or pending. |
+| `trust` | `TraderTrust` | No | Field-level trust metadata. Present only when expand=trust or expand[]=trust is requested. |
+
+## TraderExportSnapshot
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `address` | string | Yes |  |
+| `generated_at` | string | Yes |  |
+| `source_range` | `ExportSourceRange` | Yes |  |
+| `completeness` | `ExportCompleteness` | Yes |  |
+| `reconciliation` | `ExportVolumeReconciliation` | Yes |  |
+| `counts` | `ExportCounts` | Yes |  |
+| `large_export_policy` | `LargeExportPolicy` | Yes |  |
+
+## TraderPnl
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Prefixed trader ID (`trd_...`). |
+| `entries` | array of object | Yes | Daily cumulative-P&L series (oldest-first). |
+| `stats` | object | Yes |  |
+| `monthly` | array of object | Yes | Per-month P&L aggregation. |
+| `year_totals` | array of object | Yes | Per-year P&L totals (ascending by year). |
+| `drawdown` | array of object | Yes | Underwater (drawdown) series. |
+
+## TraderTrust
+
+Field-level trust metadata returned only when GET /api/v1/trader/{address} includes expand=trust.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `total_pnl` | `TrustMetadata` | Yes |  |
+| `realized_pnl` | `TrustMetadata` | Yes |  |
+| `unrealized_pnl` | `TrustMetadata` | Yes |  |
+| `markets_traded` | `TrustMetadata` | Yes |  |
+| `win_rate` | `TrustMetadata` | Yes |  |
+| `daily_win_rate` | `TrustMetadata` | Yes |  |
+| `total_volume` | `TrustMetadata` | Yes |  |
+| `grade` | `TrustMetadata` | Yes |  |
+| `score` | `TrustMetadata` | Yes |  |
+| `rank` | `TrustMetadata` | Yes |  |
+| `streak_tier` | `TrustMetadata` | Yes |  |
+| `strategy` | `TrustMetadata` | Yes |  |
+| `category_strengths` | `TrustMetadata` | Yes |  |
+| `quant_metrics` | `TrustMetadata` | Yes |  |
+| `last_active` | `TrustMetadata` | Yes |  |
+| `synced_at` | `TrustMetadata` | Yes |  |
+| `sync_status` | `TrustMetadata` | Yes |  |
+
+## TrendingWallet
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Prefixed trader ID (`trd_...`). |
+| `address` | string | Yes |  |
+| `rank` | integer | Yes | 1-based rank within the full ranked set (stable across pages). |
+| `username` | string | No |  |
+| `profile_image_url` | string | No | Official Polymarket avatar URL (profileImage). |
+| `platform` | `polymarket` \| `kalshi` | Yes | Real provider platform; surfaced, never coerced. Polymarket-only today. |
+| `trending_pnl_usd` | number | Yes | Realized P&L over the trailing window in USD (ranking axis). |
+| `window_volume_usd` | number | Yes |  |
+| `window_markets_traded` | integer | Yes |  |
+| `window_trade_days` | integer | Yes |  |
+| `grade` | `S` \| `A` \| `B` \| `C` \| `D` \| `F` | No | All-time cohort-relative skill grade (forecasting calibration, risk-adjusted returns, consistency); a separate axis from streak_tier. Not a profit ranking, and relative, so it drifts as the cohort moves. Omitted when the trader is Unranked (fewer than 5 markets, insufficient track record to cohort-rank). |
+| `streak_tier` | `hot` \| `rising` \| `neutral` \| `cooling` \| `cold` | No | Hot-streak tier (trailing-7d cross-sectional percentile). Null when no recent activity. |
+| `all_time_pnl_usd` | number | No |  |
+| `all_time_score` | number | No |  |
+| `last_synced` | string | No |  |
+| `daily_pnl_series` | array of object | Yes | Zero-filled daily P&L series across the window. |
+
+## TrustCompleteness
+
+Whether the described value or result set is complete for its stated contract.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `status` | `complete` \| `partial` \| `not_computed` \| `not_applicable` \| `unavailable` | Yes |  |
+| `detail` | string | No |  |
+
+## TrustFreshness
+
+Freshness metadata for a trust-critical value. This is separate from transport cache fields in ResponseMeta.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `status` | `fresh` \| `refreshing` \| `stale` \| `not_live` \| `unknown` \| `unavailable` | Yes |  |
+| `as_of` | string | No |  |
+| `max_age_s` | integer | No |  |
+
+## TrustMetadata
+
+Shared source/freshness/reconciliation/completeness metadata for public API values that may be cached, stale, partial, computed, or provider-unavailable. Unavailable provider values must be represented with explicit metadata instead of fabricated zeros or empty arrays.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `source` | `TrustSource` | Yes |  |
+| `freshness` | `TrustFreshness` | Yes |  |
+| `reconciliation` | `TrustReconciliation` | Yes |  |
+| `completeness` | `TrustCompleteness` | Yes |  |
+
+## TrustReconciliation
+
+How provider-owned facts were reconciled with stored/read-model values.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `status` | `provider_backed` \| `db_mirror` \| `computed` \| `partial` \| `not_applicable` \| `unavailable` | Yes |  |
+| `detail` | string | No |  |
+
+## TrustSource
+
+Source metadata for a trust-critical value. Providers and DB/read models own business truth; clients should not infer missing provider facts from titles, slugs, zeros, or empty arrays.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `kind` | `provider` \| `database` \| `cache` \| `computed` \| `client_input` \| `unavailable` | Yes |  |
+| `owner` | string | Yes | Provider, table/read-model, cache, or service that owns the value. |
+| `field` | string | No | Provider field, DB column, or computed field name when applicable. |
+
+## UpdateWebhookRequest
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | No |  |
+| `url` | string | No |  |
+| `event_types` | array of `WebhookEventType` | No |  |
+| `enabled` | boolean | No |  |
+
+## Usage
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `object` | string | Yes |  |
+| `data` | object | Yes |  |
+| `meta` | `ResponseMeta` | Yes |  |
+
+## VerifyWebhookRequest
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `verification_token` | string | Yes |  |
+
+## WebhookEndpoint
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | integer | Yes |  |
+| `object` | string | Yes |  |
+| `name` | string | Yes |  |
+| `url` | string | Yes |  |
+| `event_types` | array of `WebhookEventType` | Yes |  |
+| `status` | `WebhookStatus` | Yes |  |
+| `verified_at` | string | No |  |
+| `verification_token_expires_at` | string | Yes |  |
+| `failure_count` | integer | Yes |  |
+| `created_at` | string | Yes |  |
+| `updated_at` | string | Yes |  |
+| `retry_policy` | `WebhookRetryPolicy` | Yes |  |
+| `signing_secret` | string | No | Returned only on create or rotate-secret. |
+| `verification` | `WebhookVerification` | No |  |
+
+## WebhookEventType
+
+String enum: `whale_trades_inserted`, `live_sports_updated`, `whale_trader_synced`, `large_positions_updated`.
+
+## WebhookRetryPolicy
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `max_attempts` | integer | Yes |  |
+| `terminal_status` | string | Yes |  |
+
+## WebhookStatus
+
+String enum: `pending_verification`, `active`, `disabled`.
+
+## WebhookVerification
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `token` | string | Yes | One-time verification token returned only on create or URL change. |
+| `expires_at` | string | Yes |  |
+
+## WhaleTrade
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Prefixed ID (wt_...). |
+| `traded_at` | string | Yes |  |
+| `size_usd` | number | Yes |  |
+| `side` | `BUY` \| `SELL` | Yes |  |
+| `price` | number | Yes |  |
+| `signal_score` | number | Yes | 0.0–1.0 normalized signal score. |
+| `trader` | object | Yes |  |
+| `market` | object | Yes |  |
+
+## WhaleTradeHistoryMeta
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `request_id` | string | Yes | Unique request ID (req_ prefix). |
+| `cached` | boolean | Yes |  |
+| `cache_age_s` | integer | No | Cache age in seconds, null if not cached. |
+| `source` | object | Yes |  |
+| `completeness` | object | Yes |  |

--- a/concepts/expand.mdx
+++ b/concepts/expand.mdx
@@ -1,0 +1,69 @@
+---
+title: "Expanding Responses"
+description: "Use the expand parameter to pull heavier fields and trust metadata only when you need them."
+---
+
+Trader responses stay lean by default. The expensive fields, strategy classification, per-category performance, quant metrics, and trust metadata, are left out unless you ask for them. The `expand` parameter pulls them in.
+
+This keeps the common path fast. Expanded fields skip the cache and read fresh, so request them only when you need them.
+
+## How to pass it
+
+`expand` is repeatable. Use a comma-separated list or repeat the bracketed key:
+
+```bash
+# Comma-separated
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/trader/0x204f...?expand=strategy,categories"
+
+# Repeated bracket form
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/trader/0x204f...?expand[]=strategy&expand[]=trust"
+```
+
+Unknown values are ignored, so a forward-compatible client can safely pass options an older API build does not recognize.
+
+## The four expand values
+
+Available on [`GET /api/v1/trader/{address}`](/api-reference/endpoint/get-trader) and [`POST /api/v1/traders/batch`](/api-reference/endpoint/batch-get-traders):
+
+| Value | Adds field | What it contains |
+|---|---|---|
+| `strategy` | `strategy` | The trader's ML strategy classification: `strategy_type`, an optional `description`, and `confidence`. See [Strategy types](/concepts/strategy-types). |
+| `categories` | `category_strengths` | Per-category performance, keyed by category: rank within the category, total P&L, markets traded, wins, losses, and win rate. |
+| `quant_metrics` | `quant_metrics` | Advanced per-trader quant metrics. The key set is additive and database-owned. |
+| `trust` | `trust` | Field-level [trust metadata](/concepts/trust-metadata): source, freshness, reconciliation, and completeness for each derived field. |
+
+## Example
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/trader/0x204f...?expand=strategy"
+```
+
+```json
+{
+  "object": "trader",
+  "data": {
+    "id": "trd_0x204f72f35326db932158cba6adff0b9a1da95e14",
+    "username": "swisstony",
+    "grade": "S",
+    "strategy": {
+      "strategy_type": "swing_trader",
+      "description": null,
+      "confidence": null
+    }
+  }
+}
+```
+
+## Market snapshots
+
+[`GET /api/v1/market/{condition_id}/snapshot`](/api-reference/endpoint/get-market-snapshot) accepts `expand=trust` only. It adds trust metadata for the snapshot's `current_price` and `spread_bps`. The trader-only values (`strategy`, `categories`, `quant_metrics`) do not apply to markets.
+
+## Cost
+
+Expanded fields read live instead of from cache, so an expanded request is heavier than a plain one. Two habits keep this cheap:
+
+- Request only the expansions you use on a given screen.
+- For many traders at once, use [`POST /api/v1/traders/batch`](/api-reference/endpoint/batch-get-traders) with a single `expand` set rather than one expanded request per trader.

--- a/concepts/platforms.mdx
+++ b/concepts/platforms.mdx
@@ -1,0 +1,53 @@
+---
+title: "Platforms"
+description: "Which prediction markets 0xinsider covers, and which features are available per platform."
+---
+
+0xinsider covers two prediction-market platforms: **Polymarket** and **Kalshi**. They are not at parity. Polymarket is fully covered. Kalshi coverage is partial, because some of the on-chain signals 0xinsider computes do not exist for Kalshi's centralized markets.
+
+Plan around the real coverage. A copy-trading or whale-tracking integration that assumes Kalshi grades or Kalshi whale data will come back empty.
+
+## The platform enum
+
+Anywhere a `platform` field or filter appears, the values are lowercase:
+
+- `polymarket`
+- `kalshi`
+
+Endpoints that accept a `platform` filter (whale-trades history, smart-money flows, explore) also accept `all`.
+
+## Capability matrix
+
+This mirrors the live [`GET /api/v1/platforms`](/api-reference/endpoint/get-platforms) response, which is the source of truth. Query it at runtime rather than hard-coding coverage.
+
+| Capability | Polymarket | Kalshi |
+|---|---|---|
+| Trader grade | Supported | Unsupported |
+| P&L | Supported | Partial |
+| Strategy classification | Supported | Unsupported |
+| Position timeline | Supported | Partial |
+| Whale signal | Supported | Unsupported |
+| Insider radar | Supported | Unsupported |
+| Market snapshot | Supported | Partial |
+
+`supported` means the feature is fully populated. `partial` means some fields are present but not all (Kalshi market snapshots carry last price but no order-book top-of-book, for example). `unsupported` means the feature does not apply to that platform and returns no data.
+
+## Polymarket-only features
+
+Two surfaces are Polymarket-only today, independent of any `platform` filter you pass:
+
+- **Whale trades** ([`/whale-trades`](/api-reference/endpoint/get-whale-trades), [`/whale-trades/history`](/api-reference/endpoint/get-whale-trades-history)). The whale-trade feed is built from Polymarket fills only. A `platform=kalshi` filter returns nothing.
+- **Large positions** ([`/large-positions`](/api-reference/endpoint/list-large-positions)). The large-position scanner runs against Polymarket markets only.
+
+Trader grades, strategy classification, and insider radar are also Polymarket-only, as the matrix shows.
+
+## What works on both
+
+These read paths return both Polymarket and Kalshi data:
+
+- Trader profiles and P&L ([`/trader/{address}`](/api-reference/endpoint/get-trader), [`/trader/{address}/pnl`](/api-reference/endpoint/get-trader-pnl)), with the per-platform caveats above.
+- Positions board ([`/positions`](/api-reference/endpoint/get-positions)).
+- Market intel and smart-money flows ([`/market/{condition_id}/intel`](/api-reference/endpoint/get-market-intel), [`/markets/smart-money-flows`](/api-reference/endpoint/smart-money-flows)).
+- Market search and explore ([`/markets/search`](/api-reference/endpoint/search-markets), [`/markets/explore`](/api-reference/endpoint/explore-markets)).
+
+When a field is thin or absent for Kalshi, [trust metadata](/concepts/trust-metadata) marks it (`unsupported` sources surface as `unavailable`), so you can detect coverage gaps in code instead of guessing.

--- a/concepts/signal-scoring.mdx
+++ b/concepts/signal-scoring.mdx
@@ -1,0 +1,84 @@
+---
+title: "Signal Scoring"
+description: "The smart-money and signal fields the API exposes, and what each one measures."
+---
+
+0xinsider scores activity so you can sort noise from signal. There are a few distinct scores, each answering a different question: how good is this trader, how strong is this single trade, and which way is smart money leaning on this market. This page names each field and what it measures, so you do not confuse one for another.
+
+## Trader quality: grade and score
+
+On every trader and leaderboard entry:
+
+- `grade`: a letter from `S` to `F`. The headline quality signal. See [Grades](/concepts/grades).
+- `score`: the numeric composite (0-100) behind the grade.
+- `streak_tier`: recent form, separate from the all-time grade. One of `hot`, `rising`, `neutral`, `cooling`, `cold`.
+- `rank`: position on the leaderboard.
+
+Grade is the long-run verdict. `streak_tier` is the trailing-form overlay: an A-grade trader can be `cooling`, and a B-grade trader can be `hot`.
+
+## Per-trade strength: signal_score
+
+Each [whale trade](/api-reference/endpoint/get-whale-trades) carries a `signal_score`: how strong that single fill is as a signal. Use it to rank a feed of trades, not to judge a trader overall.
+
+```json
+{
+  "object": "whale_trade",
+  "data": {
+    "id": "wt_...",
+    "size_usd": 48200.0,
+    "side": "BUY",
+    "price": 0.61,
+    "signal_score": 87.3,
+    "trader": { "address": "0x...", "grade": "S" },
+    "market": { "title": "...", "category": "politics" }
+  }
+}
+```
+
+## Market direction: smart money
+
+[Market intel](/api-reference/endpoint/get-market-intel) and [smart-money flows](/api-reference/endpoint/smart-money-flows) return a `smart_money` object. This is the canonical view of where graded money is flowing on a market:
+
+| Field | Meaning |
+|---|---|
+| `net_flow_usd` | Buy volume minus sell volume from graded traders, in USD. The headline number. |
+| `direction` | `YES` or `NO`: the side net flow is leaning toward. |
+| `buy_volume_usd` | Graded buy volume in the timeframe. |
+| `sell_volume_usd` | Graded sell volume in the timeframe. |
+| `whale_trade_count` | Number of qualifying whale trades. |
+| `top_positions` | The largest graded positions on the market, with trader and side. |
+
+```json
+{
+  "smart_money": {
+    "net_flow_usd": 312500.0,
+    "direction": "YES",
+    "buy_volume_usd": 540000.0,
+    "sell_volume_usd": 227500.0,
+    "whale_trade_count": 41
+  }
+}
+```
+
+`net_flow_usd` is the field to read for "which way is smart money leaning, and how hard." A large positive `net_flow_usd` with `direction: YES` means graded traders are buying YES.
+
+## Market discovery: smart_score
+
+The [explore](/api-reference/endpoint/explore-markets) feed ranks markets with a separate set of discovery aggregates:
+
+- `smart_score`: a per-market smart-money intensity used for ranking.
+- `smart_count`: how many graded traders are active on the market.
+- `smart_label`: a short human-readable tag.
+- `discover_score`: the backend-owned score behind the default hot sort.
+
+These power discovery sorting and are distinct from the `smart_money` flow object above. When you want a number to act on for a specific market, use `smart_money.net_flow_usd`. When you want to rank a list of markets to surface, use the explore `sort` parameter, which is driven by these scores.
+
+## Picking the right field
+
+| Question | Field |
+|---|---|
+| Is this trader worth following? | `grade` (and `score`) |
+| Is this trader hot right now? | `streak_tier` |
+| Is this single trade a strong signal? | `signal_score` |
+| Which way is smart money leaning on this market? | `smart_money.net_flow_usd` and `direction` |
+| Which markets should I surface? | explore `sort` (driven by `discover_score`) |

--- a/concepts/strategy-types.mdx
+++ b/concepts/strategy-types.mdx
@@ -1,0 +1,61 @@
+---
+title: "Strategy Types"
+description: "How 0xinsider classifies a trader's style, and the ten strategy types it assigns."
+---
+
+0xinsider classifies each trader by how they trade, not just how well. A two-sided arbitrageur and a directional swing trader can both be S-grade, but you copy them differently. The strategy type tells you the style behind the track record.
+
+The classification is machine-derived from a trader's fill history. It is a label to filter and reason with, not a guarantee of future behavior.
+
+## The ten strategy types
+
+| Strategy type | What it describes |
+|---|---|
+| `arbitrageur` | Trades both sides to capture pricing gaps, often near-riskless. |
+| `market_maker` | Provides liquidity on both sides, earning the spread. |
+| `scalper` | Many small, fast trades for small per-trade edges. |
+| `algo_trader` | Systematic, high-frequency patterns consistent with automation. |
+| `accumulator` | Builds large positions over time, usually on one side. |
+| `swing_trader` | Holds directional positions across days, not minutes. |
+| `event_driven` | Concentrates around specific events or resolutions. |
+| `momentum` | Follows price and flow, adding as a move continues. |
+| `directional` | Takes a clear side on an outcome and holds it. |
+| `speculator` | Opportunistic, mixed style with no single dominant pattern. |
+
+## Where it appears
+
+The classification shows up in two places:
+
+**On a trader profile**, via [`expand=strategy`](/concepts/expand):
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/trader/0x204f...?expand=strategy"
+```
+
+```json
+{
+  "strategy": {
+    "strategy_type": "swing_trader",
+    "description": "Directional trader",
+    "confidence": null
+  }
+}
+```
+
+`strategy_type` is the label. `description` is an optional human-readable note (present for some types, null for others). `confidence` is reserved and currently returns `null`.
+
+**As a leaderboard filter.** Pass `strategy` to [`GET /api/v1/leaderboard`](/api-reference/endpoint/get-leaderboard) to rank only one style:
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/leaderboard?strategy=arbitrageur&limit=20"
+```
+
+Leaderboard entries also carry a `strategy_type` field directly, so you can read the style without an extra expand.
+
+## Notes
+
+- The `strategy_type` value is the ML classifier's output. New labels can be added over time, so treat the field as a string and match against the ten values above rather than assuming a fixed closed set forever.
+- Strategy classification is Polymarket-only. See [Platforms](/concepts/platforms).
+- A trader with too little history may have no classification yet; the `strategy` object is absent until enough fills exist to classify.

--- a/concepts/trust-metadata.mdx
+++ b/concepts/trust-metadata.mdx
@@ -1,0 +1,117 @@
+---
+title: "Trust Metadata"
+description: "Every derived field can tell you where it came from, how fresh it is, and whether it was reconciled against the provider."
+---
+
+Most APIs hand you a number and leave you to guess whether it is live, cached, or stale. 0xinsider can tell you. Ask for trust metadata and every covered field comes with its own provenance: the source it came from, how fresh it is, whether it was reconciled against the on-chain or provider truth, and whether the value is complete.
+
+This matters when you act on the data. A P&L figure that is `fresh` and `provider_backed` is safe to trade on. The same figure marked `stale` and `db_mirror` is a hint, not a fact.
+
+## How to get it
+
+Trust metadata is opt-in, because it adds weight to the response. Pass `expand=trust`:
+
+```bash
+# Field-level trust on a trader profile
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/trader/0x204f72f35326db932158cba6adff0b9a1da95e14?expand=trust"
+
+# Trust on a market snapshot (price and spread)
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/market/0x123.../snapshot?expand=trust"
+```
+
+Without `expand=trust`, the `trust` block is omitted. See [Expanding responses](/concepts/expand) for the full list of expand options.
+
+## The shape
+
+Each covered field maps to a `TrustMetadata` object with four dimensions:
+
+```json
+{
+  "trust": {
+    "pnl": {
+      "source": { "kind": "provider", "owner": "polymarket", "field": "cashPnl" },
+      "freshness": { "status": "fresh", "as_of": "2026-06-17T14:28:20Z", "max_age_s": 300 },
+      "reconciliation": { "status": "provider_backed", "detail": "from /positions" },
+      "completeness": { "status": "complete", "detail": null }
+    }
+  }
+}
+```
+
+On a trader profile, `trust` carries one entry per derived field (P&L, strategy, category strengths, quant metrics, last-active, and more). On a market snapshot, it covers `current_price` and `spread_bps`.
+
+## The four dimensions
+
+### source
+
+Where the value originated.
+
+| Value | Meaning |
+|---|---|
+| `provider` | Read directly from Polymarket or Kalshi. |
+| `database` | Stored in our database, mirrored from a provider read. |
+| `cache` | Served from a short-lived cache. |
+| `computed` | Derived by 0xinsider from underlying rows. |
+| `client_input` | Echoed back from your request. |
+| `unavailable` | No source could supply this field. |
+
+The `owner` and `field` tell you the upstream provider and the exact provider field name when `kind` is `provider`.
+
+### freshness
+
+How current the value is.
+
+| Value | Meaning |
+|---|---|
+| `fresh` | Within its expected age window. |
+| `refreshing` | A newer value is being fetched right now. |
+| `stale` | Past its freshness window. Treat as a hint. |
+| `not_live` | Point-in-time value that is not meant to update (a resolved market). |
+| `unknown` | Freshness could not be determined. |
+| `unavailable` | No freshness signal exists. |
+
+`as_of` is the timestamp the value was last known good. `max_age_s` is the window after which `fresh` becomes `stale`.
+
+### reconciliation
+
+Whether the value was checked against the provider's own truth.
+
+| Value | Meaning |
+|---|---|
+| `provider_backed` | Matches a direct provider read. |
+| `db_mirror` | Mirrored from an earlier provider read, not re-checked this request. |
+| `computed` | Derived locally, no single provider field to reconcile against. |
+| `partial` | Reconciled against some but not all underlying sources. |
+| `not_applicable` | Reconciliation does not apply to this field. |
+| `unavailable` | Could not reconcile. |
+
+### completeness
+
+Whether the value reflects the full picture.
+
+| Value | Meaning |
+|---|---|
+| `complete` | Computed over the full available history. |
+| `partial` | Computed over a subset (an in-progress sync, a bounded window). |
+| `not_computed` | The field was not computed for this response. |
+| `not_applicable` | Completeness does not apply. |
+| `unavailable` | Could not determine completeness. |
+
+`detail` carries a short human-readable note when the status needs one (for example, why a value is `partial`).
+
+## Using it in practice
+
+A simple rule covers most integrations: act on values that are `fresh` and either `provider_backed` or `db_mirror`, and treat anything `stale`, `partial`, or `unavailable` as a softer signal.
+
+```python
+def is_actionable(field_trust):
+    return (
+        field_trust["freshness"]["status"] == "fresh"
+        and field_trust["completeness"]["status"] == "complete"
+        and field_trust["reconciliation"]["status"] in ("provider_backed", "db_mirror")
+    )
+```
+
+When a trader is mid-sync, expect `partial` completeness on history-derived fields until the sync finishes. See [Platforms](/concepts/platforms) for which fields carry meaningful trust on Kalshi, where coverage is thinner than Polymarket.

--- a/docs.json
+++ b/docs.json
@@ -26,11 +26,22 @@
             ]
           },
           {
+            "group": "Guides",
+            "pages": [
+              "guides/webhooks"
+            ]
+          },
+          {
             "group": "Concepts",
             "pages": [
               "concepts/grades",
+              "concepts/signal-scoring",
+              "concepts/strategy-types",
+              "concepts/platforms",
+              "concepts/trust-metadata",
               "concepts/pagination",
-              "concepts/number-formatting"
+              "concepts/number-formatting",
+              "concepts/expand"
             ]
           }
         ]
@@ -42,6 +53,12 @@
             "group": "Overview",
             "pages": [
               "api-reference/introduction"
+            ]
+          },
+          {
+            "group": "Objects",
+            "pages": [
+              "api-reference/objects"
             ]
           },
           {
@@ -143,6 +160,21 @@
               "api-reference/endpoint/health",
               "api-reference/endpoint/remote-mcp",
               "api-reference/endpoint/remote-mcp-stream"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Recipes",
+        "groups": [
+          {
+            "group": "Cookbook",
+            "pages": [
+              "recipes/copy-trade",
+              "recipes/insider-scanner",
+              "recipes/alert-bot",
+              "recipes/backtest",
+              "recipes/portfolio-tracker"
             ]
           }
         ]

--- a/guides/webhooks.mdx
+++ b/guides/webhooks.mdx
@@ -1,0 +1,232 @@
+---
+title: "Webhooks"
+description: "Receive whale-trade events at your own URL, verify the signature, and handle retries safely."
+---
+
+Webhooks push events to your server as they happen, so you do not have to poll. Register an HTTPS endpoint, verify it, and 0xinsider delivers a signed POST every time a subscribed event fires.
+
+Each delivery is signed with HMAC-SHA256. Verify the signature before you trust the body. The snippets below verify a real 0xinsider signature on the first try.
+
+## Event types
+
+| Event type | Status | Fires when |
+|---|---|---|
+| `whale_trades_inserted` | Live | One or more new whale trades are ingested. The payload carries the count. |
+| `live_sports_updated` | Reserved | Accepted on subscribe, not yet emitted. |
+| `whale_trader_synced` | Reserved | Accepted on subscribe, not yet emitted. |
+| `large_positions_updated` | Reserved | Accepted on subscribe, not yet emitted. |
+
+Today, `whale_trades_inserted` is the only event delivered. You can subscribe to the reserved types now; they will begin delivering when emission ships, with no change to your verification code.
+
+A `whale_trades_inserted` delivery body:
+
+```json
+{
+  "id": "evt_whale_trades_inserted_1718634500123_7",
+  "type": "whale_trades_inserted",
+  "created_at": "2026-06-17T14:28:20Z",
+  "data": { "count": 7 }
+}
+```
+
+The event signals that new trades landed. Fetch the detail from [`GET /api/v1/whale-trades`](/api-reference/endpoint/get-whale-trades) (newest first) when you receive it.
+
+## Set up an endpoint
+
+### 1. Create it
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Production webhook",
+    "url": "https://api.yourapp.com/webhooks/0xinsider",
+    "event_types": ["whale_trades_inserted"]
+  }' \
+  "https://api.0xinsider.com/api/v1/webhooks"
+```
+
+The URL must be `https` and publicly routable. Localhost and private IP literals are rejected. You can register up to 10 endpoints.
+
+The create response includes two values you only see once:
+
+```json
+{
+  "object": "webhook",
+  "data": {
+    "id": 42,
+    "object": "webhook",
+    "name": "Production webhook",
+    "url": "https://api.yourapp.com/webhooks/0xinsider",
+    "event_types": ["whale_trades_inserted"],
+    "status": "pending_verification",
+    "signing_secret": "whsec_8tF...redacted",
+    "verification": {
+      "token": "whv_3c2e...redacted",
+      "expires_at": "2026-06-18T14:28:20Z"
+    }
+  }
+}
+```
+
+Store the `signing_secret` now. It is shown only on create and on [rotate-secret](/api-reference/endpoint/rotate-webhook-secret), never on a later read. The webhook `id` is an integer.
+
+### 2. Verify it
+
+A new endpoint starts in `pending_verification` and receives nothing until you verify it. Prove you control the secret by sending the verification token back within 24 hours:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"verification_token": "whv_3c2e...redacted"}' \
+  "https://api.0xinsider.com/api/v1/webhooks/42/verify"
+```
+
+On success the endpoint flips to `active` and deliveries begin. Verification does not send a test delivery; it activates the endpoint by matching the token from create.
+
+## Delivery format
+
+Every delivery is an HTTP POST with a JSON body and these headers:
+
+| Header | Value |
+|---|---|
+| `x-0xinsider-signature` | `v1=<hex>`: the HMAC signature. |
+| `x-0xinsider-timestamp` | Unix seconds when the delivery was signed. |
+| `x-0xinsider-event-id` | Stable per-event id. Dedupe on this. |
+| `x-0xinsider-event-type` | The event type. |
+| `x-0xinsider-delivery-id` | Id of this delivery attempt's row. |
+| `x-0xinsider-delivery-attempt` | Attempt counter, starting at 1. |
+
+## Verify the signature
+
+The signature is computed over the timestamp and the raw request body, joined by a literal `.`:
+
+```
+signature = "v1=" + hex( HMAC_SHA256( signing_secret, timestamp + "." + raw_body ) )
+```
+
+Two rules make or break verification:
+
+- Use the **raw request body bytes**, exactly as received. Do not parse and re-serialize the JSON first; whitespace and key order would change and the HMAC would not match.
+- Use the `signing_secret` string as the HMAC key, the full `whsec_...` value.
+
+Reject the delivery if the signature does not match, or if `x-0xinsider-timestamp` is more than 5 minutes from your clock (a replay guard you enforce on your side).
+
+<CodeGroup>
+```javascript Node (Express)
+import express from "express";
+import crypto from "node:crypto";
+
+const SECRET = process.env.OXINSIDER_WEBHOOK_SECRET;
+const TOLERANCE_SECONDS = 300;
+
+function verify(rawBody, signatureHeader, timestampHeader) {
+  const ts = Number(timestampHeader);
+  if (!Number.isFinite(ts)) return false;
+  if (Math.abs(Date.now() / 1000 - ts) > TOLERANCE_SECONDS) return false;
+
+  const expected =
+    "v1=" +
+    crypto
+      .createHmac("sha256", SECRET)
+      .update(`${timestampHeader}.${rawBody}`)
+      .digest("hex");
+
+  // The header may carry a comma-separated list; accept any match.
+  return signatureHeader
+    .split(",")
+    .map((s) => s.trim())
+    .some((candidate) => {
+      const a = Buffer.from(candidate);
+      const b = Buffer.from(expected);
+      return a.length === b.length && crypto.timingSafeEqual(a, b);
+    });
+}
+
+const app = express();
+
+// Capture the raw body; do NOT use a JSON parser before verifying.
+app.post(
+  "/webhooks/0xinsider",
+  express.raw({ type: "application/json" }),
+  (req, res) => {
+    const rawBody = req.body.toString("utf8");
+    const ok = verify(
+      rawBody,
+      req.get("x-0xinsider-signature") ?? "",
+      req.get("x-0xinsider-timestamp") ?? ""
+    );
+    if (!ok) return res.status(400).send("bad signature");
+
+    const event = JSON.parse(rawBody);
+    // Dedupe on event.id, then ACK fast and process async.
+    res.status(200).send("ok");
+    handleEvent(event).catch(console.error);
+  }
+);
+```
+
+```python Python (Flask)
+import hashlib
+import hmac
+import time
+from flask import Flask, request
+
+SECRET = os.environ["OXINSIDER_WEBHOOK_SECRET"].encode()
+TOLERANCE_SECONDS = 300
+
+def verify(raw_body: bytes, signature_header: str, timestamp_header: str) -> bool:
+    try:
+        ts = int(timestamp_header)
+    except (TypeError, ValueError):
+        return False
+    if abs(time.time() - ts) > TOLERANCE_SECONDS:
+        return False
+
+    signed = f"{timestamp_header}.".encode() + raw_body
+    expected = "v1=" + hmac.new(SECRET, signed, hashlib.sha256).hexdigest()
+
+    # The header may carry a comma-separated list; accept any match.
+    return any(
+        hmac.compare_digest(part.strip(), expected)
+        for part in signature_header.split(",")
+    )
+
+app = Flask(__name__)
+
+@app.post("/webhooks/0xinsider")
+def receive():
+    raw_body = request.get_data()  # raw bytes, before any JSON parse
+    ok = verify(
+        raw_body,
+        request.headers.get("x-0xinsider-signature", ""),
+        request.headers.get("x-0xinsider-timestamp", ""),
+    )
+    if not ok:
+        return "bad signature", 400
+
+    event = request.get_json()
+    # Dedupe on event["id"], then return 200 quickly.
+    return "ok", 200
+```
+</CodeGroup>
+
+## Retries and idempotency
+
+Respond with any `2xx` to mark a delivery successful. Anything else, or a timeout, counts as a failure.
+
+- **Timeout**: respond within 15 seconds. ACK fast, then do slow work asynchronously.
+- **Retries**: a failed delivery is retried up to 8 attempts, roughly a minute apart. After the last attempt it is moved to a dead-letter state and not retried.
+- **Idempotency**: the same logical event always carries the same `x-0xinsider-event-id`. A retried delivery reuses its `x-0xinsider-delivery-id` and increments `x-0xinsider-delivery-attempt`. Dedupe your processing on `x-0xinsider-event-id` so a redelivery does not double-handle.
+
+## Manage and rotate
+
+- [Update](/api-reference/endpoint/update-webhook) the URL, events, or enabled flag. Changing the URL drops the endpoint back to `pending_verification` and issues a fresh verification token.
+- [Rotate the secret](/api-reference/endpoint/rotate-webhook-secret) if it leaks. The old secret stops working the moment the call returns, so deploy the new one to your verifier first.
+- [Disable](/api-reference/endpoint/delete-webhook) to stop deliveries without losing the registration, or set `enabled: false` via update.
+
+## Don't have a public endpoint yet?
+
+Poll instead. [`GET /api/v1/whale-trades`](/api-reference/endpoint/get-whale-trades) is the live feed, [`GET /api/v1/events/feed/since`](/api-reference/endpoint/get-event-replay-since) is a durable cursor-based replay of the same events, and [`GET /api/v1/stream`](/api-reference/endpoint/get-stream) is a real-time SSE stream. The [alert bot recipe](/recipes/alert-bot) shows both the webhook and the polling path.

--- a/recipes/alert-bot.mdx
+++ b/recipes/alert-bot.mdx
@@ -1,0 +1,81 @@
+---
+title: "Alert bot"
+description: "Get notified on large trades, by webhook push or by polling, then post to Slack or Discord."
+---
+
+Goal: fire an alert when a large trade lands. There are two ways to receive the events: a webhook push (no infrastructure to poll, needs a public URL) or polling (works anywhere). Pick one.
+
+All requests need a Bearer key. See [Authentication](/authentication).
+
+## Option A: webhook push
+
+Register an endpoint on `whale_trades_inserted` and verify it. Full setup, signature verification, and retry handling are in the [Webhooks guide](/guides/webhooks). The event tells you new trades landed; fetch the detail and filter:
+
+```python
+# Inside your verified webhook handler, after signature check:
+def handle_event(event):
+    if event["type"] != "whale_trades_inserted":
+        return
+    feed = requests.get(
+        f"{BASE}/whale-trades",
+        params={"min_grade": "A", "min_size": 25000, "limit": 50},
+        headers=H,
+    ).json()
+    for tr in feed["data"]:
+        post_alert(tr)
+```
+
+Webhook events are coarse: one event per ingest batch, no per-market or per-grade server-side filter. Apply your `min_size` and `min_grade` filter on the fetched trades.
+
+## Option B: polling
+
+No public URL required. Walk the durable replay feed with a cursor so you never miss or double-count an event across restarts:
+
+```python
+import os, time, requests
+
+BASE = "https://api.0xinsider.com/api/v1"
+H = {"Authorization": f"Bearer {os.environ['OXINSIDER_API_KEY']}"}
+
+cursor = load_cursor()  # persist this between runs
+
+while True:
+    params = {"limit": 100}
+    if cursor:
+        params["cursor"] = cursor
+    resp = requests.get(f"{BASE}/events/feed/since", params=params, headers=H).json()
+
+    for ev in resp["data"]:
+        if ev["type"] == "whale_trades_inserted":
+            check_new_trades()
+    if resp.get("next_cursor"):
+        cursor = resp["next_cursor"]
+        save_cursor(cursor)
+    if not resp.get("has_more"):
+        time.sleep(15)
+```
+
+For the live feed directly, poll [`GET /api/v1/whale-trades`](/api-reference/endpoint/get-whale-trades) with your filters, or open the [SSE stream](/api-reference/endpoint/get-stream) for real-time push without a webhook.
+
+## Post the alert
+
+```python
+def post_alert(tr):
+    msg = (
+        f'{tr["trader"]["grade"]}-grade {tr["trader"]["username"] or "wallet"} '
+        f'{tr["side"]} ${tr["size_usd"]:,.0f} @ {tr["price"]} '
+        f'on {tr["market"]["title"]} (signal {tr["signal_score"]:.0f})'
+    )
+    requests.post(os.environ["SLACK_WEBHOOK_URL"], json={"text": msg})
+```
+
+## Which to choose
+
+| | Webhook push | Polling |
+|---|---|---|
+| Public HTTPS URL | Required | Not required |
+| Latency | Lowest | Poll interval |
+| Missed events on downtime | Retried up to 8 times | Caught up via cursor |
+| Filtering | After receipt | Query params (whale-trades) |
+
+Webhooks win when you have a server and want the lowest latency. Polling the cursor feed wins for a script, a notebook, or anything behind NAT.

--- a/recipes/backtest.mdx
+++ b/recipes/backtest.mdx
@@ -1,0 +1,68 @@
+---
+title: "Backtest a trader"
+description: "Pull a wallet's historical P&L series and fill history to evaluate it before you follow."
+---
+
+Goal: judge a trader on history, not vibes. This recipe pulls a wallet's P&L time series and its historical fills so you can reconstruct how it actually performed.
+
+All requests need a Bearer key. See [Authentication](/authentication).
+
+## 1. The P&L series
+
+[`GET /api/v1/trader/{address}/pnl`](/api-reference/endpoint/get-trader-pnl) returns the daily series plus rolled-up stats and drawdowns:
+
+```python
+import os, requests
+
+BASE = "https://api.0xinsider.com/api/v1"
+H = {"Authorization": f"Bearer {os.environ['OXINSIDER_API_KEY']}"}
+
+addr = "0x204f72f35326db932158cba6adff0b9a1da95e14"
+pnl = requests.get(f"{BASE}/trader/{addr}/pnl", headers=H).json()["data"]
+
+print("all-time:", pnl["stats"]["all"])
+print("last 30d:", pnl["stats"]["d30"])
+
+for entry in pnl["entries"][-10:]:
+    print(entry["date"], entry["cumulative_profit"], entry["daily_change"])
+```
+
+`entries` is the daily series (`date`, `total_pnl`, `cumulative_profit`, `daily_change`, `markets_traded`, `total_volume`). `monthly`, `year_totals`, and `drawdown` give you the longer view. `stats` is pre-rolled for `all`, `d90`, `d30`, and `d7` windows.
+
+## 2. The fill history
+
+For the trades behind the curve, replay this wallet's historical whale trades over a date range with [`GET /api/v1/whale-trades/history`](/api-reference/endpoint/get-whale-trades-history). It accepts a `trader` filter and a `from`/`to` window:
+
+```python
+fills = requests.get(
+    f"{BASE}/whale-trades/history",
+    params={
+        "trader": addr,
+        "from": "2026-01-01T00:00:00Z",
+        "to": "2026-06-01T00:00:00Z",
+        "limit": 100,
+    },
+    headers=H,
+).json()
+
+for tr in fills["data"]:
+    print(tr["traded_at"], tr["side"], tr["size_usd"], "@", tr["price"], tr["market"]["title"])
+```
+
+Page through with the cursor (see [Pagination](/concepts/pagination)) to pull the full window.
+
+## 3. Per-market entries and exits
+
+To reconstruct cost basis on a single market, use the [position timeline](/api-reference/endpoint/get-trader-position-timeline) with a `condition_id`. It gives ordered buys and sells with the running average price:
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/traders/0x204f.../position-timeline?condition_id=0x123..."
+```
+
+## Scope and limits
+
+- The whale-trade history covers fills above the whale threshold. Small trades below it are not in this feed; use the aggregated P&L series for the complete return picture.
+- There is no single "closed positions" list endpoint. Reconstruct closed lots from the per-market timelines, or rely on the `pnl` series for net performance.
+- [`/trader/{address}/export`](/api-reference/endpoint/get-trader-export-snapshot) returns export metadata (ranges, counts, completeness), not raw rows.
+- Backtest history is Polymarket-only; see [Platforms](/concepts/platforms).

--- a/recipes/copy-trade.mdx
+++ b/recipes/copy-trade.mdx
@@ -1,0 +1,85 @@
+---
+title: "Copy-trade signals"
+description: "Build a follow list of top traders, then watch for their new activity."
+---
+
+Goal: pick the best wallets, then get notified when they make a move. This recipe builds a follow list from the leaderboard and watches the whale-trade feed for activity from anyone on it.
+
+All requests need a Bearer key. See [Authentication](/authentication).
+
+## 1. Build the follow list
+
+Pull the leaderboard and keep the top grades. The leaderboard ranks S, A, and B already; filter to S and A in code (there is no `min_grade` param on this endpoint).
+
+```python
+import os, requests
+
+BASE = "https://api.0xinsider.com/api/v1"
+H = {"Authorization": f"Bearer {os.environ['OXINSIDER_API_KEY']}"}
+
+leaders = requests.get(f"{BASE}/leaderboard", params={"limit": 100}, headers=H).json()
+follow = [t["address"] for t in leaders["data"] if t["grade"] in ("S", "A")]
+```
+
+Narrow by style if you want to copy one approach. Pass `strategy` to rank a single [strategy type](/concepts/strategy-types):
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/leaderboard?strategy=swing_trader&limit=50"
+```
+
+## 2. Enrich the list
+
+Pull full profiles for the whole set in one call with [batch](/api-reference/endpoint/batch-get-traders). Add `expand` for strategy and trust if you want to weight them:
+
+```python
+batch = requests.post(
+    f"{BASE}/traders/batch",
+    json={"traders": follow, "expand": ["strategy", "trust"]},
+    headers=H,
+).json()
+
+for item in batch["data"]:
+    if item["status"] == "ok":
+        t = item["data"]
+        print(t["username"], t["grade"], t["pnl"]["total"], t.get("strategy", {}).get("strategy_type"))
+```
+
+## 3. Watch for new activity
+
+The whale-trade feed is the live signal. Poll it filtered to high grades, then keep only trades from wallets on your follow list:
+
+```python
+follow_set = set(a.lower() for a in follow)
+
+def new_moves(min_size=10000):
+    feed = requests.get(
+        f"{BASE}/whale-trades",
+        params={"min_grade": "A", "min_size": min_size, "limit": 100},
+        headers=H,
+    ).json()
+    return [
+        tr for tr in feed["data"]
+        if tr["trader"]["address"].lower() in follow_set
+    ]
+
+for tr in new_moves():
+    print(f'{tr["trader"]["username"]} {tr["side"]} ${tr["size_usd"]:,.0f} @ {tr["price"]} on {tr["market"]["title"]}')
+```
+
+For a push instead of a poll, register a webhook on `whale_trades_inserted` and apply the same follow-list filter when each event arrives. See [Webhooks](/guides/webhooks).
+
+## 4. Drill into one market
+
+When a followed trader enters a market you care about, read their full entry and exit history on that market with the [position timeline](/api-reference/endpoint/get-trader-position-timeline). It takes the trader and a `condition_id`:
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/traders/0x204f.../position-timeline?condition_id=0x123..."
+```
+
+Each event is a buy or sell with price, notional, and the running average price.
+
+## What this recipe does not do
+
+There is no per-trader open-positions endpoint and no per-trader push channel. "Watch" means polling the whale-trade feed (or the `whale_trades_inserted` webhook) and matching addresses, plus the per-market timeline once you know the `condition_id`. Plan your loop around the feed, not around a subscription to a single wallet.

--- a/recipes/insider-scanner.mdx
+++ b/recipes/insider-scanner.mdx
@@ -1,0 +1,70 @@
+---
+title: "Insider scanner"
+description: "Surface suspicious early activity, then confirm it with trader and market context."
+---
+
+Goal: catch wallets that look like they knew something, fresh wallets taking large, well-timed positions right before a move. The [insider radar](/api-reference/endpoint/get-insider-radar) does the detection; this recipe drills into each flag for context.
+
+All requests need a Bearer key. See [Authentication](/authentication). Insider radar is Polymarket-only; see [Platforms](/concepts/platforms).
+
+## 1. Pull the flags
+
+Each flag has a `suspicion_score` and a `severity` of `flag` or `watch` (`watch` is the higher-conviction tier). Filter to the strong ones:
+
+```python
+import os, requests
+
+BASE = "https://api.0xinsider.com/api/v1"
+H = {"Authorization": f"Bearer {os.environ['OXINSIDER_API_KEY']}"}
+
+flags = requests.get(
+    f"{BASE}/insider-radar",
+    params={"severity": "watch", "min_suspicion": 70, "limit": 50},
+    headers=H,
+).json()
+
+for f in flags["data"]:
+    s = f["scores"]
+    print(f'{f["suspicion_score"]:.0f} {f["trader"]["username"] or f["trader"]["address"][:10]} '
+          f'timing={s["timing"]:.0f} edge={s["edge"]:.0f} size={s["size"]:.0f} fresh={s["fresh_wallet"]:.0f}')
+```
+
+The `scores` object breaks the suspicion down into `timing`, `edge`, `size`, and `fresh_wallet` components, so you can see why a wallet was flagged.
+
+## 2. Open one flag
+
+Fetch the full flag for its evidence and the linked trader and market:
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/insider-radar/flg_..."
+```
+
+## 3. Confirm with context
+
+A flag is a lead. Confirm it with two reads:
+
+```python
+flag = flags["data"][0]
+addr = flag["trader"]["address"]
+cond = flag["market"]["condition_id"]
+
+trader = requests.get(f"{BASE}/trader/{addr}", headers=H).json()["data"]
+intel = requests.get(f"{BASE}/market/{cond}/intel", headers=H).json()["data"]
+
+print("trader grade:", trader["grade"], "| markets traded:", trader["stats"]["markets_traded"])
+print("smart money net flow:", intel["smart_money"]["net_flow_usd"], intel["smart_money"]["direction"])
+```
+
+A fresh wallet with a high `size` score, taking the same side smart money is leaning, is the pattern worth a closer look.
+
+## 4. Cross-check size
+
+Confirm the position is large in absolute terms with [large positions](/api-reference/endpoint/list-large-positions), filtered to the same market:
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/large-positions?condition_id=0x123...&min_size=25000"
+```
+
+`Position.trader.is_new_wallet` and `wallet_age_days` are the fresh-wallet signals to confirm the radar's `fresh_wallet` score independently.

--- a/recipes/portfolio-tracker.mdx
+++ b/recipes/portfolio-tracker.mdx
@@ -1,0 +1,81 @@
+---
+title: "Portfolio tracker"
+description: "Track a set of wallets' P&L and current positions on one dashboard."
+---
+
+Goal: keep a dashboard of the wallets you care about, their aggregate P&L and their live positions. This recipe uses the batch endpoint for the numbers and the positions board for current holdings.
+
+All requests need a Bearer key. See [Authentication](/authentication).
+
+## 1. Aggregate P&L in one call
+
+[`POST /api/v1/traders/batch`](/api-reference/endpoint/batch-get-traders) takes up to 25 wallets (by address or `trd_` id) and returns a full profile for each. This is the clean path for portfolio totals:
+
+```python
+import os, requests
+
+BASE = "https://api.0xinsider.com/api/v1"
+H = {"Authorization": f"Bearer {os.environ['OXINSIDER_API_KEY']}"}
+
+wallets = ["0x204f...", "0x863...", "0x885..."]
+batch = requests.post(
+    f"{BASE}/traders/batch",
+    json={"traders": wallets, "expand": ["trust"]},
+    headers=H,
+).json()
+
+book = []
+for item in batch["data"]:
+    if item["status"] == "ok":
+        t = item["data"]
+        book.append({
+            "wallet": t["address"],
+            "name": t["username"],
+            "grade": t["grade"],
+            "total_pnl": t["pnl"]["total"],
+            "unrealized": t["pnl"]["unrealized"],
+            "last_30d": t["pnl"]["last_30d"],
+        })
+    else:
+        print("failed:", item["input"], item["error"]["message"])
+
+print("portfolio P&L:", sum(b["total_pnl"] for b in book))
+```
+
+Each item reports its own `status` (`ok` or `error`), so one bad wallet does not fail the batch. For more than 25 wallets, split into batches of 25.
+
+## 2. Current positions
+
+There is no per-trader open-positions endpoint. The [positions board](/api-reference/endpoint/get-positions) is global, filterable by grade, size, side, and category, but not by wallet, so scan it and intersect on your wallet set:
+
+```python
+wallet_set = set(w.lower() for w in wallets)
+
+def positions_for_book(min_size=1000):
+    held, cursor = [], None
+    while True:
+        params = {"limit": 100, "min_size": min_size}
+        if cursor:
+            params["cursor"] = cursor
+        page = requests.get(f"{BASE}/positions", params=params, headers=H).json()
+        held += [p for p in page["data"] if p["trader"]["address"].lower() in wallet_set]
+        if not page.get("has_more"):
+            return held
+        cursor = page["next_cursor"]
+
+for p in positions_for_book():
+    print(p["trader"]["address"][:10], p["market"]["outcome_label"],
+          p["side"], f'${p["current_value_usd"]:,.0f}', p["freshness"])
+```
+
+Check each position's `freshness` ([trust](/concepts/trust-metadata)) before you trust the value. `fresh` is live; `stale` means the provider read is past its window.
+
+## 3. Refresh cadence
+
+- Pull batch P&L on a slow loop (minutes). It is the heavier call.
+- Scan the positions board on whatever cadence your dashboard needs; it is cursor-paginated and cheap per page.
+- For a specific wallet-and-market pair, the [position timeline](/api-reference/endpoint/get-trader-position-timeline) gives exact entry and exit events.
+
+## Scope and limits
+
+Tracking N specific wallets means scanning the global positions board and filtering, because there is no "open positions for wallet X" endpoint. If your set is large, raise `min_size` so the board scan stays cheap and you only track meaningful positions. Aggregate P&L via batch is exact; the live position list is a board intersection.

--- a/scripts/generate-objects-reference.py
+++ b/scripts/generate-objects-reference.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Generate the Objects reference MDX from the OpenAPI component schemas.
+
+The page at `api-reference/objects.mdx` is GENERATED from
+`api-reference/openapi.json` (`components.schemas`) so it can never drift from
+the spec. Do not hand-edit the output; edit this script or the spec and
+re-run (#4972):
+
+    python3 scripts/generate-objects-reference.py
+
+The docs spec is itself a synced copy of the canonical app spec, enforced by
+`check-spec-sync.py`. So this page tracks the live API contract end to end.
+"""
+import json
+import os
+import sys
+
+SPEC = "api-reference/openapi.json"
+OUT = "api-reference/objects.mdx"
+
+HEADER = """---
+title: "Objects"
+description: "Every object the API returns, generated from the OpenAPI schema."
+---
+
+{/* GENERATED FILE -- do not edit by hand. Run scripts/generate-objects-reference.py. */}
+
+These are the objects the API returns, generated directly from the OpenAPI
+schema so they always match the live contract. Each table lists a field, its
+type, whether it is always present, and what it means.
+
+"""
+
+
+def ref_name(ref):
+    return ref.rsplit("/", 1)[-1]
+
+
+def type_label(node):
+    """Render a property's type as a short markdown string."""
+    if node is None:
+        return "any"
+    if "$ref" in node:
+        return f"`{ref_name(node['$ref'])}`"
+    if "oneOf" in node:
+        return " or ".join(type_label(n) for n in node["oneOf"])
+    if "enum" in node:
+        vals = " \\| ".join(f"`{v}`" for v in node["enum"])
+        return vals
+    t = node.get("type")
+    if t == "array":
+        return f"array of {type_label(node.get('items'))}"
+    if t == "object":
+        ap = node.get("additionalProperties")
+        if isinstance(ap, dict):
+            return f"map of {type_label(ap)}"
+        return "object"
+    if isinstance(t, list):
+        return " \\| ".join(t)
+    return t or "object"
+
+
+def escape(text):
+    return (text or "").replace("|", "\\|").replace("\n", " ").strip()
+
+
+def render_schema(name, schema):
+    lines = [f"## {name}", ""]
+    desc = schema.get("description")
+    if desc:
+        lines += [escape(desc), ""]
+
+    if "oneOf" in schema:
+        variants = ", ".join(f"`{ref_name(n['$ref'])}`" for n in schema["oneOf"] if "$ref" in n)
+        disc = schema.get("discriminator", {}).get("propertyName")
+        lines.append(f"One of: {variants}." + (f" Discriminated by `{disc}`." if disc else ""))
+        lines.append("")
+        return "\n".join(lines)
+
+    if "enum" in schema and "properties" not in schema:
+        vals = ", ".join(f"`{v}`" for v in schema["enum"])
+        lines += [f"String enum: {vals}.", ""]
+        return "\n".join(lines)
+
+    props = schema.get("properties")
+    if not props:
+        lines += ["_No documented fields._", ""]
+        return "\n".join(lines)
+
+    required = set(schema.get("required", []))
+    lines += ["| Field | Type | Required | Description |", "|---|---|---|---|"]
+    for field, node in props.items():
+        req = "Yes" if field in required else "No"
+        lines.append(
+            f"| `{field}` | {type_label(node)} | {req} | {escape(node.get('description'))} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    if not os.path.exists(SPEC):
+        print(f"spec not found: {SPEC}", file=sys.stderr)
+        return 1
+    with open(SPEC, encoding="utf-8") as handle:
+        spec = json.load(handle)
+    schemas = spec.get("components", {}).get("schemas", {})
+    if not schemas:
+        print("no component schemas found", file=sys.stderr)
+        return 1
+
+    body = [HEADER]
+    for name in sorted(schemas):
+        body.append(render_schema(name, schemas[name]))
+    with open(OUT, "w", encoding="utf-8") as handle:
+        handle.write("\n".join(body).rstrip() + "\n")
+    print(f"wrote {OUT} ({len(schemas)} schemas)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-webhook-snippets.mjs
+++ b/scripts/verify-webhook-snippets.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// Validates the Node webhook-verification snippet in guides/webhooks.mdx against
+// a signature produced by the documented scheme:
+//   v1=hex(HMAC_SHA256(secret, `${timestamp}.${rawBody}`))
+// Asserts a valid signature verifies and a tampered body is rejected. Exits
+// non-zero on any failure so CI catches a drifted snippet (#4972).
+import crypto from "node:crypto";
+
+const SECRET = "whsec_test_secret_value";
+const TOLERANCE_SECONDS = 300;
+
+// --- The verify function from guides/webhooks.mdx (keep in sync) ---
+function verify(rawBody, signatureHeader, timestampHeader) {
+  const ts = Number(timestampHeader);
+  if (!Number.isFinite(ts)) return false;
+  if (Math.abs(Date.now() / 1000 - ts) > TOLERANCE_SECONDS) return false;
+
+  const expected =
+    "v1=" +
+    crypto
+      .createHmac("sha256", SECRET)
+      .update(`${timestampHeader}.${rawBody}`)
+      .digest("hex");
+
+  return signatureHeader
+    .split(",")
+    .map((s) => s.trim())
+    .some((candidate) => {
+      const a = Buffer.from(candidate);
+      const b = Buffer.from(expected);
+      return a.length === b.length && crypto.timingSafeEqual(a, b);
+    });
+}
+
+// --- Reproduce the server signing scheme to produce a real signature ---
+function sign(secret, timestamp, rawBody) {
+  return (
+    "v1=" +
+    crypto.createHmac("sha256", secret).update(`${timestamp}.${rawBody}`).digest("hex")
+  );
+}
+
+const ts = String(Math.floor(Date.now() / 1000));
+const body = JSON.stringify({
+  id: "evt_whale_trades_inserted_1718634500123_7",
+  type: "whale_trades_inserted",
+  created_at: "2026-06-17T14:28:20Z",
+  data: { count: 7 },
+});
+const sig = sign(SECRET, ts, body);
+
+let failed = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failed += 1;
+  }
+}
+
+check("valid signature verifies", verify(body, sig, ts) === true);
+check("tampered body is rejected", verify(body + " ", sig, ts) === false);
+check("wrong secret is rejected", verify(body, sign("whsec_other", ts, body), ts) === false);
+check("stale timestamp is rejected", verify(body, sign(SECRET, "1000000000", body), "1000000000") === false);
+check(
+  "comma-joined header still matches",
+  verify(body, `v0=deadbeef, ${sig}`, ts) === true
+);
+
+if (failed > 0) {
+  console.error(`\n${failed} webhook snippet check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall webhook snippet checks passed (Node)");

--- a/scripts/verify-webhook-snippets.py
+++ b/scripts/verify-webhook-snippets.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Validate the Python webhook-verification snippet in guides/webhooks.mdx.
+
+Signs a payload with the documented scheme:
+    v1=hex(HMAC_SHA256(secret, f"{timestamp}.{raw_body}"))
+then asserts the snippet's verify() accepts a valid signature and rejects a
+tampered body, a wrong secret, and a stale timestamp. Exits non-zero on any
+failure so a drifted snippet is caught (#4972).
+"""
+import hashlib
+import hmac
+import json
+import sys
+import time
+
+SECRET = b"whsec_test_secret_value"
+TOLERANCE_SECONDS = 300
+
+
+# --- The verify function from guides/webhooks.mdx (keep in sync) ---
+def verify(raw_body: bytes, signature_header: str, timestamp_header: str) -> bool:
+    try:
+        ts = int(timestamp_header)
+    except (TypeError, ValueError):
+        return False
+    if abs(time.time() - ts) > TOLERANCE_SECONDS:
+        return False
+
+    signed = f"{timestamp_header}.".encode() + raw_body
+    expected = "v1=" + hmac.new(SECRET, signed, hashlib.sha256).hexdigest()
+
+    return any(
+        hmac.compare_digest(part.strip(), expected)
+        for part in signature_header.split(",")
+    )
+
+
+# --- Reproduce the server signing scheme to produce a real signature ---
+def sign(secret: bytes, timestamp: str, raw_body: bytes) -> str:
+    signed = f"{timestamp}.".encode() + raw_body
+    return "v1=" + hmac.new(secret, signed, hashlib.sha256).hexdigest()
+
+
+def main() -> int:
+    ts = str(int(time.time()))
+    body = json.dumps(
+        {
+            "id": "evt_whale_trades_inserted_1718634500123_7",
+            "type": "whale_trades_inserted",
+            "created_at": "2026-06-17T14:28:20Z",
+            "data": {"count": 7},
+        }
+    ).encode()
+    sig = sign(SECRET, ts, body)
+
+    checks = [
+        ("valid signature verifies", verify(body, sig, ts) is True),
+        ("tampered body is rejected", verify(body + b" ", sig, ts) is False),
+        ("wrong secret is rejected", verify(body, sign(b"whsec_other", ts, body), ts) is False),
+        ("stale timestamp is rejected", verify(body, sign(SECRET, "1000000000", body), "1000000000") is False),
+        ("comma-joined header still matches", verify(body, f"v0=deadbeef, {sig}", ts) is True),
+    ]
+
+    failed = 0
+    for name, ok in checks:
+        if ok:
+            print(f"ok   - {name}")
+        else:
+            print(f"FAIL - {name}", file=sys.stderr)
+            failed += 1
+
+    if failed:
+        print(f"\n{failed} webhook snippet check(s) failed", file=sys.stderr)
+        return 1
+    print("\nall webhook snippet checks passed (Python)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Content half of API docs Bundle K (0xinsider/0xinsider#4972). The parity + param-fix half already shipped (#28/#29); this adds the conceptual guides, recipes cookbook, webhooks guide, and a generated Objects reference.

Every value was verified against the canonical OpenAPI spec and the backend handlers, not the issue's assumptions. Corrections folded in along the way (see below).

## Added

- **Concepts** (`concepts/`): `signal-scoring`, `strategy-types`, `platforms`, `trust-metadata`, `expand`.
- **Webhooks guide** (`guides/webhooks.mdx`): event types, create -> verify -> active lifecycle, the exact HMAC signing scheme, delivery headers, retry/idempotency, and copy-pasteable Node + Python verification snippets.
- **Recipes** (`recipes/`): `copy-trade`, `insider-scanner`, `alert-bot`, `backtest`, `portfolio-tracker` -- each built only on documented endpoints/params.
- **Objects reference** (`api-reference/objects.mdx`): generated from `components.schemas` by `scripts/generate-objects-reference.py`, so it cannot drift. 65 schemas.
- **Harness** (`scripts/verify-webhook-snippets.{mjs,py}`): signs a payload with the documented scheme and asserts the guide's verifiers accept it and reject tampering, a wrong secret, and a stale timestamp.

## Fixed (contract drift in existing pages)

- `verify-webhook.mdx` fabricated a `verify.test` test delivery and the wrong signing scheme (`HMAC_SHA256(secret, raw_body)`). Verify actually activates the endpoint by matching the create-time token; no delivery is sent. Rewrote it.
- Webhook ids are integers, not `wh_abc123`. Fixed across all webhook endpoint pages.
- `create-webhook.mdx` claimed "radar events"; webhooks have no radar event type. Corrected.
- `introduction.mdx` listed the completeness enum as `full / partial / unavailable`. The shipped enum is `complete / partial / not_computed / not_applicable / unavailable`. Fixed, plus a link to the new trust-metadata page.

## Contract corrections vs the issue draft

- `expand` has **four** values (`strategy, categories, quant_metrics, trust`), not three. `categories` adds `category_strengths`; market snapshot accepts only `trust`.
- Only `whale_trades_inserted` is emitted today; the other three event types are subscribe-only with no producer yet. The guide says so plainly.
- There is **no per-trader positions-list endpoint**, so the copy-trade / portfolio-tracker / backtest recipes poll the global `/positions` board and the whale-trade feed instead of inventing one.
- `leaderboard` has no `min_grade` param; recipes filter S/A client-side.

## Verification

```
python3 scripts/check-openapi-parity.py        # 41 operations covered, exit 0
python3 scripts/check-spec-sync.py --app-spec ../0xinsider/web/public/api/v1/openapi.json
                                                # 37 paths / 65 schemas match, exit 0
python3 scripts/generate-objects-reference.py   # wrote api-reference/objects.mdx (65 schemas)
node   scripts/verify-webhook-snippets.mjs      # all checks pass
python3 scripts/verify-webhook-snippets.py      # all checks pass
npx mint broken-links                           # no broken links found
```

No API contract changed (docs + a generated page + a local harness), so per the repo's API changelog policy `changelog.mdx` is untouched. Rollback is a plain revert.

Closes 0xinsider/0xinsider#4972
