### PR TITLE
docs: remove sandbox/test-mode API keys (oxi_sk_test_)

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -14,10 +14,6 @@
     {
       "url": "https://api.0xinsider.com",
       "description": "Production (live data). Authenticate with a live key (oxi_sk_live_...); requires an active Insider subscription."
-    },
-    {
-      "url": "https://api.0xinsider.com",
-      "description": "Sandbox / test mode (deterministic fixture data, no live rows). Authenticate with a test key (oxi_sk_test_...) on a free account. Same base URL and paths as production: the key class selects live vs sandbox. Test keys are billing-exempt, served from a fixed fixture dataset, and never read live data or persist writes; webhooks, usage, and MCP responses show the response shape only."
     }
   ],
   "security": [
@@ -6563,7 +6559,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "API key: Authorization: Bearer oxi_sk_live_... for live data (requires an active Insider subscription), or oxi_sk_test_... for sandbox/test mode (free account, deterministic fixture data, no live rows). Both key classes use the same paths; the prefix selects live vs sandbox."
+        "description": "API key authentication. Send your key in the Authorization header as `Bearer oxi_sk_live_...`. Live keys require an active Insider subscription and return live data."
       }
     },
     "parameters": {

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,6 +7,12 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
+<Update label="July 4, 2026" description="Sandbox / test-mode API keys removed; a single live key class remains">
+  Sandbox / test-mode API keys (`oxi_sk_test_...`) are removed. The API now has a single key class: `oxi_sk_live_...`, sent as `Authorization: Bearer oxi_sk_live_...`, which requires an active Insider subscription and always returns live data.
+
+  Any request still authenticating with an `oxi_sk_test_...` key will fail. Generate a live key from your account's API keys page and switch clients over before this lands. There is no fixture/deterministic-data mode - every request now reads live data.
+</Update>
+
 <Update label="July 2, 2026" description="Pick of the Day: fixed 19:00 Europe/Berlin release and a multi-sport candidate pool">
   Two behavior changes to [`GET /api/v1/pick-of-the-day`](/api-reference/endpoint/get-pick-of-the-day) and its archive. No fields were added, removed, or retyped - existing clients are unaffected - but two value semantics changed:
 


### PR DESCRIPTION
Retires the sandbox/test-mode API key tier. The developer API now has a single key class, `oxi_sk_live_...`, which requires an active Insider subscription and always returns live data — there is no fixture/deterministic-data mode to keep in sync with production behavior.

- `api-reference/openapi.json`: removed the second `servers[]` entry (the sandbox/test-mode server description) and rewrote `components.securitySchemes.bearerAuth.description` to: "API key authentication. Send your key in the Authorization header as `Bearer oxi_sk_live_...`. Live keys require an active Insider subscription and return live data."
- `changelog.mdx`: added a new `<Update label="July 4, 2026" ...>` entry at the top of the list announcing the removal of `oxi_sk_test_...` keys and the single-live-key-class model.

Part of 0xinsider/0xinsider#6750

**Verification**

```
$ jq . api-reference/openapi.json >/dev/null && echo VALID
VALID

$ python3 scripts/check-openapi-parity.py
OpenAPI/docs parity OK: 43 operations covered.

$ npx mint broken-links
success no broken links found

$ rg -i 'oxi_sk_test|sandbox|test mode|test key|fixture data' . --glob '!.git'
changelog.mdx:10: (new entry title, announces the removal)
changelog.mdx:11: (new entry body, mentions old oxi_sk_test_ prefix being removed)
changelog.mdx:13: (new entry body, mentions no fixture/deterministic-data mode remains)
```

No other `.mdx`/`.json` file in the repo references sandbox keys, test mode, or fixture data outside the new changelog entry that announces the removal.
