### PR TITLE
docs(api): add quant-metrics concept page + link from scoring hub

### DIFF
--- a/concepts/expand.mdx
+++ b/concepts/expand.mdx
@@ -31,7 +31,7 @@ Available on [`GET /api/v1/trader/{address}`](/api-reference/endpoint/get-trader
 |---|---|---|
 | `strategy` | `strategy` | The trader's ML strategy classification: `strategy_type`, an optional `description`, and `confidence`. See [Strategy types](/concepts/strategy-types). |
 | `categories` | `category_strengths` | Per-category performance, keyed by category: rank within the category, total P&L, markets traded, wins, losses, and win rate. |
-| `quant_metrics` | `quant_metrics` | Advanced per-trader quant metrics. The key set is additive and database-owned. |
+| `quant_metrics` | `quant_metrics` | A fixed set of nine curated risk and performance metrics, including the `smart_score` and `copy_score` headline scores. See [Quant metrics](/concepts/quant-metrics). |
 | `trust` | `trust` | Field-level [trust metadata](/concepts/trust-metadata): source, freshness, reconciliation, and completeness for each derived field. |
 
 ## Example

--- a/concepts/quant-metrics.mdx
+++ b/concepts/quant-metrics.mdx
@@ -48,11 +48,11 @@ smart_score = clamp(0, 100,
 
 | Penalty | When it applies |
 |---|---|
-| −20 | Fewer than 50 markets traded (thin track record) |
-| −15 | Positions are highly concentrated |
-| −15 | Position sizing exceeds about 2x Kelly (over-betting) |
-| −10 | Worst single-trade loss exceeds 30% |
-| −10 | Edge is inconsistent |
+| -20 | Fewer than 50 markets traded (thin track record) |
+| -15 | Positions are highly concentrated |
+| -15 | Position sizing exceeds about 2x Kelly (over-betting) |
+| -10 | Worst single-trade loss exceeds 30% |
+| -10 | Edge is inconsistent |
 
 A trader can have a high `smart_score` and a much lower `copy_score`: genuinely skilled, but running a book that is risky or impractical to mirror. When you are ranking traders to follow or copy, read `copy_score`. When you are ranking pure skill, read `smart_score`.
 
@@ -94,7 +94,7 @@ These place the trader against the whole population, 0-100. They are the inputs 
     "grade": "S",
     "quant_metrics": {
       "smart_score": 84.2,
-      "copy_score": 71.5,
+      "copy_score": 74.2,
       "sharpe_30d": 2.13,
       "sharpe_7d": 3.44,
       "profit_factor": 4.1,

--- a/concepts/quant-metrics.mdx
+++ b/concepts/quant-metrics.mdx
@@ -1,0 +1,115 @@
+---
+title: "Quant Metrics"
+description: "The curated risk and performance metrics behind a trader's scores, what each field means, and how to read them."
+---
+
+`quant_metrics` is a curated set of risk and performance metrics for a trader. It is where the two headline scores live, `smart_score` and `copy_score`, alongside the risk-adjusted return and consistency measures they are built from.
+
+The field set is fixed and documented: exactly nine fields, each a number or `null`. It is not a raw database dump, and it does not grow silently as we add internal columns. New internal metrics stay internal until they are curated into this contract.
+
+## How to get it
+
+`quant_metrics` is an [expanded field](/concepts/expand). It is omitted from trader responses unless you ask for it:
+
+```bash
+# Single trader
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/trader/0x204f...?expand=quant_metrics"
+
+# Many traders at once
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  -X POST "https://api.0xinsider.com/api/v1/traders/batch" \
+  -H "Content-Type: application/json" \
+  -d '{"traders": ["0x204f...", "swisstony"], "expand": ["quant_metrics"]}'
+```
+
+It appears on [`GET /api/v1/trader/{address}`](/api-reference/endpoint/get-trader) and [`POST /api/v1/traders/batch`](/api-reference/endpoint/batch-get-traders). The field is present only when the trader has computed metrics; when present, all nine keys are present.
+
+## The two headline scores
+
+Both scores are 0-100 and higher is better. They answer different questions.
+
+- `smart_score` measures **skill**: how good is this trader, on a risk-adjusted basis, relative to everyone else?
+- `copy_score` measures **copyability**: how safely could you follow this trader, after discounting traits that make a strategy hard to replicate?
+
+`smart_score` is a weighted blend of the trader's cross-sectional percentiles and a few absolute measures:
+
+```
+smart_score = clamp(0, 100,
+    30 * sharpe_percentile_fraction
+  + 20 * profit_factor_percentile_fraction
+  + 20 * edge_consistency_percentile_fraction
+  + 10 * min(1, return_on_capital / 2)
+  + 10 * equity_smoothness
+  + 10 * (1 - min(1, asset_concentration)))
+```
+
+`copy_score` starts from that same base and subtracts penalties for hard-to-replicate behaviour, then clamps to 0-100:
+
+| Penalty | When it applies |
+|---|---|
+| −20 | Fewer than 50 markets traded (thin track record) |
+| −15 | Positions are highly concentrated |
+| −15 | Position sizing exceeds about 2x Kelly (over-betting) |
+| −10 | Worst single-trade loss exceeds 30% |
+| −10 | Edge is inconsistent |
+
+A trader can have a high `smart_score` and a much lower `copy_score`: genuinely skilled, but running a book that is risky or impractical to mirror. When you are ranking traders to follow or copy, read `copy_score`. When you are ranking pure skill, read `smart_score`.
+
+## The component metrics
+
+These are the underlying measures. They are absolute values, not ranks.
+
+| Field | Meaning |
+|---|---|
+| `sharpe_30d` | Sharpe ratio over the trailing 30 days (risk-adjusted return; higher is better). Magnitude can be large for small samples. |
+| `sharpe_7d` | Sharpe ratio over the trailing 7 days. |
+| `profit_factor` | Gross profit divided by gross loss; greater than 1 is profitable. Capped at 1000 when there are effectively no losses. |
+| `edge_consistency` | Stability of the trader's edge over time, 0-1 (higher is more consistent). |
+
+## The percentile ranks
+
+These place the trader against the whole population, 0-100. They are the inputs the scores lean on, exposed directly so you can see where a number sits in the field.
+
+| Field | Meaning |
+|---|---|
+| `sharpe_percentile` | Percentile rank of the trader's Sharpe ratio versus all traders. |
+| `pf_percentile` | Percentile rank of profit factor versus all traders. |
+| `consistency_percentile` | Percentile rank of edge consistency versus all traders. |
+
+## Reading the values
+
+- **`null` means insufficient trade history, not zero.** Every field is a number or `null`. A `null` field is one we cannot compute yet for this trader; treating it as `0` will rank a brand-new wallet as the worst possible trader rather than an unknown one.
+- **Values refresh periodically.** The scores and percentiles are recomputed by the cross-sectional ranking job, not on every request. A trader's percentile moves as the rest of the population moves, even if their own trades do not.
+- **Scores are 0-100; components are absolute.** `smart_score`, `copy_score`, and the three percentiles are bounded 0-100. `sharpe_30d`/`sharpe_7d` and `profit_factor` are unbounded (profit factor is capped at 1000), so compare them against the percentile fields for context.
+
+## Full response shape
+
+```json
+{
+  "object": "trader",
+  "data": {
+    "id": "trd_0x204f72f35326db932158cba6adff0b9a1da95e14",
+    "username": "swisstony",
+    "grade": "S",
+    "quant_metrics": {
+      "smart_score": 84.2,
+      "copy_score": 71.5,
+      "sharpe_30d": 2.13,
+      "sharpe_7d": 3.44,
+      "profit_factor": 4.1,
+      "edge_consistency": 0.62,
+      "sharpe_percentile": 97.4,
+      "pf_percentile": 88.9,
+      "consistency_percentile": 91.0
+    }
+  }
+}
+```
+
+## Related
+
+- [Signal scoring](/concepts/signal-scoring) names every score the API exposes and which to reach for.
+- [Grades](/concepts/grades) explains the headline `S`-`F` grade, the long-run quality verdict that sits above these metrics.
+- [Expanding responses](/concepts/expand) covers the `expand` parameter and the other expandable fields.
+- [Trust metadata](/concepts/trust-metadata) exposes per-field provenance, including for `quant_metrics`.

--- a/concepts/signal-scoring.mdx
+++ b/concepts/signal-scoring.mdx
@@ -16,6 +16,15 @@ On every trader and leaderboard entry:
 
 Grade is the long-run verdict. `streak_tier` is the trailing-form overlay: an A-grade trader can be `cooling`, and a B-grade trader can be `hot`.
 
+## Deeper trader metrics: quant_metrics
+
+`grade` and `score` are the headline verdict. When you want the risk and performance detail behind them, request [`quant_metrics`](/concepts/quant-metrics) on a trader (`expand=quant_metrics`). It returns nine curated fields, including two 0-100 scores that answer different questions:
+
+- `smart_score`: how skilled is this trader, risk-adjusted, versus the field.
+- `copy_score`: how safely could you copy them, after penalising traits that make a strategy hard to replicate.
+
+The other seven fields (30- and 7-day Sharpe, profit factor, edge consistency, and their cross-sectional percentiles) are the inputs behind those scores. See [Quant metrics](/concepts/quant-metrics) for the full field set and how to read `null`.
+
 ## Per-trade strength: signal_score
 
 Each [whale trade](/api-reference/endpoint/get-whale-trades) carries a `signal_score`: how strong that single fill is as a signal. Use it to rank a feed of trades, not to judge a trader overall.
@@ -78,6 +87,7 @@ These power discovery sorting and are distinct from the `smart_money` flow objec
 | Question | Field |
 |---|---|
 | Is this trader worth following? | `grade` (and `score`) |
+| How skilled is this trader, in detail? | `quant_metrics.smart_score` (and `copy_score` for copyability) |
 | Is this trader hot right now? | `streak_tier` |
 | Is this single trade a strong signal? | `signal_score` |
 | Which way is smart money leaning on this market? | `smart_money.net_flow_usd` and `direction` |

--- a/docs.json
+++ b/docs.json
@@ -36,6 +36,7 @@
             "pages": [
               "concepts/grades",
               "concepts/signal-scoring",
+              "concepts/quant-metrics",
               "concepts/strategy-types",
               "concepts/platforms",
               "concepts/trust-metadata",


### PR DESCRIPTION
## What

Adds a human-readable **Quant metrics** concept page to docs.0xinsider.com and wires it into the scoring docs.

An API consumer asked whether we have documentation for the `quant_metrics` scoring fields returned by `expand=quant_metrics` (on `GET /api/v1/trader/{address}` and `POST /api/v1/traders/batch`). The nine curated fields were already defined one-by-one in the OpenAPI reference and the June 29 changelog (#31), but there was no concept page explaining what they mean or how to read them, and the scoring hub (`signal-scoring.mdx`) never mentioned them.

## Changes

- **New `concepts/quant-metrics.mdx`** — explains all nine curated fields:
  - The two headline 0-100 scores and how they differ: `smart_score` (skill) vs `copy_score` (copyability), including the `copy_score` penalty table.
  - The component metrics (`sharpe_30d`, `sharpe_7d`, `profit_factor`, `edge_consistency`) and the three cross-sectional percentiles.
  - How to read the values: `null` means insufficient history, not zero; values refresh on the cross-sectional ranking job; scores are bounded, components are not.
  - Full response shape example.
  - Wording is kept consistent with the curated public OpenAPI field descriptions.
- **`docs.json`** — register the new page in the Concepts group, next to `signal-scoring`.
- **`concepts/signal-scoring.mdx`** — add a "Deeper trader metrics" section and a picking-the-right-field row pointing at `quant_metrics`, so the scoring hub no longer omits it.
- **`concepts/expand.mdx`** — fix a stale line that described `quant_metrics` as "additive and database-owned"; the set is now a fixed nine-field curated contract (`additionalProperties: false`). Link to the new page.

## Not in scope

- No OpenAPI spec change — this documents the existing, unchanged contract. Per the repo changelog policy, docs-only edits get no changelog entry.
- A follow-up docs PR will sync a separate API addition (per-outcome CLOB `token_id` alongside YES/NO labels) once that ships in the app; it depends on the app OpenAPI spec landing first.

## Verification

- `python3 -c "import json;json.load(open('docs.json'))"` — valid JSON.
- `python3 scripts/check-openapi-parity.py` — `OpenAPI/docs parity OK: 41 operations covered.`
- `npx mint broken-links` — `success no broken links found` (all cross-links resolve).

Generated with Claude Code.


---

### Review fixes (adversarial local fact-check, applied)

An independent fact-check subagent verified every claim against `origin/main` `openapi.json`, `service.rs` (`V1_QUANT_METRICS_FIELDS`), and `cross_sectional_ranks.sql`. Substance passed with no field/formula/penalty/range/semantics error. Two fixes applied on the latest commit:

- Replaced five U+2212 minus signs in the `copy_score` penalty table with ASCII hyphens (repo no-non-ASCII rule).
- Corrected the example `copy_score` (`71.5` -> `74.2`) so `smart_score - copy_score = 10` is a valid single penalty with a matching fractional part, i.e. the example is reproducible under the documented formula.

Re-verified: no non-ASCII glyphs in any touched file; `mint broken-links` clean.
