### PR TITLE
docs(changelog): Pick of the Day archive adds hit_rate.series cumulative track record

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,6 +7,18 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
+<Update label="July 1, 2026" description="Pick of the Day archive adds a cumulative track-record series for charting">
+  `GET /api/v1/pick-of-the-day/archive` now returns a `hit_rate.series` array — the cumulative track record of the Pick of the Day, ready to chart without recomputing it on the client.
+
+  Each element is one resolved (win or loss) pick, in ascending `pick_date` order, and carries:
+
+  - `date` — the pick's publish date (`YYYY-MM-DD`).
+  - `net_profit_usd` — the running cumulative profit of a $100 stake on every resolved, priced pick through that date.
+  - `hit_rate_pct` — the running hit rate (wins / decided) through that date, to one decimal.
+
+  The final point equals the top-level `hit_rate.net_profit_usd` and `hit_rate.pct`, so a chart of the series always ends exactly on the headline numbers. The array is empty until at least one pick has resolved. Every existing `hit_rate` field is unchanged — this is purely additive.
+</Update>
+
 <Update label="June 29, 2026" description="Trader quant_metrics is now a documented, fixed field set">
   [`GET /api/v1/trader/{address}`](/api-reference/endpoint/get-trader) and [`POST /api/v1/traders/batch`](/api-reference/endpoint/batch-get-traders) now return a curated, documented `quant_metrics` object when you pass `?expand=quant_metrics`, instead of an unconstrained pass-through of internal metrics.
 


### PR DESCRIPTION
Same-round changelog entry (required per the 2026-07-01 hard rule) for the additive v1 API change in 0xinsider/0xinsider#6523 / PR #6524.

## What
Adds a `<Update label="July 1, 2026">` block to `changelog.mdx`: `GET /api/v1/pick-of-the-day/archive` now returns an additive `hit_rate.series` array (one cumulative point per resolved pick — `date`, `net_profit_usd`, `hit_rate_pct`; the last point equals the headline `hit_rate.net_profit_usd`/`pct`; empty until a pick resolves).

## Notes
- Changelog-only; no illustration (matches every existing `<Update>` in this Mintlify docs repo — the ChangelogIllustrations rule is the main web app's).
- No `api-reference/openapi.json` sync: the pick-of-the-day archive endpoint is not documented in the docs-site spec (no `PickOfTheDayHitRate` schema present), so there is no schema to extend. The canonical spec (`web/public/api/v1/openapi.json`) + llms/agents docs were updated in the main PR.
- Entry uses inline code (no internal links) -> broken-links safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)