### PR TITLE
docs(api): sync whale-trades outcome + token_id into openapi + changelog

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -7430,6 +7430,16 @@
               "SELL"
             ]
           },
+          "outcome": {
+            "type": "string",
+            "nullable": true,
+            "description": "Traded outcome label (e.g. \"Yes\"/\"No\"/team name), resolved provider-first from the trade's outcome_index against market_canonical (index 0 -> yes, 1 -> no). Distinct axis from side (BUY/SELL): side is the trade direction, outcome is which leg was traded. null for multi-outcome (outcome_index >= 2) or unsynced markets; a Kalshi row carries its provider label here (only token_id is null for Kalshi, since there is no CLOB token)."
+          },
+          "token_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "The Polymarket CLOB token id (ERC1155 asset id, decimal string) for the traded outcome; null when unavailable (e.g. Kalshi markets, unsynced markets)."
+          },
           "price": {
             "type": "number"
           },

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,6 +7,12 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
+<Update label="July 1, 2026" description="Whale trades now expose the traded outcome and its CLOB token id">
+  Each whale trade ([`GET /api/v1/whale-trades`](/api-reference/endpoint/get-whale-trades), [`/whale-trades/history`](/api-reference/endpoint/get-whale-trades-history), [`/whale-trades/{id}`](/api-reference/endpoint/get-whale-trade)) now returns the traded `outcome` (the provider outcome label - which leg the trade was on, e.g. Yes/No/team) and its per-outcome Polymarket CLOB `token_id`, alongside the existing `side` (BUY/SELL, unchanged). Previously only BUY/SELL was exposed, so you could not tell which outcome a whale trade was on, or get that outcome's on-chain token id.
+
+  `outcome` is null only for a multi-outcome or unsynced market with no stored label; a Kalshi trade carries its provider label here (only `token_id` is null for Kalshi, since there is no CLOB token). Both fields are additive and nullable, so existing clients are unaffected.
+</Update>
+
 <Update label="July 1, 2026" description="Every V1 YES/NO/outcome now carries its Polymarket CLOB token id">
   Reads that expose an outcome, side, or net-flow direction now also return a per-outcome Polymarket CLOB `token_id`, so you can go straight from a YES/NO/outcome label to its on-chain ERC1155 asset id without a second lookup. Use it for order placement, per-token price history, and on-chain reconciliation.
 


### PR DESCRIPTION
Mirrors app change 0xinsider/0xinsider#6551 (merged). Adds `outcome` + `token_id` (both nullable, non-required) to the docs-repo `WhaleTrade` schema and a changelog Update entry. `outcome` is null only for multi-outcome/unsynced markets; a Kalshi trade carries its provider label (only `token_id` is null for Kalshi). Verified: openapi valid JSON, parity OK (41 ops), mint broken-links clean, ASCII-only.

Generated with Claude Code.