### PR TITLE
docs(api): document Pick of the Day trust, plus two fields already live but unspecified

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -9242,6 +9242,23 @@
           }
         }
       },
+      "PickTrust": {
+        "type": "object",
+        "description": "Field-level trust metadata for the full Pick of the Day payload. Present on the full shape only (omitted on the teaser and the no-pick state, because whether a specialist backs the pick is itself backed-side evidence). Unlike TraderTrust it is not gated behind expand=trust: it carries one member on an endpoint that returns a single object per day.",
+        "required": [
+          "qualifying_expert"
+        ],
+        "properties": {
+          "qualifying_expert": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TrustMetadata"
+              }
+            ],
+            "description": "Provenance of the frozen qualifying category expert, which has three states where the qualifying_expert field alone can express only two. source.kind=database with reconciliation.status=db_mirror means the evidence deserialized and is being served. freshness.status is always not_live, never fresh: this evidence is frozen at selection and never refreshed, so on an archived pick the as_of (the expert's own stats_computed_at) can be days or months old by design. source.kind=computed with reconciliation.status=not_applicable means no expert was recorded: nobody qualified on the backed side, the pick predates the field, or a manual off-slate takeover cleared it \u2014 a real negative. source.kind=unavailable means the row HAS frozen evidence that does not deserialize into the published shape: a contract defect, NOT a negative, and the pick's selection rank was decided by evidence this response cannot describe. Do not read an omitted qualifying_expert as 'no specialist' without checking this field. Note the exact claim: this reports whether the payload matched the published SHAPE, not whether it still satisfies the selection gates."
+          }
+        }
+      },
       "TraderTrust": {
         "type": "object",
         "description": "Field-level trust metadata returned only when GET /api/v1/trader/{address} includes expand=trust.",
@@ -10101,6 +10118,10 @@
             "type": "string",
             "description": "Market category (e.g. \"Soccer\")."
           },
+          "display_category": {
+            "type": "string",
+            "description": "Frozen public presentation category. For supported Polymarket sports this is the exact verified official event league (e.g. \"WNBA\" or \"UFC\"); otherwise it equals category. Additive and optional for mixed-version client compatibility."
+          },
           "platform": {
             "type": "string",
             "description": "Provider platform (e.g. \"polymarket\")."
@@ -10237,6 +10258,59 @@
             "type": "number",
             "nullable": true,
             "description": "Backed-side graded dollars the confidence is measured against (its denominator)."
+          },
+          "qualifying_expert": {
+            "type": "object",
+            "nullable": true,
+            "description": "The qualifying category expert whose sport-specific record and real position earned this pick its top selection tier: a candidate backed by one outranks every candidate without one. Present only on the full payload. Omitted when no wallet qualified on the backed side, on picks generated before the field existed, and on the first-party web teaser, which withholds all backed-side evidence. Frozen at SELECTION time \u2014 the wallet's position can move before the pick renders.",
+            "properties": {
+              "address": {
+                "type": "string",
+                "description": "Wallet address of the qualifying expert."
+              },
+              "name": {
+                "type": "string",
+                "nullable": true,
+                "description": "Provider display name, or null for an unnamed wallet."
+              },
+              "grade": {
+                "type": "string",
+                "nullable": true,
+                "description": "0xinsider grade letter. Always S or A: Pick of the Day only counts S/A wallets as proven."
+              },
+              "canonical_category": {
+                "type": "string",
+                "description": "The canonical sport bucket the win rate was measured over (for example Basketball). Can be BROADER than the pick's display_category, which names an exact league such as NBA \u2014 label the rate with this field, never with display_category."
+              },
+              "win_rate": {
+                "type": "number",
+                "description": "Share of this wallet's resolved markets in canonical_category whose realized P&L came out positive, as a 0..1 fraction. Above 0.60 by construction. Deliberately NOT phrased as \"closed profitable\": the metric counts realized P&L above zero, so a resolved winner the wallet never redeemed sits at zero and counts against it."
+              },
+              "n_resolved": {
+                "type": "integer",
+                "description": "Resolved markets in canonical_category behind win_rate. At least 10 by construction."
+              },
+              "position_usd": {
+                "type": "number",
+                "description": "Polymarket's own currentValue for this wallet on the backed outcome, in USD, as of selection. At least 1000 by construction."
+              },
+              "stats_computed_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "When the category read model behind win_rate was last rebuilt."
+              }
+            },
+            "required": [
+              "address",
+              "canonical_category",
+              "win_rate",
+              "n_resolved",
+              "position_usd",
+              "stats_computed_at"
+            ]
+          },
+          "trust": {
+            "$ref": "#/components/schemas/PickTrust"
           },
           "traders": {
             "type": "integer",

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,6 +7,18 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
+<Update label="July 26, 2026" description="Pick of the Day reports whether its category-specialist evidence is trustworthy">
+  [`GET /api/v1/pick-of-the-day`](/api-reference/endpoint/get-pick-of-the-day) adds `trust`, a full-only object carrying field-level provenance in the same vocabulary the trader endpoint uses.
+
+  It exists because `qualifying_expert` has three real states and only two serializations. That field is omitted when no wallet qualified on the backed side, when the pick predates the field, and when the stored evidence is malformed - so an absent `qualifying_expert` could not be read as "no specialist backed this pick" with any confidence. `trust.qualifying_expert` says which case applies: `source.kind: "database"` with `reconciliation.status: "db_mirror"` means the evidence is present and being served; `source.kind: "computed"` with `reconciliation.status: "not_applicable"` means no specialist was recorded, a real negative; `source.kind: "unavailable"` means the pick carries specialist evidence that does not match the published shape. The distinction matters because the specialist tier is the outermost selection rank key, so a pick whose evidence is unreadable still reached the top of the slate on the strength of it.
+
+  `freshness.status` is always `not_live`, never `fresh`: this evidence is frozen when the pick is composed and is never refreshed, so `freshness.as_of` - the expert's own `stats_computed_at` - is legitimately old on an archived pick. The object reports whether the stored payload matched the published shape; it does not re-check the selection thresholds behind that payload.
+
+  `trust` is omitted on the first-party web teaser and on the no-pick state, since whether a specialist backs the pick is itself backed-side evidence. Additive and optional: existing clients are unaffected.
+
+  This release also documents two Pick of the Day fields that were already live but missing from this specification: `qualifying_expert` and `display_category`.
+</Update>
+
 <Update label="July 14, 2026" description="Observation-only wider-holder and in-play sports cohorts">
   Added [`GET /api/v1/sports-edge-observations`](/api-reference/endpoint/get-sports-edge-observations), an Insider-tier evidence endpoint for sports opportunities that do not enter the funded Sports Edge slate.
 


### PR DESCRIPTION
Follow-through for 0xinsider/0xinsider#7955 (PR 0xinsider/0xinsider#7957), which adds a full-only `trust` object to `GET /api/v1/pick-of-the-day`.

`qualifying_expert` has three real states and only two serializations: it is omitted when nobody qualified, when the pick predates the field, and when the stored evidence is malformed. `trust.qualifying_expert` reports which case applies. `freshness.status` is always `not_live` -- the evidence is frozen when the pick is composed, so `as_of` is legitimately old on an archived pick.

Also syncs two Pick of the Day fields that were already live but missing from this specification: `qualifying_expert` (0xinsider/0xinsider#7938) and `display_category`. Both shipped without a spec sync; caught here rather than left for a third to pile on.

`api-reference/openapi.json` is a manual copy of `web/public/api/v1/openapi.json`. The sync is additive only -- 74 insertions, 0 deletions -- and preserves the file's existing unicode escaping (a naive re-dump reformatted 9 unrelated lines; that was reverted and redone).