### PR TITLE
docs(changelog): sports-edge-signals now cover Golf, F1, NBA Summer League, CFL, table tennis, pickleball

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,6 +7,16 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
+<Update label="July 13, 2026" description="Sports Edge Signals now cover Golf, Formula 1, NBA Summer League, CFL, table tennis and pickleball">
+  [`GET /api/v1/sports-edge-signals`](/api-reference/endpoint/get-sports-edge-signals) and [`GET /api/v1/pick-of-the-day`](/api-reference/endpoint/get-pick-of-the-day) now return signals for six sports that were previously absent: **Golf**, **Formula 1** (and NASCAR), **NBA Summer League**, **CFL**, **table tennis** and **pickleball**.
+
+  These markets were never surfaced. Polymarket sends no specific category for them - only the generic `Sports` - and no event-level league or series metadata, so they were classified as `Sports`, which is not one of the sport buckets the signal slate is built from. They were therefore filtered out before any ranking ran. Nothing errored and nothing was logged; the sports simply did not exist as far as the API was concerned. Across the 30 days to July 13 that was 218 markets and roughly $11.9M of traded volume, the largest slices being golf majors (~$6.3M) and Formula 1 (~$4.0M).
+
+  Markets are now classified from the provider tags Polymarket actually ships (for example `pga` / `pga-tour`, `formula1`, `nba-summer-league`, `cfl`), and each rolls up to a sport bucket the slate reads. `Racing`, `Table Tennis` and `Pickleball` are new buckets; table tennis is deliberately **not** folded into `Tennis`, so the two keep separate track records.
+
+  **What this changes for you:** the `category` field on affected signals moves from `"Sports"` to the real sport, and signal volume increases as these markets become eligible. No request or response shape changed, and no existing category was renamed - so this is additive and non-breaking. Existing rows reclassify on their next provider sync.
+</Update>
+
 <Update label="July 6, 2026" description="Sports Edge Signals: ranked pre-game sports markets where graded smart money is piled">
   Added [`GET /api/v1/sports-edge-signals`](/api-reference/endpoint/get-sports-edge-signals) - the ranked list of upcoming pre-game sports markets (moneyline and props) where graded (S/A/B) smart money is piled on one side, computed server-side in one call.
 


### PR DESCRIPTION
Changelog entry for 0xinsider/0xinsider#7261.

Six sports were never surfaced by the signals API. Polymarket sends only the generic `Sports` category for them (no `eventMetadata.league`, no `seriesSlug`), so they classified as `Sports` — not one of the sport buckets the signal slate is built from — and were filtered out before any ranking ran. Silent: no error, no log.

**218 markets / ~$11.9M volume in 30 days**, mostly golf majors (~$6.3M) and Formula 1 (~$4.0M).

Externally visible, hence the changelog entry:
- `category` moves from `"Sports"` to the real sport on affected signals
- signal volume rises as these markets become eligible

Additive and non-breaking — no request/response shape change, no renamed category. Existing rows reclassify on their next provider sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)