### PR TITLE
docs(api): document curated trader quant_metrics + changelog entry

### DIFF
--- a/api-reference/objects.mdx
+++ b/api-reference/objects.mdx
@@ -515,7 +515,7 @@ String enum: `supported`, `partial`, `unsupported`.
 | `stats` | object | Yes |  |
 | `strategy` | object | No |  |
 | `category_strengths` | object | No | Per-category performance breakdown (expand=categories or expand[]=categories). Null unless expanded. Object keyed by category name; each value is the precomputed trader_rankings.category_ranks payload (rank, total_in_category, total_pnl, scaled_total_pnl, n_markets, wins, losses, win_rate; scaled_total_pnl is a legacy alias that currently equals total_pnl). Pass-through DB JSON: keys and value shape are DB-owned, so the inner shape is intentionally unconstrained and may carry additional compatibility fields. |
-| `quant_metrics` | object | No | Advanced risk/performance metrics (expand=quant_metrics or expand[]=quant_metrics). Null unless expanded. Pass-through of the advanced_metrics row as JSON (trader_id and id stripped); the metric key-set is DB-owned and additive, so the inner shape is intentionally unconstrained. |
+| `quant_metrics` | object | No | Curated advanced risk/performance metrics (expand=quant_metrics or expand[]=quant_metrics). Omitted unless expanded and the trader has computed metrics; when present, all listed fields are present (each is a number or null). null means insufficient trade history and must not be treated as 0. This is a fixed, documented field set, refreshed periodically by the cross-sectional ranking job. |
 | `last_active` | string | No |  |
 | `synced_at` | string | No |  |
 | `sync_status` | string | No | synced, unknown, or pending. |

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -7127,8 +7127,66 @@
           "quant_metrics": {
             "type": "object",
             "nullable": true,
-            "additionalProperties": true,
-            "description": "Advanced risk/performance metrics (expand=quant_metrics or expand[]=quant_metrics). Null unless expanded. Pass-through of the advanced_metrics row as JSON (trader_id and id stripped); the metric key-set is DB-owned and additive, so the inner shape is intentionally unconstrained."
+            "additionalProperties": false,
+            "required": [
+              "smart_score",
+              "copy_score",
+              "sharpe_30d",
+              "sharpe_7d",
+              "profit_factor",
+              "edge_consistency",
+              "sharpe_percentile",
+              "pf_percentile",
+              "consistency_percentile"
+            ],
+            "description": "Curated advanced risk/performance metrics (expand=quant_metrics or expand[]=quant_metrics). Omitted unless expanded and the trader has computed metrics; when present, all listed fields are present (each is a number or null). null means insufficient trade history and must not be treated as 0. This is a fixed, documented field set, refreshed periodically by the cross-sectional ranking job.",
+            "properties": {
+              "smart_score": {
+                "type": "number",
+                "nullable": true,
+                "description": "Composite skill score, 0-100. smart_score = clamp(0, 100, 30*sharpe_percentile_fraction + 20*profit_factor_percentile_fraction + 20*edge_consistency_percentile_fraction + 10*min(1, return_on_capital/2) + 10*equity_smoothness + 10*(1 - min(1, asset_concentration))). Higher is better. null when insufficient history."
+              },
+              "copy_score": {
+                "type": "number",
+                "nullable": true,
+                "description": "Copyability score, 0-100. Same base as smart_score minus penalties for traits that make a strategy hard to replicate: -20 if fewer than 50 markets traded, -15 if positions are highly concentrated, -15 if position sizing exceeds about 2x Kelly, -10 if the worst single-trade loss exceeds 30%, -10 if edge is inconsistent; result clamped to 0-100. Higher means easier to follow. null when insufficient history."
+              },
+              "sharpe_30d": {
+                "type": "number",
+                "nullable": true,
+                "description": "Sharpe ratio over the trailing 30 days (risk-adjusted return; higher is better). Magnitude can be large for small samples. null when insufficient history."
+              },
+              "sharpe_7d": {
+                "type": "number",
+                "nullable": true,
+                "description": "Sharpe ratio over the trailing 7 days (risk-adjusted return; higher is better). null when insufficient history."
+              },
+              "profit_factor": {
+                "type": "number",
+                "nullable": true,
+                "description": "Gross profit divided by gross loss; greater than 1 is profitable. Capped at 1000 when there are effectively no losses. null when insufficient history."
+              },
+              "edge_consistency": {
+                "type": "number",
+                "nullable": true,
+                "description": "Stability of the trader's edge over time, 0-1 (higher is more consistent). null when insufficient history."
+              },
+              "sharpe_percentile": {
+                "type": "number",
+                "nullable": true,
+                "description": "Cross-sectional percentile rank of the trader's Sharpe ratio versus all traders, 0-100. null when insufficient history."
+              },
+              "pf_percentile": {
+                "type": "number",
+                "nullable": true,
+                "description": "Cross-sectional percentile rank of profit factor versus all traders, 0-100. null when insufficient history."
+              },
+              "consistency_percentile": {
+                "type": "number",
+                "nullable": true,
+                "description": "Cross-sectional percentile rank of edge consistency versus all traders, 0-100. null when insufficient history."
+              }
+            }
           },
           "last_active": {
             "type": "string",

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,6 +7,20 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
+<Update label="June 29, 2026" description="Trader quant_metrics is now a documented, fixed field set">
+  [`GET /api/v1/trader/{address}`](/api-reference/endpoint/get-trader) and [`POST /api/v1/traders/batch`](/api-reference/endpoint/batch-get-traders) now return a curated, documented `quant_metrics` object when you pass `?expand=quant_metrics`, instead of an unconstrained pass-through of internal metrics.
+
+  When expanded, the object always carries these nine fields, each a number or `null` (`null` means insufficient trade history and is never `0`):
+
+  - `copy_score`, `smart_score`: 0-100 composite scores. `smart_score` blends risk-adjusted return, profit factor, edge consistency, return on capital, equity smoothness, and diversification. `copy_score` is that same base minus penalties for traits that make a strategy hard to replicate (small sample, concentration, oversized position sizing, large single losses, inconsistent edge).
+  - `sharpe_30d`, `sharpe_7d`: risk-adjusted return over the trailing 30 and 7 days.
+  - `profit_factor`: gross profit divided by gross loss (capped at 1000).
+  - `edge_consistency`: stability of the trader's edge over time (0-1).
+  - `sharpe_percentile`, `pf_percentile`, `consistency_percentile`: cross-sectional ranks versus all traders (0-100).
+
+  Every field is now defined in the [trader endpoint reference](/api-reference/endpoint/get-trader). Undocumented internal and experimental metrics that previously leaked through the pass-through are no longer returned.
+</Update>
+
 <Update label="June 1, 2026" description="Smart-money flow market discovery endpoint">
   Added [`GET /api/v1/markets/smart-money-flows`](/api-reference/endpoint/smart-money-flows), a ranked discovery feed that answers where smart money is flowing before you know a `condition_id`.
 


### PR DESCRIPTION
## What

Document the curated v1 trader `quant_metrics` contract shipped in 0xinsider/0xinsider#6425 (PR #6426, merged), and add the API changelog entry.

## Changes

- **`api-reference/openapi.json`**: `Trader.quant_metrics` was an opaque `additionalProperties:true` pass-through ("intentionally unconstrained"). It now declares the curated 9-field contract that the API actually returns: `smart_score`, `copy_score`, `sharpe_30d`, `sharpe_7d`, `profit_factor`, `edge_consistency`, `sharpe_percentile`, `pf_percentile`, `consistency_percentile` -- each `number | null`, with per-field descriptions and the `copy_score`/`smart_score` formulas; `required:[9]` + `additionalProperties:false`. Mirrors the canonical web spec so the rendered `get-trader` reference is accurate.
- **`changelog.mdx`**: June 29, 2026 `<Update>` describing the user-visible impact (the nine fields are now defined; undocumented internal/experimental metrics that previously leaked through the pass-through are no longer returned). Plain `<Update>` block matching every existing entry (this Mintlify changelog has no illustrations).
- **`api-reference/objects.mdx`** (regenerated): the Objects reference is generated from `api-reference/openapi.json` by `scripts/generate-objects-reference.py`. The curated `quant_metrics` schema landed in the spec but `objects.mdx` had not been regenerated, so the Trader row still advertised the old intentionally-unconstrained pass-through shape -- self-contradicting the curated spec and the changelog. Regenerated; only the `quant_metrics` row changed.

## Why

`copy_score`/`smart_score` are product-defining trader-quality signals an external developer hit and could not interpret (they were undocumented). The upstream PR curated the response to a stable, documented field set; this keeps the public API reference and changelog truthful against the shipped contract.

## Adversarial review dispositions

A local adversarial review of this PR raised two HIGH must-fixes, both now resolved:

- **HIGH #1 -- `objects.mdx` contradicted the new contract.** Resolved here: regenerated `objects.mdx` from the curated spec (commit in this PR); the Trader `quant_metrics` row now reads "Curated... fixed, documented field set" instead of "intentionally unconstrained pass-through".
- **HIGH #2 -- docs spec description was hand-edited off the canonical app spec (#4972 sync-invariant), and the app spec's public description leaked internal references (`advanced_metrics`, `API_VERSIONING.md`).** Resolved at the source: 0xinsider/0xinsider#6432 (PR 0xinsider/0xinsider#6433, merged) cleaned the canonical app spec's public `quant_metrics` description to the exact wording this docs spec carries. The two specs are now byte-identical on the `quant_metrics` block, so a future verbatim re-sync neither reverts this wording nor re-leaks the internal references.

## Verification

- `python3 scripts/check-openapi-parity.py` -> `parity OK: 41 operations covered`.
- `npx mint broken-links` -> `no broken links found`.
- openapi.json valid; `quant_metrics` `required` == `properties` (9), `additionalProperties:false`; description byte-identical to the merged app spec (`advanced_metrics`/`API_VERSIONING` absent).
- `objects.mdx` regen diff is exactly one row (the `quant_metrics` row).
- ASCII-clean (no em-dashes/emoji introduced; pre-existing dashes in unrelated descriptions are out of scope and mirror the canonical app spec).
