### PR TITLE
docs: pick-of-the-day game_started + current-day 404 (changelog + openapi)

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -6131,7 +6131,7 @@
       "get": {
         "operationId": "getPickOfTheDay",
         "summary": "Get today's Pick of the Day",
-        "description": "One sourced sharp-money call a day (Insider-tier). Returns the single latest published pick: the backed side, the pre-game odds and $100 return, the proven smart-money holders on that side, the grade and category edge, and the thesis. The price is snapshotted before kickoff so it does not drift. Returns 404 when no pick is published.",
+        "description": "One sourced sharp-money call a day (Insider-tier). Returns the published pick for the CURRENT product day: the backed side, the pre-game odds and $100 return, the proven smart-money holders on that side, the grade and category edge, and the thesis. The price is snapshotted before kickoff so it does not drift. Returns 404 when today has no published pick yet -- it never serves a prior day's finished pick as today's, so an automated consumer never acts on a settled game (a prior pick stays available through the archive endpoint).",
         "tags": [
           "Pick of the Day"
         ],
@@ -6661,7 +6661,11 @@
           },
           "is_locked": {
             "type": "boolean",
-            "description": "Whether the market has locked (kicked off) so the snapshotted price no longer trades."
+            "description": "True only before the pick's daily release slot (a pre-release embargo flag); effectively always false on a served, already-published pick. To detect that the backed game has kicked off, use `game_started`."
+          },
+          "game_started": {
+            "type": "boolean",
+            "description": "True once the backed game's kickoff has passed (kickoff <= now). When true the snapshotted pre-game price is no longer actionable. Absent for a legacy pick with no stored kickoff (treat as not-started)."
           },
           "outcome": {
             "type": "string",

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,6 +7,13 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
+<Update label="July 5, 2026" description="Pick of the Day returns 404 outside today's pick, and adds a game_started field">
+  Two changes to [`GET /api/v1/pick-of-the-day`](/api-reference/endpoint/get-pick-of-the-day):
+
+  - **New field `game_started`** (boolean): true once the backed game's kickoff has passed, so the snapshotted pre-game price is no longer actionable. Absent for a legacy pick with no stored kickoff (treat as not-started). Additive and optional - existing clients are unaffected. Separately, the `is_locked` description was corrected: it is a pre-release embargo flag (effectively always false on a served pick), not a "kicked off" signal - use `game_started` for kickoff.
+  - **Behavior change (non-breaking):** the endpoint now returns `404` when today has no published pick yet, instead of serving the most recent prior day's (often already-settled) pick. The response shape is unchanged and `404` was already a documented response; this conforms the endpoint to its "today's Pick of the Day" contract so an automated consumer never acts on a finished game. Prior picks stay available through the archive endpoint.
+</Update>
+
 <Update label="July 4, 2026" description="Sandbox / test-mode API keys removed; a single live key class remains">
   Sandbox / test-mode API keys (`oxi_sk_test_...`) are removed. The API now has a single key class: `oxi_sk_live_...`, sent as `Authorization: Bearer oxi_sk_live_...`, which requires an active Insider subscription and always returns live data.
 


### PR DESCRIPTION
Same-round API-docs update for the merged 0xinsider/0xinsider#6944.

- **changelog.mdx**: new July 5 `<Update>` block for the `game_started` field + the current-day 404 behavior change (non-breaking).
- **api-reference/openapi.json**: adds the `game_started` property to `PickOfTheDay`, corrects the `is_locked` description (pre-release embargo, effectively always false on a served pick -- not "kicked off"), and updates the endpoint + 404 description to the current-day semantics.

Verified: `check-openapi-parity.py` -> parity OK (43 ops), openapi.json valid JSON, endpoint page exists. No new endpoint/schema; additive field + description edits + one changelog entry.