### PR TITLE
docs(changelog): link Quant metrics guide from the June 29 entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -18,7 +18,7 @@ This changelog tracks externally visible REST API changes only. Documentation-on
   - `edge_consistency`: stability of the trader's edge over time (0-1).
   - `sharpe_percentile`, `pf_percentile`, `consistency_percentile`: cross-sectional ranks versus all traders (0-100).
 
-  Every field is now defined in the [trader endpoint reference](/api-reference/endpoint/get-trader). Undocumented internal and experimental metrics that previously leaked through the pass-through are no longer returned.
+  Every field is defined in the [trader endpoint reference](/api-reference/endpoint/get-trader), and the new [Quant metrics guide](/concepts/quant-metrics) explains what each score and metric means, its range, and how to read `null`. Undocumented internal and experimental metrics that previously leaked through the pass-through are no longer returned.
 </Update>
 
 <Update label="June 1, 2026" description="Smart-money flow market discovery endpoint">


### PR DESCRIPTION
## What

Links the new [Quant metrics guide](/concepts/quant-metrics) (shipped in #32) from the existing June 29 `quant_metrics` changelog entry.

Per Trevor's directive to keep the changelog current on API work: the `quant_metrics` API change is already logged (the June 29 entry), and the dedicated concept guide did not exist when that entry was written. Rather than add a duplicate docs-only entry (the changelog is REST-API-changes-only by its own header policy), this enriches the existing API-change entry with a link to the fuller guide.

## Verification

- `npx mint broken-links` — clean (the `/concepts/quant-metrics` target exists as of #32).

Generated with Claude Code.
