### PR TITLE
docs: stop hardcoding the Insider price in quickstart

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -7,7 +7,7 @@ Generate a key, confirm it works, then run a real "follow the smartest traders" 
 
 ## 1. Generate your API key
 
-API access is bundled with the [Insider subscription](https://0xinsider.com/pricing) ($89/mo).
+API access is bundled with the [Insider subscription](https://0xinsider.com/pricing); current pricing is on that page.
 
 <Steps>
   <Step title="Sign up or log in">


### PR DESCRIPTION
quickstart.mdx said API access costs $89/mo; the live price is $149/mo (bumped after GA). Root-cause fix: drop the inline number and point at [/pricing](https://0xinsider.com/pricing) as the single source of truth so future price changes cannot strand the docs again.

Voice audit note: swept the whole docs site for the 0xinsider/0xinsider#7475-era hedge-speak being removed from the main site in 0xinsider/0xinsider#7614 -- zero hits; the docs voice already matches the plain semi-official standard, so no copy rewrite is needed here.

Verification: `npx mint broken-links` clean; only prose changed, no API contract change, so no changelog entry per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)