### PR TITLE
docs(api): sync per-outcome token_id into openapi + changelog (#6535)

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -6977,6 +6977,11 @@
               "no"
             ]
           },
+          "token_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "The Polymarket CLOB token id (ERC1155 asset id, decimal string) for this outcome; null when unavailable (e.g. Kalshi markets, unsynced markets)."
+          },
           "amount_delta": {
             "type": "number",
             "description": "Signed share delta (+ on buy, − on sell)."
@@ -7246,6 +7251,11 @@
               "NO"
             ],
             "description": "Binary outcome side. Non-binary positions are not surfaced on V1."
+          },
+          "token_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "The Polymarket CLOB token id (ERC1155 asset id, decimal string) for this outcome; null when unavailable (e.g. Kalshi markets, unsynced markets)."
           },
           "shares": {
             "type": "number",
@@ -7679,9 +7689,19 @@
             "type": "string",
             "nullable": true
           },
+          "token_id_yes": {
+            "type": "string",
+            "nullable": true,
+            "description": "The Polymarket CLOB token id (ERC1155 asset id, decimal string) for the YES outcome; null when unavailable (e.g. Kalshi markets, unsynced markets)."
+          },
           "outcome_no": {
             "type": "string",
             "nullable": true
+          },
+          "token_id_no": {
+            "type": "string",
+            "nullable": true,
+            "description": "The Polymarket CLOB token id (ERC1155 asset id, decimal string) for the NO outcome; null when unavailable (e.g. Kalshi markets, unsynced markets)."
           },
           "event_slug": {
             "type": "string",
@@ -8016,6 +8036,11 @@
                   "NO"
                 ]
               },
+              "token_id": {
+                "type": "string",
+                "nullable": true,
+                "description": "The Polymarket CLOB token id (ERC1155 asset id, decimal string) for the net-flow direction outcome; null when unavailable (e.g. Kalshi markets, unsynced markets)."
+              },
               "whale_trade_count": {
                 "type": "integer"
               },
@@ -8056,6 +8081,11 @@
                         "YES",
                         "NO"
                       ]
+                    },
+                    "token_id": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "The Polymarket CLOB token id (ERC1155 asset id, decimal string) for this outcome; null when unavailable (e.g. Kalshi markets, unsynced markets)."
                     },
                     "size_usd": {
                       "type": "number"
@@ -8132,6 +8162,11 @@
                   "YES",
                   "NO"
                 ]
+              },
+              "token_id": {
+                "type": "string",
+                "nullable": true,
+                "description": "The Polymarket CLOB token id (ERC1155 asset id, decimal string) for the net-flow direction outcome; null when unavailable (e.g. Kalshi markets, unsynced markets)."
               },
               "whale_trade_count": {
                 "type": "integer"
@@ -8911,7 +8946,76 @@
           "top_whale_trades": {
             "type": "array",
             "items": {
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "outcome": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Provider outcome label for the traded side."
+                },
+                "side": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Trade direction (BUY or SELL), not the outcome side."
+                },
+                "title": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Market title."
+                },
+                "size": {
+                  "type": "number",
+                  "nullable": true,
+                  "description": "Trade size in USD."
+                },
+                "price": {
+                  "type": "number",
+                  "nullable": true,
+                  "description": "Trade price in provider [0, 1] units."
+                },
+                "token_id": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "The Polymarket CLOB token id (ERC1155 asset id, decimal string) for the traded outcome; null when unavailable (e.g. Kalshi markets, unsynced markets)."
+                },
+                "id": {
+                  "type": "integer",
+                  "format": "int64",
+                  "nullable": true,
+                  "description": "Whale trade id."
+                },
+                "trade_time": {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true,
+                  "description": "Trade timestamp (UTC)."
+                },
+                "market_category": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Provider market category."
+                },
+                "platform": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Venue: polymarket or kalshi."
+                },
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Trader display name, when known."
+                },
+                "pseudonym": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Trader pseudonym, when no display name is known."
+                },
+                "trader_grade": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Trader grade (S-F) at snapshot time."
+                }
+              }
             },
             "nullable": true
           },
@@ -9245,6 +9349,11 @@
             "type": "string",
             "nullable": true,
             "description": "Backend-resolved outcome label (provider outcome, else Yes/No from the binary index)."
+          },
+          "token_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "The Polymarket CLOB token id (ERC1155 asset id, decimal string) for this outcome; null when unavailable (e.g. Kalshi markets, unsynced markets)."
           },
           "event_leg_count": {
             "type": "integer",

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,6 +7,22 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
+<Update label="July 1, 2026" description="Every V1 YES/NO/outcome now carries its Polymarket CLOB token id">
+  Reads that expose an outcome, side, or net-flow direction now also return a per-outcome Polymarket CLOB `token_id`, so you can go straight from a YES/NO/outcome label to its on-chain ERC1155 asset id without a second lookup. Use it for order placement, per-token price history, and on-chain reconciliation.
+
+  The value is a decimal string for a synced Polymarket market and `null` when unavailable (for example Kalshi markets, or markets that have not synced yet). It is always present and never in a `required` set, so the change is purely additive and safe for existing clients.
+
+  The endpoints that gained it:
+
+  - [`GET /api/v1/positions`](/api-reference/endpoint/get-positions): `token_id` alongside `side`.
+  - [`GET /api/v1/large-positions`](/api-reference/endpoint/list-large-positions): `token_id` alongside `outcome_label`.
+  - [`GET /api/v1/market/{condition_id}/intel`](/api-reference/endpoint/get-market-intel) and [`POST /api/v1/markets/intel/batch`](/api-reference/endpoint/batch-get-market-intel): `token_id` on `smart_money` (alongside `direction`) and on every `smart_money.top_positions` entry.
+  - [`GET /api/v1/markets/smart-money-flows`](/api-reference/endpoint/smart-money-flows): `token_id` on `smart_money`, alongside `direction`.
+  - [`GET /api/v1/trader/{address}/position-timeline`](/api-reference/endpoint/get-position-timeline) and [`GET /api/v1/traders/{trader}/position-timeline`](/api-reference/endpoint/get-trader-position-timeline): `token_id` alongside `outcome_side`.
+  - [`GET /api/v1/markets/explore`](/api-reference/endpoint/explore-markets): `token_id_yes` and `token_id_no` alongside `outcome_yes` / `outcome_no`. These are CLOB token ids (decimal strings), distinct from the integer `outcome_yes_provider_id` / `outcome_no_provider_id` Gamma ids.
+  - [`GET /api/v1/reports/daily`](/api-reference/endpoint/get-daily-report-snapshot), [`weekly`](/api-reference/endpoint/get-weekly-report-snapshot), and [`monthly`](/api-reference/endpoint/get-monthly-report-snapshot): `token_id` on every `top_whale_trades` entry.
+</Update>
+
 <Update label="July 1, 2026" description="Pick of the Day archive adds a cumulative track-record series for charting">
   `GET /api/v1/pick-of-the-day/archive` now returns a `hit_rate.series` array — the cumulative track record of the Pick of the Day, ready to chart without recomputing it on the client.
 


### PR DESCRIPTION
## Summary

Sync the just-merged app-repo API change into the docs site: a new nullable per-outcome Polymarket CLOB `token_id` (string) added next to every V1 YES/NO/outcome/direction label. Mirrors `0xinsider/0xinsider@8fd9ed3f` (PR #6536, issue #6535).

This is a **scoped insert** of only the `token_id` deltas into the manually-drifting `api-reference/openapi.json`. No full resync, no whole-file reformat, no unrelated in-flight deltas pulled.

## OpenAPI changes (`api-reference/openapi.json`)

Each block copied verbatim from the app spec (`{"type":"string","nullable":true,"description":...}`), always kept **out of** every `required` array:

| Schema | Added property | Anchor (sibling) |
| --- | --- | --- |
| `PositionTimelineEvent` | `token_id` | `outcome_side` (covers both position-timeline routes) |
| `Position` | `token_id` | `side` |
| `ExploreMarket` | `token_id_yes`, `token_id_no` | `outcome_yes` / `outcome_no` |
| `MarketIntel` | `smart_money.token_id` | `direction` |
| `MarketIntel` | `smart_money.top_positions[].token_id` | `side` (covers `/markets/intel/batch` via the shared schema) |
| `SmartMoneyFlowMarket` | `smart_money.token_id` | `direction` |
| `ReportPayload` | `top_whale_trades[].token_id` | typed the previously-untyped `object` |
| `LargePosition` | `token_id` | `outcome_label` |

`ReportPayload.top_whale_trades[]` was an untyped `{"type":"object"}`; it is now fully typed to match the app spec's 13 properties (`outcome, side, title, size, price, token_id, id, trade_time, market_category, platform, name, pseudonym, trader_grade`).

### Intentional omission: `PickOfTheDay`

The app change also added `token_id` to `PickOfTheDay`, but this docs site **does not document** `/api/v1/pick-of-the-day` (no path, no endpoint page, no schema). There is nothing to scope-insert a sibling into, and adding the whole schema/endpoint would be an out-of-scope resync. Skipped deliberately; noted here.

### Clarity: Explore CLOB ids vs Gamma provider ids

On `ExploreMarket`, the new `token_id_yes` / `token_id_no` descriptions say "CLOB token id (ERC1155 asset id, decimal string)" so they are not confused with the existing integer `outcome_yes_provider_id` / `outcome_no_provider_id` Gamma ids. The changelog entry calls this out explicitly.

## Changelog (`changelog.mdx`)

New `<Update label="July 1, 2026">` entry at the top, describing the per-outcome `token_id` (nullable) and linking every documented V1 read endpoint that gained it. ASCII only, sentence-case, second person, matching the existing `<Update>` style.

## Verification

- `python3 -c "import json;json.load(open('api-reference/openapi.json'))"` -> valid
- `python3 scripts/check-openapi-parity.py` -> `OpenAPI/docs parity OK: 41 operations covered.`
- `npx --yes mint broken-links` -> `success no broken links found`
- `git diff | grep '^\+' | grep -P '[^\x00-\x7F]'` -> no matches (all added lines ASCII)

Diffstat: `api-reference/openapi.json` +111/-1, `changelog.mdx` +16.

Refs 0xinsider/0xinsider#6535

Generated with [Claude Code](https://claude.com/claude-code)
