### PR TITLE
docs: sync the API reference to the Pro plan rename and the current spec (#7867)

### DIFF
--- a/api-reference/endpoint/get-pick-of-the-day-archive.mdx
+++ b/api-reference/endpoint/get-pick-of-the-day-archive.mdx
@@ -10,7 +10,7 @@ The full Pick of the Day track record: every published pick with its real outcom
 - `hit_rate.net_profit_usd`, `staked_usd`, and `roi_pct` model a flat $100-per-pick strategy over resolved, priced picks.
 - `hit_rate.series` is the cumulative curve, one point per decided pick in ascending date order, ready to chart. Its last point equals the headline `net_profit_usd` and `pct` by construction.
 
-Resolved picks are the public record. A still-pending pick's backed side (`pick_outcome_label`) is included because the API key already proves Insider tier.
+Resolved picks are the public record. A still-pending pick's backed side (`pick_outcome_label`) is included because the API key already proves Pro tier.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \

--- a/api-reference/endpoint/get-pick-of-the-day.mdx
+++ b/api-reference/endpoint/get-pick-of-the-day.mdx
@@ -3,7 +3,7 @@ title: "Get Pick of the Day"
 openapi: "GET /api/v1/pick-of-the-day"
 ---
 
-One sourced sharp-money call a day, promoted to the API. This is an Insider-tier endpoint: your API key already proves the subscription, so the response is always the full pick (the web teaser is a product-UI concept, not an API one).
+One sourced sharp-money call a day, promoted to the API. This is a Pro-tier endpoint: your API key already proves the subscription, so the response is always the full pick (the web teaser is a product-UI concept, not an API one).
 
 The pick returns the backed side, the pre-game odds and the return on a $100 stake, the proven smart-money holders on that side, the grade and category edge, and the thesis behind it.
 

--- a/api-reference/endpoint/list-webhook-events.mdx
+++ b/api-reference/endpoint/list-webhook-events.mdx
@@ -10,4 +10,4 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/webhooks/events"
 ```
 
-Insider-only event types appear in the catalog for every authenticated key, but they deliver only to an API key with an active Insider subscription. A dormant event is subscribable but does not currently fire.
+Pro-only event types appear in the catalog for every authenticated key, but they deliver only to an API key with an active Pro subscription. A dormant event is subscribable but does not currently fire.

--- a/api-reference/objects.mdx
+++ b/api-reference/objects.mdx
@@ -412,7 +412,7 @@ One outcome token's bucketed candle series.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `state` | `full` | Yes | Always 'full' for an authenticated Insider key. |
+| `state` | `full` | Yes | Always 'full' for an authenticated Pro key. |
 | `pick_date` | string | Yes | The pick's local publication date (YYYY-MM-DD). |
 | `matchup` | string | Yes | Human-readable matchup (e.g. "Portugal vs. Uzbekistan"). |
 | `category` | string | Yes | Market category (e.g. "Soccer"). |
@@ -470,7 +470,7 @@ One outcome token's bucketed candle series.
 | `matchup` | string | Yes | Human-readable matchup (e.g. "Portugal vs. Uzbekistan"). |
 | `category` | string | Yes | Market category (e.g. "Soccer"). |
 | `image_url` | string | No | Provider (Polymarket Gamma) market thumbnail URL (markets.image); omitted (not null) when the market has no image. Public regardless of the backed-side gate, so present for pending rows too. |
-| `pick_outcome_label` | string \| null | No | The backed side's outcome label. Omitted for a still-pending pick when the request is not from an authenticated Insider key. |
+| `pick_outcome_label` | string \| null | No | The backed side's outcome label. Omitted for a still-pending pick when the request is not from an authenticated Pro key. |
 | `top_grade` | string \| null | No | Best grade among the proven smart-money holders on the backed side (S, A, B, C, D, F). |
 | `outcome` | `pending` \| `win` \| `loss` \| `void` | Yes | Settlement outcome of the backed side; 'pending' until the market resolves. |
 | `outcome_display` | string | No | Pre-formatted settlement status for display: "Win" / "Loss" / "Void" / "Pending" -- the outcome enum above as a label, from the same formatter the pick payload's outcome_display uses. Convenience only; outcome is the source value. |
@@ -995,7 +995,7 @@ Owner-scoped view of one webhook delivery attempt. Deliberately omits the reques
 
 ## WebhookEventDescriptor
 
-Self-describing entry in the webhook event catalog: the event type a subscriber lists in event_types, when it fires, the data payload shape, and whether it currently fires (active) or is reserved (dormant, subscribable but not yet delivered). Insider-only event types (wallet_grade_changed, insider_radar_flag_raised, smart_money_flow_detected) only deliver to API keys on an active Insider subscription.
+Self-describing entry in the webhook event catalog: the event type a subscriber lists in event_types, when it fires, the data payload shape, and whether it currently fires (active) or is reserved (dormant, subscribable but not yet delivered). Pro-only event types (wallet_grade_changed, insider_radar_flag_raised, smart_money_flow_detected) only deliver to API keys on an active Pro subscription.
 
 | Field | Type | Required | Description |
 |---|---|---|---|

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1,8 +1,9 @@
 {
   "openapi": "3.1.0",
   "info": {
+    "x-generated-rate-limit-policy-from": "web/src/lib/rate-limit-facts.ts via web/scripts/generate-api-policy.ts",
     "title": "0xinsider API",
-    "description": "Find your edge on Polymarket and Kalshi. Every wallet graded, every trade scored, every outlier flagged. API exposes trader grades, whale trades, smart money signals, and insider detection for AI agents, trading bots, and research tools. Normal API requests use a 30-second server timeout that returns HTTP 408 Request Timeout with an empty body when exceeded. Public REST /api/v1/* endpoints, excluding /api/v1/mcp, use Bearer-token based non-credentialed browser CORS: any Origin may call with Authorization, Content-Type, If-None-Match, Idempotency-Key, and Mcp-Session-Id request headers. Remote MCP at /api/v1/mcp is non-credentialed, but still validates Origin against the 0xinsider/localhost allowlist per MCP Streamable HTTP DNS-rebinding guidance. Successful browser CORS preflight responses advertise Access-Control-Max-Age: 86400. Browser JavaScript may read X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After, ETag, X-Request-Id, X-Request-Cost, X-Batch-RateLimit-Limit, X-Batch-RateLimit-Remaining, X-Batch-RateLimit-Reset, Mcp-Session-Id, and X-Mcp-Error-Code response headers. Credentialed first-party routes such as /api/keys, /api/billing, and auth endpoints remain restricted to configured 0xinsider origins.",
+    "description": "Follow provider-exposed large-trade activity from Polymarket and Kalshi. Polymarket wallet-attributed trades can add grades, P&L, strategy, and diagnostic-score context when sufficient source data exists; Kalshi public prints remain anonymous, and fields can be null or unavailable. Normal API requests use a 30-second server timeout that returns HTTP 408 Request Timeout with an empty body when exceeded. Public REST /api/v1/* endpoints, excluding /api/v1/mcp, use Bearer-token based non-credentialed browser CORS: any Origin may call with Authorization, Content-Type, If-None-Match, Idempotency-Key, and Mcp-Session-Id request headers. Remote MCP at /api/v1/mcp is non-credentialed, but still validates Origin against the 0xinsider/localhost allowlist per MCP Streamable HTTP DNS-rebinding guidance. Successful browser CORS preflight responses advertise Access-Control-Max-Age: 86400. Browser JavaScript may read X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After, ETag, X-Request-Id, X-Request-Cost, X-Batch-RateLimit-Limit, X-Batch-RateLimit-Remaining, X-Batch-RateLimit-Reset, Mcp-Session-Id, and X-Mcp-Error-Code response headers. Credentialed first-party routes such as /api/keys, /api/billing, and auth endpoints remain restricted to configured 0xinsider origins.",
     "version": "1.0.0",
     "contact": {
       "name": "0xinsider",
@@ -13,7 +14,7 @@
   "servers": [
     {
       "url": "https://api.0xinsider.com",
-      "description": "Production (live data). Authenticate with a live key (oxi_sk_live_...); requires an active Insider subscription."
+      "description": "Production (live data). Authenticate with a live key (oxi_sk_live_...); requires an active Pro subscription."
     }
   ],
   "security": [
@@ -739,7 +740,7 @@
       "get": {
         "operationId": "getPositionTimeline",
         "summary": "Get a trader's position timeline for one market",
-        "description": "Returns every Polymarket fill for one trader in one market, newest first, with server-computed running_amount and running_avg_price. Only HOT and WARM tier traders are tracked; other traders return 404. running_avg_price is a buy-weighted entry basis (sells do not change the running average) matching Polymarket /positions avgPrice semantics. Cursor-paginated. An id-keyed alias exists at GET /api/v1/traders/{id}/position-timeline.",
+        "description": "Returns stored Polymarket fills for one tracked trader in one market, newest first, with server-computed running_amount and running_avg_price. The {address} segment accepts the same four identity shapes as the plural alias: 0x... wallet, username, trd_-prefixed trader id, or bare integer traders.id, resolved with precedence wallet -> trd_ -> integer -> username. Only HOT and WARM tier traders are tracked; other traders return 404. running_avg_price is a buy-weighted entry basis (sells do not change the running average) matching Polymarket /positions avgPrice semantics. Cursor-paginated.",
         "tags": [
           "Traders"
         ],
@@ -748,7 +749,7 @@
             "name": "address",
             "in": "path",
             "required": true,
-            "description": "Trader wallet address (0x...) or trd_-prefixed trader ID emitted by this API. Case-insensitive wallet addresses are lowercased server-side.",
+            "description": "Trader identity: 0x... wallet address, username, trd_-prefixed trader id, or bare integer traders.id. Resolved with precedence wallet -> trd_ -> integer -> username; wallet matching is case-insensitive.",
             "schema": {
               "type": "string"
             }
@@ -911,7 +912,7 @@
           {
             "lang": "curl",
             "label": "cURL",
-            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/trader/{address}/position-timeline'"
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/trader/0x1111111111111111111111111111111111111111/position-timeline?condition_id=0x2222222222222222222222222222222222222222222222222222222222222222'"
           }
         ],
         "x-examples": {
@@ -1134,7 +1135,7 @@
       "get": {
         "operationId": "getPositionTimelineById",
         "summary": "Get a trader's position timeline (unified identity resolver)",
-        "description": "Unified trader-timeline route (#4975). {trader} accepts all four identity shapes - 0x... wallet, username, trd_-prefixed trader id, and bare integer id - resolved by the single shared trader-identity resolver. Returns every Polymarket fill for one trader in one market, newest first, with server-computed running_amount and running_avg_price. Only HOT and WARM tier traders are tracked; other traders return 404. Response body is byte-identical to the singular GET /api/v1/trader/{address}/position-timeline route for the same (trader, market). The prior integer-id-only variant is preserved: the same path now accepts every identity shape.",
+        "description": "Unified trader-timeline route (#4975). {trader} accepts all four identity shapes - 0x... wallet, username, trd_-prefixed trader id, and bare integer id - resolved by the single shared trader-identity resolver. Returns stored Polymarket fills for one tracked trader in one market, newest first, with server-computed running_amount and running_avg_price. Only HOT and WARM tier traders are tracked; other traders return 404. Response payload matches the singular GET /api/v1/trader/{address}/position-timeline route for the same (trader, market), except for the per-request meta.request_id. The prior integer-id-only variant is preserved: the same path now accepts every identity shape.",
         "tags": [
           "Traders"
         ],
@@ -1306,7 +1307,7 @@
           {
             "lang": "curl",
             "label": "cURL",
-            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/traders/{id}/position-timeline'"
+            "source": "curl -sS \\\n  -H 'Authorization: Bearer $OXI_SK' \\\n  'https://api.0xinsider.com/api/v1/traders/trd_123/position-timeline?condition_id=0x2222222222222222222222222222222222222222222222222222222222222222'"
           }
         ],
         "x-examples": {
@@ -1545,7 +1546,7 @@
       "get": {
         "operationId": "listLargePositions",
         "summary": "List large positions",
-        "description": "Returns the largest current open positions from graded traders, value-descending, with opaque cursor pagination. Polymarket-only by design: the large-positions scanner filters platform = 'polymarket' (backend/crates/large-positions/src/scanner.rs), so no Kalshi rows are ever scanned and a Kalshi or unknown condition_id filter returns an empty list (never fabricated rows). The teaser cap that the internal product UI applies to anonymous viewers does not apply here: the API key already proves an active insider/annual subscription, so authed API callers get full access.",
+        "description": "Returns the largest current open positions from graded traders, value-descending, with opaque cursor pagination. Polymarket-only by design: the large-positions scanner filters platform = 'polymarket' (backend/crates/large-positions/src/scanner.rs), so no Kalshi rows are ever scanned and a Kalshi or unknown condition_id filter returns an empty list (never fabricated rows). The teaser cap that the internal product UI applies to anonymous viewers does not apply here: the API key already proves an active Pro subscription (wire tier `insider`), so authed API callers get full access.",
         "tags": [
           "Large Positions"
         ],
@@ -1580,7 +1581,7 @@
           {
             "name": "category",
             "in": "query",
-            "description": "Filter by provider-backed market category.",
+            "description": "One RFC 4180 CSV record of exact current provider-backed market_canonical.category values. Legacy unquoted lists such as NBA,WNBA remain valid; values containing commas, quotes, or newlines are CSV-quoted. Matching is case-insensitive. Malformed quoted input fails closed as one unknown exact category.",
             "schema": {
               "type": "string"
             }
@@ -2537,7 +2538,7 @@
       "get": {
         "operationId": "getPickOfTheDay",
         "summary": "Get today's Pick of the Day",
-        "description": "One sourced sharp-money call a day (Insider-tier). Returns the published pick for the CURRENT product day: the backed side, the pre-game odds and $100 return, the proven smart-money holders on that side, the grade, and the thesis. The price is snapshotted before kickoff so it does not drift. It never serves a prior day's finished pick as today's, so an automated consumer never acts on a stale, already-settled game (a prior pick stays available through the archive endpoint). When no pick is published for the current product day it returns 404 with error.code=\"not_found\" and error.reason=\"pick_not_released\" -- branch on the reason, because error.code is a frozen contract and stays \"not_found\". That 404 is a schedule, not an outage: each selected pick normally releases one hour before its provider kickoff, within the 11:00-19:00 UTC operating window; a skipped day has no release. DO NOT POLL. error.retry_at (RFC3339, always in the future) and Retry-After give the recommended next attempt: an exact floor before a scheduled release, or a bounded cadence while the selector is hunting. Schedule one request rather than sleeping a worker thread.",
+        "description": "One sourced sharp-money call a day (Pro-tier). Returns the published pick for the CURRENT product day: the backed side, the pre-game odds and $100 return, the proven smart-money holders on that side, the grade, and a required truthful thesis. With proven holder backing the thesis uses the sharp-money grammar; without it the required string names the Pick of the Day without fabricating proof. The price is snapshotted before kickoff so it does not drift. It never serves a prior day's finished pick as today's, so an automated consumer never acts on a stale, already-settled game (a prior pick stays available through the archive endpoint). When no pick is published for the current product day it returns 404 with error.code=\"not_found\" and error.reason=\"pick_not_released\" -- branch on the reason, because error.code is a frozen contract and stays \"not_found\". That 404 is a schedule, not an outage: each selected pick normally releases one hour before its provider kickoff, within the 11:00-23:00 UTC operating window; a skipped day has no release. DO NOT POLL. error.retry_at (RFC3339, always in the future) and Retry-After give the recommended next attempt: the automatic release boundary before a selected pick; normally the persisted next automatic selector attempt (~15m) while no candidate exists; or a ~60s degradation when that schedule is absent, due, or a pick is overdue. Every value is advisory under supported operator actions: manual publication, release-time override, or admin generation can make a pick available first. Schedule one request rather than sleeping a worker thread.",
         "tags": [
           "Pick of the Day"
         ],
@@ -2599,7 +2600,7 @@
                 },
                 "examples": {
                   "success": {
-                    "summary": "Successful response",
+                    "summary": "Published pick whose selector recorded no qualifying category expert -- a real negative, confirmed by trust",
                     "value": {
                       "object": "pick_of_the_day",
                       "data": {
@@ -2607,6 +2608,7 @@
                         "pick_date": "2026-06-23",
                         "matchup": "Portugal vs. Uzbekistan",
                         "category": "Soccer",
+                        "display_category": "Soccer",
                         "platform": "polymarket",
                         "release_at": "2026-06-23T17:00:00Z",
                         "is_locked": false,
@@ -2639,8 +2641,8 @@
                         ],
                         "holder_count": 7,
                         "editorial_note": null,
-                        "thesis": "Graded soccer specialists are stacked on Portugal at a price the market has not fully repriced.",
-                        "market_url": "https://0xinsider.com/market/portugal-vs-uzbekistan",
+                        "thesis": "Proven sharp money holds Portugal, led by a grade-A trader.",
+                        "market_url": "https://0xinsider.com/event/portugal-vs-uzbekistan",
                         "event_slug": "portugal-vs-uzbekistan",
                         "sports_context": {
                           "league_name": "FIFA World Cup",
@@ -2669,7 +2671,128 @@
                           "event_matchup": false,
                           "matchup_title": "Portugal \u2013 Uzbekistan"
                         },
-                        "disclaimer": "Not financial advice. Prediction markets carry risk; do your own research."
+                        "disclaimer": "Not financial advice. Prediction markets carry risk; do your own research.",
+                        "trust": {
+                          "qualifying_expert": {
+                            "source": {
+                              "kind": "computed",
+                              "owner": "pick_of_the_day",
+                              "field": "qualifying_expert"
+                            },
+                            "freshness": {
+                              "status": "not_live"
+                            },
+                            "reconciliation": {
+                              "status": "not_applicable",
+                              "detail": "the selector evaluated this pick and no qualifying category expert was recorded on the backed side"
+                            },
+                            "completeness": {
+                              "status": "not_applicable",
+                              "detail": "the selector evaluated this pick and no qualifying category expert was recorded on the backed side"
+                            }
+                          }
+                        }
+                      },
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false,
+                        "cost": 1
+                      }
+                    }
+                  },
+                  "specialist_evidence_unavailable": {
+                    "summary": "Identical absent qualifying_expert, but the stored evidence is malformed. Read trust before concluding that no specialist backed the pick.",
+                    "value": {
+                      "object": "pick_of_the_day",
+                      "data": {
+                        "state": "full",
+                        "pick_date": "2026-06-23",
+                        "matchup": "Portugal vs. Uzbekistan",
+                        "category": "Soccer",
+                        "display_category": "Soccer",
+                        "platform": "polymarket",
+                        "release_at": "2026-06-23T17:00:00Z",
+                        "is_locked": false,
+                        "outcome": "pending",
+                        "pick_outcome_label": "Portugal",
+                        "position": "Portugal to win",
+                        "side_summary": "Smart money is backing Portugal",
+                        "smart_wallet_count": 7,
+                        "top_grade": "A",
+                        "smart_usd": 48250.0,
+                        "backed_price": 0.62,
+                        "return_per_100": 161.29,
+                        "sharp_pct": 0.9,
+                        "market_pct": 0.62,
+                        "consensus_edge_pct": 0.28,
+                        "directional_confidence": 0.82,
+                        "one_way_holder_count": 3,
+                        "hedged_holder_count": 1,
+                        "one_way_graded_usd": 820.0,
+                        "total_graded_usd": 1000.0,
+                        "traders": 7,
+                        "backed_sharp_usd": 312500.0,
+                        "holders": [
+                          {
+                            "address": "0x0000000000000000000000000000000000000000",
+                            "name": "swisstony",
+                            "grade": "A",
+                            "shares": 12500.0
+                          }
+                        ],
+                        "holder_count": 7,
+                        "editorial_note": null,
+                        "thesis": "Proven sharp money holds Portugal, led by a grade-A trader.",
+                        "market_url": "https://0xinsider.com/event/portugal-vs-uzbekistan",
+                        "event_slug": "portugal-vs-uzbekistan",
+                        "sports_context": {
+                          "league_name": "FIFA World Cup",
+                          "league_logo": "https://polymarket.com/leagues/fifa-world-cup.png",
+                          "yes_team": {
+                            "label": "Portugal",
+                            "short_label": "POR",
+                            "full_name": "Portugal national football team",
+                            "provider_id": 1421,
+                            "logo": "https://polymarket.com/teams/portugal.png",
+                            "color": "#C8102E",
+                            "record": null,
+                            "score": null
+                          },
+                          "no_team": {
+                            "label": "Uzbekistan",
+                            "short_label": "UZB",
+                            "full_name": "Uzbekistan national football team",
+                            "provider_id": 1738,
+                            "logo": "https://polymarket.com/teams/uzbekistan.png",
+                            "color": "#1EB53A",
+                            "record": null,
+                            "score": null
+                          },
+                          "game_id": 884213,
+                          "event_matchup": false,
+                          "matchup_title": "Portugal \u2013 Uzbekistan"
+                        },
+                        "disclaimer": "Not financial advice. Prediction markets carry risk; do your own research.",
+                        "trust": {
+                          "qualifying_expert": {
+                            "source": {
+                              "kind": "unavailable",
+                              "owner": "pick_of_the_day",
+                              "field": "qualifying_expert"
+                            },
+                            "freshness": {
+                              "status": "unavailable"
+                            },
+                            "reconciliation": {
+                              "status": "unavailable",
+                              "detail": "frozen qualifying-expert evidence does not deserialize into the published shape; the specialist that decided this pick's selection rank cannot be described"
+                            },
+                            "completeness": {
+                              "status": "unavailable",
+                              "detail": "frozen qualifying-expert evidence does not deserialize into the published shape; the specialist that decided this pick's selection rank cannot be described"
+                            }
+                          }
+                        }
                       },
                       "meta": {
                         "request_id": "req_example",
@@ -2715,7 +2838,7 @@
             "$ref": "#/components/responses/RateLimited"
           },
           "503": {
-            "$ref": "#/components/responses/RateLimitUnavailable"
+            "$ref": "#/components/responses/ReadModelWarming"
           }
         },
         "x-codeSamples": [
@@ -2733,6 +2856,7 @@
               "pick_date": "2026-06-23",
               "matchup": "Portugal vs. Uzbekistan",
               "category": "Soccer",
+              "display_category": "Soccer",
               "platform": "polymarket",
               "release_at": "2026-06-23T17:00:00Z",
               "is_locked": false,
@@ -2765,8 +2889,8 @@
               ],
               "holder_count": 7,
               "editorial_note": null,
-              "thesis": "Graded soccer specialists are stacked on Portugal at a price the market has not fully repriced.",
-              "market_url": "https://0xinsider.com/market/portugal-vs-uzbekistan",
+              "thesis": "Proven sharp money holds Portugal, led by a grade-A trader.",
+              "market_url": "https://0xinsider.com/event/portugal-vs-uzbekistan",
               "event_slug": "portugal-vs-uzbekistan",
               "sports_context": {
                 "league_name": "FIFA World Cup",
@@ -2795,7 +2919,27 @@
                 "event_matchup": false,
                 "matchup_title": "Portugal \u2013 Uzbekistan"
               },
-              "disclaimer": "Not financial advice. Prediction markets carry risk; do your own research."
+              "disclaimer": "Not financial advice. Prediction markets carry risk; do your own research.",
+              "trust": {
+                "qualifying_expert": {
+                  "source": {
+                    "kind": "computed",
+                    "owner": "pick_of_the_day",
+                    "field": "qualifying_expert"
+                  },
+                  "freshness": {
+                    "status": "unknown"
+                  },
+                  "reconciliation": {
+                    "status": "not_applicable",
+                    "detail": "this pick was never evaluated for a qualifying category expert: it predates the field or was replaced by a manual off-slate takeover"
+                  },
+                  "completeness": {
+                    "status": "not_computed",
+                    "detail": "this pick was never evaluated for a qualifying category expert: it predates the field or was replaced by a manual off-slate takeover"
+                  }
+                }
+              }
             },
             "meta": {
               "request_id": "req_example",
@@ -2810,7 +2954,7 @@
       "get": {
         "operationId": "getPickOfTheDayArchive",
         "summary": "Get the Pick of the Day track record",
-        "description": "Every published Pick of the Day with its real outcome, plus the rolling hit rate (wins / decided; void and pending excluded). Resolved picks are public; a still-pending pick's backed side is included for the authenticated Insider key.",
+        "description": "Every published Pick of the Day with its real outcome, plus the rolling hit rate (wins / decided; void and pending excluded). Resolved picks are public; a still-pending pick's backed side is included for the authenticated Pro key.",
         "tags": [
           "Pick of the Day"
         ],
@@ -2878,22 +3022,24 @@
                       "data": {
                         "picks": [
                           {
+                            "pick_date": "2026-06-23",
+                            "matchup": "Portugal vs. Uzbekistan",
+                            "category": "Soccer",
+                            "display_category": "Soccer",
+                            "pick_outcome_label": "Portugal",
+                            "top_grade": "A",
+                            "outcome": "pending"
+                          },
+                          {
                             "pick_date": "2026-06-22",
                             "matchup": "Spain vs. France",
                             "category": "Soccer",
+                            "display_category": "Soccer",
                             "image_url": "https://polymarket-upload.s3.us-east-2.amazonaws.com/soccer%20ball-bba4025f77.png",
                             "pick_outcome_label": "Spain",
                             "top_grade": "A",
                             "outcome": "win",
                             "return_per_100": 200.0
-                          },
-                          {
-                            "pick_date": "2026-06-23",
-                            "matchup": "Portugal vs. Uzbekistan",
-                            "category": "Soccer",
-                            "pick_outcome_label": "Portugal",
-                            "top_grade": "A",
-                            "outcome": "pending"
                           }
                         ],
                         "hit_rate": {
@@ -4087,7 +4233,7 @@
       "get": {
         "operationId": "listSportsEdgeSignals",
         "summary": "List ranked pre-game sports-edge signals",
-        "description": "Insider-tier. Ranked list of upcoming pre-game sports markets (moneyline + props) where graded (S/A/B) smart money is piled on one side, each row carrying the piled side, its grade distribution (S/A/B counts, dollar concentration, top grade), the kickoff time, and the piled-side Polymarket CLOB token id. Eligibility is a market with recent graded whale FLOW in the kickoff window; ranking is the current graded HOLDER pile. Deliberately NOT the editorial Pick of the Day ranker. Served from a shared server-side snapshot cache (TTL ~180s) computed once per category window at the maximum 48h horizon and filtered to the requested horizon_hours at request time (so every horizon shares one cache entry); the cursor pins to that snapshot and a stale cursor is rejected. Polymarket only (Kalshi lacks kickoff + graded-holder data).",
+        "description": "Pro-tier. Ranked list of upcoming pre-game sports markets (moneyline + props) where graded (S/A/B) smart money is piled on one side, each row carrying the piled side, its grade distribution, kickoff, piled-side Polymarket CLOB token id, and required shadow-only category_skill evidence. Eligibility and ranking remain the funded FLOW/HOLDER contract; category skill cannot change membership, order, rank, cursor, routing, or sizing. meta exposes explicit category source/model/status plus independently computed pre/post SHA-256 base-vector hashes that must match. Served from a shared server-side snapshot cache (healthy TTL ~180s, degraded ~30s) computed once per category at the maximum 48h horizon and filtered at request time; the cursor pins to that snapshot and a stale cursor is rejected. Polymarket only; source coverage is partial first-observed post-launch Goldsky primary taker BUY fills admitted by the canonical whale-alert thresholds, never reconstructed history. Deliberately not the editorial Pick of the Day ranker.",
         "tags": [
           "Markets"
         ],
@@ -4273,7 +4419,7 @@
       "get": {
         "operationId": "listSportsEdgeObservations",
         "summary": "List observation-only sports-edge cohorts",
-        "description": "Insider-tier. Measures two explicitly observation-only Polymarket sports cohorts without changing or feeding GET /api/v1/sports-edge-signals: wider_holder measures pre-game holder piles outside the funded route's exact raw slate admission, including recent-flow rows rejected by its event, bucket, or total caps; in_play admits only provider-confirmed live games and fails closed when the provider live-board snapshot is stale or unavailable or holder/directional evidence is stale or unavailable. Every row carries observation_only=true, provider/holder freshness and completeness fields, and the response carries a required snapshot-wide operational/unknown-completeness degraded boolean plus an accountable per-sport funnel over a closed 25-value terminal-reason vocabulary. Omitted or blank category selects all 14 registered observation sport buckets, including Table Tennis and Pickleball; those two remain outside the funded sports projection. All category and all-sports cache scopes share one global observation provider-work admission, so distinct scope keys cannot multiply concurrent provider fanout. One absolute ~25s compute deadline covers cache coordination, board/universe and primary-slate membership reads, holder cache/provider work, price/metadata evaluation, and directional reads, leaving ~5s below the public router timeout for funnel reconciliation, cleanup, and response transport. A shared pre-holder stage deadline jointly bounds those database reads and board reconciliation to the smaller of 12s or half of the absolute budget remaining when that stage starts, preserving holder/post-holder opportunity; board reads use bounded fair waves and cold holder admission gives each represented canonical sport one row before any sport repeats. Single-flight refresh contention, global provider-work admission contention, absolute deadline exhaustion before a usable cache, or pre-holder stage expiry before a usable stored universe or primary-slate membership result returns 503 with error.reason=read_model_warming. Category-resolution SQL errors, Redis coordination failures, observation-universe SQL errors, and primary-slate membership query failures return 500 internal_error instead. Once a usable universe exists, later operational or unknown-completeness board, holder, or price/metadata failures are retained as explicit terminal reasons in a degraded 200 response with degraded=true: board_source_unavailable is a completed board-source failure, board_deadline_unavailable is fair-wave deadline exhaustion, provider_unavailable is an attempted holder-provider failure, and holder_deadline_unavailable is holder-stage deadline exhaustion. Directional incompleteness is cohort-specific: a wider_holder row remains emitted with terminal wider_holder_emitted and directional_status=unavailable, while an in_play row fails closed with terminal in_play_directional_unavailable. capacity_limited records intentional bounded provider-work admission in the funnel and does not by itself set degraded=true. Healthy wider_holder requests may reuse a snapshot for ~180s; in_play never serves a cached observation snapshot older than ~30s, and degraded snapshots use ~30s. The ETag is a weak semantic validator over the stable page payload, including next_cursor, with request-specific meta excluded.",
+        "description": "Pro-tier. Measures two explicitly observation-only Polymarket sports cohorts without changing or feeding GET /api/v1/sports-edge-signals: wider_holder measures pre-game holder piles outside the funded route's exact raw slate admission, including recent-flow rows rejected by its event, bucket, or total caps; in_play admits only provider-confirmed live games and fails closed when the provider live-board snapshot is stale or unavailable or holder/directional evidence is stale or unavailable. Every row carries observation_only=true, provider/holder freshness and completeness fields, and the response carries a required snapshot-wide operational/unknown-completeness degraded boolean plus an accountable per-sport funnel over a closed 25-value terminal-reason vocabulary. Omitted or blank category selects all 14 registered observation sport buckets, including Table Tennis and Pickleball; those two remain outside the funded sports projection. All category and all-sports cache scopes share one global observation provider-work admission, so distinct scope keys cannot multiply concurrent provider fanout. One absolute ~25s compute deadline covers cache coordination, board/universe and primary-slate membership reads, holder cache/provider work, price/metadata evaluation, and directional reads, leaving ~5s below the public router timeout for funnel reconciliation, cleanup, and response transport. A shared pre-holder stage deadline jointly bounds those database reads and board reconciliation to the smaller of 12s or half of the absolute budget remaining when that stage starts, preserving holder/post-holder opportunity; board reads use bounded fair waves and cold holder admission gives each represented canonical sport one row before any sport repeats. Single-flight refresh contention, global provider-work admission contention, absolute deadline exhaustion before a usable cache, or pre-holder stage expiry before a usable stored universe or primary-slate membership result returns 503 with error.reason=read_model_warming. Category-resolution SQL errors, Redis coordination failures, observation-universe SQL errors, and primary-slate membership query failures return 500 internal_error instead. Once a usable universe exists, later operational or unknown-completeness board, holder, or price/metadata failures are retained as explicit terminal reasons in a degraded 200 response with degraded=true: board_source_unavailable is a completed board-source failure, board_deadline_unavailable means live-board work missed either an internal configured-scope deadline or the outer fair-wave deadline; both classify only already-started rows, so for the upcoming source read funnel.sports[].board_upcoming_status instead; provider_unavailable is an attempted holder-provider failure, and holder_deadline_unavailable is holder-stage deadline exhaustion. Directional incompleteness is cohort-specific: a wider_holder row remains emitted with terminal wider_holder_emitted and directional_status=unavailable, while an in_play row fails closed with terminal in_play_directional_unavailable. capacity_limited records intentional bounded provider-work admission in the funnel and does not by itself set degraded=true. Healthy wider_holder requests may reuse a snapshot for ~180s; in_play never serves a cached observation snapshot older than ~30s, and degraded snapshots use ~30s. The ETag is a weak semantic validator over the stable page payload, including next_cursor, with request-specific meta excluded.",
         "tags": [
           "Markets"
         ],
@@ -4346,6 +4492,13 @@
               },
               "ETag": {
                 "$ref": "#/components/headers/ETag"
+              },
+              "Cache-Control": {
+                "description": "Client caches may store the private response but must revalidate it before every reuse, independently of the server-side snapshot TTL.",
+                "schema": {
+                  "type": "string",
+                  "const": "private, no-cache"
+                }
               }
             },
             "content": {
@@ -4401,10 +4554,17 @@
             }
           },
           "304": {
-            "description": "Not Modified. Returned when If-None-Match matches the current payload.",
+            "description": "Not Modified. Returned when If-None-Match matches the current sports-edge observation payload.",
             "headers": {
               "ETag": {
                 "$ref": "#/components/headers/ETag"
+              },
+              "Cache-Control": {
+                "description": "Client caches may store the private response but must revalidate it before every reuse, independently of the server-side snapshot TTL.",
+                "schema": {
+                  "type": "string",
+                  "const": "private, no-cache"
+                }
               }
             }
           },
@@ -5604,7 +5764,7 @@
       "get": {
         "operationId": "getStream",
         "summary": "Resumable real-time event stream (SSE)",
-        "description": "Server-Sent Events stream of the live feed envelopes the platform already broadcasts (whale-trade pulses and other public/insider feed events). Forwards the same backend-owned envelope shape as the internal feed; no provider data is recomputed. Authenticated via the oxi_sk Bearer key like every other /api/v1 endpoint, and limited to a small number of concurrent connections per API key and a cluster-wide ceiling across all keys (HTTP 429 with Retry-After when either cap is exceeded; HTTP 503 with Retry-After if the admission backend is briefly unavailable). Each delivered frame carries an SSE id equal to the envelope sequence; reconnect with the Last-Event-ID header (or the last_event_id / seq query fallback) to replay the missed window before resuming live. When the requested resume point predates the retained window the stream emits one resync marker event (event: resync) instead of silently skipping frames. Idle connections receive periodic ': keep-alive' comment lines. This is a long-lived response: keep the connection open and read frames as they arrive.",
+        "description": "Server-Sent Events stream of the live feed envelopes the platform already broadcasts (whale-trade pulses and other public/Pro feed events). Forwards the same backend-owned envelope shape as the internal feed; no provider data is recomputed. Authenticated via the oxi_sk Bearer key like every other /api/v1 endpoint, and limited to a small number of concurrent connections per API key and a cluster-wide ceiling across all keys (HTTP 429 with Retry-After when either cap is exceeded; HTTP 503 with Retry-After if the admission backend is briefly unavailable). Each delivered frame carries an SSE id equal to the envelope sequence; reconnect with the Last-Event-ID header (or the last_event_id / seq query fallback) to replay the missed window before resuming live. When the requested resume point predates the retained window the stream emits one resync marker event (event: resync) instead of silently skipping frames. Idle connections receive periodic ': keep-alive' comment lines. This is a long-lived response: keep the connection open and read frames as they arrive.",
         "tags": [
           "Streaming"
         ],
@@ -5909,7 +6069,7 @@
       "get": {
         "operationId": "listWebhooks",
         "summary": "List builder webhook destinations",
-        "description": "Returns webhook destinations owned by the authenticated API key user. Disabled endpoints are omitted. Subscribable event_types and their payload shapes are described by GET /api/v1/webhooks/events. Three event types are Insider-only and only deliver to API keys on an active Insider subscription: wallet_grade_changed (data: wallet, trader_id, old_grade, new_grade, direction (upgrade|downgrade), skill_index, final_score, date) fires on a Pass-2 grade transition; insider_radar_flag_raised (data: trade_id, wallet, trader_id, condition_id, suspicion_score, track, side (yes|no), size, price) fires the first time a trade's suspicion score crosses the radar flag threshold; smart_money_flow_detected (data: condition_id, net_flow_usd, abs_net_flow_usd, dominant_side (yes|no), grade_floor (S|A|B|C|D|F), whale_trade_count, window) fires when a scheduled scanner detects ranked-trader net flow crossing a threshold (up or down) on a market.",
+        "description": "Returns webhook destinations owned by the authenticated API key user. Disabled endpoints are omitted. Subscribable event_types and their payload shapes are described by GET /api/v1/webhooks/events. Four subscribable event types are Pro-only and only deliver to API keys on an active Pro subscription. whale_trades_inserted is one of them, gated by the same SubscriberScope::InsiderOnly mechanism as the other three (each type carries its own LiveEventContract entry; they share the scope value). The other three: wallet_grade_changed (data: wallet, trader_id, old_grade, new_grade, direction (upgrade|downgrade), skill_index, final_score, date) fires on a Pass-2 grade transition; insider_radar_flag_raised (data: trade_id, wallet, trader_id, condition_id, suspicion_score, track, side (yes|no), size, price) fires the first time a trade's suspicion score crosses the radar flag threshold; smart_money_flow_detected (data: condition_id, net_flow_usd, abs_net_flow_usd, dominant_side (yes|no), grade_floor (S|A|B|C|D|F), whale_trade_count, window) fires when a scheduled scanner detects ranked-trader net flow crossing a threshold (up or down) on a market.",
         "tags": [
           "Webhooks"
         ],
@@ -5980,7 +6140,7 @@
       "post": {
         "operationId": "createWebhook",
         "summary": "Create a builder webhook destination",
-        "description": "Creates a pending HTTPS webhook destination. The response includes one-time signing_secret and verification.token values. Deliveries are not sent until the endpoint is verified. The subscribable event_types and their data payload shapes are described by GET /api/v1/webhooks/events; the per-endpoint delivery log is GET /api/v1/webhooks/{id}/deliveries. Three event types are Insider-only and only deliver to API keys on an active Insider subscription: wallet_grade_changed (data: wallet, trader_id, old_grade, new_grade, direction (upgrade|downgrade), skill_index, final_score, date) fires on a Pass-2 grade transition; insider_radar_flag_raised (data: trade_id, wallet, trader_id, condition_id, suspicion_score, track, side (yes|no), size, price) fires the first time a trade's suspicion score crosses the radar flag threshold; smart_money_flow_detected (data: condition_id, net_flow_usd, abs_net_flow_usd, dominant_side (yes|no), grade_floor (S|A|B|C|D|F), whale_trade_count, window) fires when a scheduled scanner detects ranked-trader net flow crossing a threshold (up or down) on a market. Delivery signing: each delivery request carries an HMAC-SHA256 signature in the x-0xinsider-signature header formatted as v1=<hex>, where <hex> is HMAC-SHA256(signing_secret, \"<timestamp>.<raw_request_body>\"). The signed <timestamp> is sent separately as x-0xinsider-timestamp (unix seconds). To verify a delivery: read x-0xinsider-timestamp, reject it if it differs from the current time by more than 300 seconds, recompute v1=<hex> over \"<timestamp>.<raw_body>\" with your signing_secret, and compare against x-0xinsider-signature using a constant-time comparison. Each delivery also carries x-0xinsider-event-id, x-0xinsider-event-type, x-0xinsider-delivery-id, and x-0xinsider-delivery-attempt headers.",
+        "description": "Creates a pending HTTPS webhook destination. The response includes one-time signing_secret and verification.token values. Deliveries are not sent until the endpoint is verified. The subscribable event_types and their data payload shapes are described by GET /api/v1/webhooks/events; the per-endpoint delivery log is GET /api/v1/webhooks/{id}/deliveries. Four subscribable event types are Pro-only and only deliver to API keys on an active Pro subscription. whale_trades_inserted is one of them, gated by the same SubscriberScope::InsiderOnly mechanism as the other three (each type carries its own LiveEventContract entry; they share the scope value). The other three: wallet_grade_changed (data: wallet, trader_id, old_grade, new_grade, direction (upgrade|downgrade), skill_index, final_score, date) fires on a Pass-2 grade transition; insider_radar_flag_raised (data: trade_id, wallet, trader_id, condition_id, suspicion_score, track, side (yes|no), size, price) fires the first time a trade's suspicion score crosses the radar flag threshold; smart_money_flow_detected (data: condition_id, net_flow_usd, abs_net_flow_usd, dominant_side (yes|no), grade_floor (S|A|B|C|D|F), whale_trade_count, window) fires when a scheduled scanner detects ranked-trader net flow crossing a threshold (up or down) on a market. Delivery signing: each delivery request carries an HMAC-SHA256 signature in the x-0xinsider-signature header formatted as v1=<hex>, where <hex> is HMAC-SHA256(signing_secret, \"<timestamp>.<raw_request_body>\"). The signed <timestamp> is sent separately as x-0xinsider-timestamp (unix seconds). To verify a delivery: read x-0xinsider-timestamp, reject it if it differs from the current time by more than 300 seconds, recompute v1=<hex> over \"<timestamp>.<raw_body>\" with your signing_secret, and compare against x-0xinsider-signature using a constant-time comparison. Each delivery also carries x-0xinsider-event-id, x-0xinsider-event-type, x-0xinsider-delivery-id, and x-0xinsider-delivery-attempt headers.",
         "tags": [
           "Webhooks"
         ],
@@ -6077,7 +6237,7 @@
       "get": {
         "operationId": "listWebhookEvents",
         "summary": "List webhook event catalog",
-        "description": "Self-describing catalog of every webhook event type: its description, data payload shape, and whether it is active (has a firing producer) or dormant (subscribable but not yet delivered). The catalog is identical for every authenticated key and exposes no owner-scoped data. Insider-only event types (wallet_grade_changed, insider_radar_flag_raised, smart_money_flow_detected) appear in the catalog but only deliver to API keys on an active Insider subscription.",
+        "description": "Self-describing catalog of every webhook event type: its description, data payload shape, and whether it is active (has a firing producer) or dormant (subscribable but not yet delivered). The catalog is identical for every authenticated key and exposes no owner-scoped data. Pro-only event types (whale_trades_inserted, wallet_grade_changed, insider_radar_flag_raised, smart_money_flow_detected) appear in the catalog but only deliver to API keys on an active Pro subscription.",
         "tags": [
           "Webhooks"
         ],
@@ -6430,7 +6590,7 @@
       "patch": {
         "operationId": "updateWebhook",
         "summary": "Update a builder webhook destination",
-        "description": "Updates name, HTTPS URL, event types, or enabled state. URL changes force pending_verification and return a new verification token.",
+        "description": "Updates name, HTTPS URL, event types, or enabled state. URL changes force pending_verification and return a new verification token. A URL change returns 409 with error.reason=webhook_delivery_in_progress while this destination has an active delivery; retry the same mutation after that request completes.",
         "tags": [
           "Webhooks"
         ],
@@ -6479,7 +6639,50 @@
             "$ref": "#/components/responses/RequestTimeout"
           },
           "409": {
-            "$ref": "#/components/responses/IdempotencyInProgress"
+            "description": "The same idempotent mutation is still running, or this destination has an active delivery whose frozen URL cannot change until its request completes. Branch on error.reason.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "idempotency_in_progress": {
+                    "summary": "Idempotent mutation still in progress",
+                    "value": {
+                      "object": "error",
+                      "error": {
+                        "code": "bad_request",
+                        "message": "Your previous request is still processing. Retry in a moment.",
+                        "param": "Idempotency-Key",
+                        "reason": "idempotency_in_progress"
+                      },
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false,
+                        "cost": 1
+                      }
+                    }
+                  },
+                  "delivery_in_progress": {
+                    "summary": "Destination URL is frozen for an active delivery",
+                    "value": {
+                      "object": "error",
+                      "error": {
+                        "code": "bad_request",
+                        "message": "webhook URL cannot change while a delivery is processing; retry after the active request completes",
+                        "param": "endpoint",
+                        "reason": "webhook_delivery_in_progress"
+                      },
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false,
+                        "cost": 1
+                      }
+                    }
+                  }
+                }
+              }
+            }
           },
           "422": {
             "$ref": "#/components/responses/IdempotencyConflict"
@@ -6692,7 +6895,7 @@
       "post": {
         "operationId": "rotateWebhookSecret",
         "summary": "Rotate a builder webhook signing secret",
-        "description": "Rotates the endpoint signing secret and returns the new signing_secret once in the response.",
+        "description": "Rotates the endpoint signing secret and returns the new signing_secret once in the response. Returns 409 with error.reason=webhook_delivery_in_progress while a live delivery freezes the current signing nonce; retry after it completes.",
         "tags": [
           "Webhooks"
         ],
@@ -6707,6 +6910,9 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/WebhookObject"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -6724,7 +6930,50 @@
             "$ref": "#/components/responses/RequestTimeout"
           },
           "409": {
-            "$ref": "#/components/responses/IdempotencyInProgress"
+            "description": "The same idempotent mutation is still running, or this destination has an active delivery whose signing secret cannot rotate until its request completes. Branch on error.reason.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "idempotency_in_progress": {
+                    "summary": "Idempotent mutation still in progress",
+                    "value": {
+                      "object": "error",
+                      "error": {
+                        "code": "bad_request",
+                        "message": "Your previous request is still processing. Retry in a moment.",
+                        "param": "Idempotency-Key",
+                        "reason": "idempotency_in_progress"
+                      },
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false,
+                        "cost": 1
+                      }
+                    }
+                  },
+                  "delivery_in_progress": {
+                    "summary": "Destination signing secret is frozen for an active delivery",
+                    "value": {
+                      "object": "error",
+                      "error": {
+                        "code": "bad_request",
+                        "message": "webhook signing secret cannot rotate while a delivery is processing; retry after the active request completes",
+                        "param": "endpoint",
+                        "reason": "webhook_delivery_in_progress"
+                      },
+                      "meta": {
+                        "request_id": "req_example",
+                        "cached": false,
+                        "cost": 1
+                      }
+                    }
+                  }
+                }
+              }
+            }
           },
           "422": {
             "$ref": "#/components/responses/IdempotencyConflict"
@@ -6850,7 +7099,8 @@
                                 "stale",
                                 "missing",
                                 "invalid",
-                                "unconfigured"
+                                "unconfigured",
+                                "paused"
                               ],
                               "description": "Public-safe aggregate status for expected background job successful-completion heartbeats. Does not expose Redis keys, job names, raw errors, provider payloads, wallet addresses, or condition IDs.",
                               "properties": {
@@ -6889,6 +7139,11 @@
                                 "unconfigured": {
                                   "type": "integer",
                                   "minimum": 0
+                                },
+                                "paused": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Heavy-periodic jobs that are stale/missing/invalid while the heavy executor is disabled (heavy_pipeline_control.executor_mode != 'active'), so this binary does not dispatch them. Observable but expected; they never drive status to 'down' (paused > 0 yields 'degraded')."
                                 }
                               }
                             }
@@ -7816,7 +8071,7 @@
             "name": "address",
             "in": "path",
             "required": true,
-            "description": "Trader wallet address (0x...), known trader username-style lookup, or trd_-prefixed trader ID emitted by this API.",
+            "description": "Trader wallet address (0x...), known trader username-style lookup, or trd_-prefixed trader ID emitted by this API. Bare integer database IDs are not accepted.",
             "schema": {
               "type": "string"
             }
@@ -8315,7 +8570,7 @@
             }
           },
           "401": {
-            "$ref": "#/components/responses/InvalidApiKey"
+            "$ref": "#/components/responses/Unauthorized"
           },
           "402": {
             "$ref": "#/components/responses/SubscriptionRequired"
@@ -8374,7 +8629,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "API key authentication. Send your key in the Authorization header as `Bearer oxi_sk_live_...`. Live keys require an active Insider subscription and return live data."
+        "description": "API key authentication. Send your key in the Authorization header as `Bearer oxi_sk_live_...`. Live keys require an active Pro subscription and return live data."
       }
     },
     "parameters": {
@@ -8458,7 +8713,7 @@
       },
       "WebhookEventDescriptor": {
         "type": "object",
-        "description": "Self-describing entry in the webhook event catalog: the event type a subscriber lists in event_types, when it fires, the data payload shape, and whether it currently fires (active) or is reserved (dormant, subscribable but not yet delivered). Insider-only event types (wallet_grade_changed, insider_radar_flag_raised, smart_money_flow_detected) only deliver to API keys on an active Insider subscription.",
+        "description": "Self-describing entry in the webhook event catalog: the event type a subscriber lists in event_types, when it fires, the data payload shape, and whether it currently fires (active) or is reserved (dormant, subscribable but not yet delivered). Pro-only event types (whale_trades_inserted, wallet_grade_changed, insider_radar_flag_raised, smart_money_flow_detected) only deliver to API keys on an active Pro subscription.",
         "required": [
           "id",
           "description",
@@ -8807,6 +9062,58 @@
               "db_only"
             ],
             "description": "Which ranking-data path produced this response. Only present on endpoints that can degrade a ranking (today: GET /api/v1/sports-edge-signals). \"live\" is the normal path (the current holder pile from the provider batch); \"db_only\" is the degraded fallback (a truthful but weaker trader_markets ranking) served when the live sharp-money ranking batch is unavailable (a smart-money DB read failure, not a Polymarket outage) and cached on a shorter TTL, so a consumer can down-weight or skip it. Omitted on endpoints that never degrade."
+          },
+          "category_skill_source": {
+            "type": "string",
+            "enum": ["live", "partial", "degraded", "unavailable"],
+            "description": "Whole filtered snapshot category-evidence status before pagination. Operational live always remains partial source coverage."
+          },
+          "category_skill_model_version": {
+            "type": "string"
+          },
+          "category_skill_taxonomy_version": {
+            "type": "string"
+          },
+          "category_skill_platform": {
+            "type": "string",
+            "const": "polymarket"
+          },
+          "category_skill_scope": {
+            "type": "string",
+            "const": "observed_goldsky_primary_taker_fill"
+          },
+          "category_skill_source_coverage": {
+            "type": "string",
+            "const": "partial_whale_threshold_fills"
+          },
+          "category_skill_observation_started_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "category_skill_model_operationally_degraded": {
+            "type": "boolean",
+            "description": "Whole-model operational readiness captured with the category model snapshot. Present on category-enriched responses even when the filtered signal slate is empty. When true, category_skill_source is degraded and sports-edge-signals uses the shorter degraded cache TTL."
+          },
+          "category_skill_status_counts": {
+            "type": "object",
+            "required": ["live", "insufficient", "stale", "unknown", "degraded"],
+            "properties": {
+              "live": { "type": "integer", "minimum": 0 },
+              "insufficient": { "type": "integer", "minimum": 0 },
+              "stale": { "type": "integer", "minimum": 0 },
+              "unknown": { "type": "integer", "minimum": 0 },
+              "degraded": { "type": "integer", "minimum": 0 }
+            }
+          },
+          "category_skill_base_payload_hash": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$",
+            "description": "SHA-256 of the funded signal membership/order/rank/cursor vector immediately before category-skill enrichment. Sports-edge-signals only."
+          },
+          "category_skill_enriched_base_payload_hash": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$",
+            "description": "Independent SHA-256 recomputation over the same base fields immediately after category-skill enrichment. Equality with category_skill_base_payload_hash proves shadow enrichment did not change funded inputs. Sports-edge-signals only."
           }
         }
       },
@@ -9255,7 +9562,7 @@
                 "$ref": "#/components/schemas/TrustMetadata"
               }
             ],
-            "description": "Provenance of the frozen qualifying category expert, which has three states where the qualifying_expert field alone can express only two. source.kind=database with reconciliation.status=db_mirror means the evidence deserialized and is being served. freshness.status is always not_live, never fresh: this evidence is frozen at selection and never refreshed, so on an archived pick the as_of (the expert's own stats_computed_at) can be days or months old by design. source.kind=computed with reconciliation.status=not_applicable means no expert was recorded: nobody qualified on the backed side, the pick predates the field, or a manual off-slate takeover cleared it \u2014 a real negative. source.kind=unavailable means the row HAS frozen evidence that does not deserialize into the published shape: a contract defect, NOT a negative, and the pick's selection rank was decided by evidence this response cannot describe. Do not read an omitted qualifying_expert as 'no specialist' without checking this field. Note the exact claim: this reports whether the payload matched the published SHAPE, not whether it still satisfies the selection gates."
+            "description": "Provenance of the frozen qualifying category expert. source.kind=database with reconciliation.status=db_mirror means the evidence deserialized, still satisfies every frozen selection gate, and is being served. On that arm freshness.status is always not_live and never fresh, because this evidence is frozen at selection and never refreshed, so on an archived pick the as_of (the expert's own stats_computed_at) can be days or months old by design. source.kind=computed with reconciliation.status=not_applicable means the selector evaluated the backed side and nobody qualified -- a real negative. source.kind=computed with freshness.status=unknown and completeness.status=not_computed means the selector never evaluated this field, as on a pre-feature pick or manual off-slate takeover. source.kind=unavailable means the payload is malformed, violates a selection gate, or conflicts with its persisted status: a contract defect, NOT a negative, on a pick whose selection rank that evidence decided. Do not read an omitted qualifying_expert as 'no specialist' without checking this field."
           }
         }
       },
@@ -9609,7 +9916,7 @@
               "pf_percentile",
               "consistency_percentile"
             ],
-            "description": "Curated advanced risk/performance metrics (expand=quant_metrics or expand[]=quant_metrics). Omitted unless expanded and the trader has computed metrics; when present, all listed fields are present (each is a number or null). null means insufficient trade history and must not be treated as 0. This is a fixed, documented field set, refreshed periodically by the cross-sectional ranking job.",
+            "description": "Curated advanced risk/performance metrics (expand=quant_metrics or expand[]=quant_metrics). Omitted unless expanded and backed by a computed row strictly under six hours old; a missing row, NULL computed_at, or age of exactly six hours or more is stale and omitted. Provider-input changes may intentionally lag inside the bounded six-hour window. When present, all listed fields are present (each is a number or null); null means insufficient trade history and must not be treated as 0. The fixed field shape is unchanged.",
             "properties": {
               "smart_score": {
                 "type": "number",
@@ -10103,7 +10410,7 @@
             "enum": [
               "full"
             ],
-            "description": "Always 'full' for an authenticated Insider key."
+            "description": "Always 'full' for an authenticated Pro key."
           },
           "pick_date": {
             "type": "string",
@@ -10116,7 +10423,7 @@
           },
           "category": {
             "type": "string",
-            "description": "Market category (e.g. \"Soccer\")."
+            "description": "Frozen canonical calibration/report bucket (e.g. \"Basketball\", \"MMA\", or \"Soccer\"). Existing semantics are unchanged; presentation consumers should prefer display_category when present."
           },
           "display_category": {
             "type": "string",
@@ -10168,16 +10475,16 @@
           },
           "side_summary": {
             "type": "string",
-            "description": "One-line summary of which side smart money is backing."
+            "description": "One-line summary of which side smart money is backing. Any current-day published pick whose required holder proof is not safely readable returns 503 read_model_warming instead of a partial success shape."
           },
           "smart_wallet_count": {
             "type": "integer",
-            "description": "Number of proven smart-money wallets on the backed side."
+            "description": "Number of proven smart-money wallets on the backed side. Any current-day published pick whose required holder proof is not safely readable returns 503 read_model_warming instead of fabricating zero or omitting this required field."
           },
           "top_grade": {
             "type": "string",
             "nullable": true,
-            "description": "Highest trader grade among the backed-side holders (S, A, B, C, D, F)."
+            "description": "Best (highest) grade among the PROVEN smart-money (S/A-graded) wallets on the backed side. Scoped to S and A only: a backing whose graded holders are all sub-S/A (B) reports null, so a grade is never shown next to a zero proven-wallet count. null when no S/A wallet backs a current-policy pick. A current-day published pick with pending legacy proof, unknown-future proof, or structurally invalid current-policy proof returns 503 before this success schema is served. Resolved legacy proof remains readable on both current-day and archive/history responses."
           },
           "category_edge_pct": {
             "type": "number",
@@ -10325,7 +10632,7 @@
           "holders": {
             "type": "array",
             "nullable": true,
-            "description": "Proven smart-money holders on the backed side.",
+            "description": "Frozen smart-money holders on the backed side. Newly captured backing snapshots use a complete provider-confirmed S/A-only cohort; historical rows can retain their earlier frozen shape.",
             "items": {
               "$ref": "#/components/schemas/PickHolder"
             }
@@ -10333,7 +10640,7 @@
           "holder_count": {
             "type": "integer",
             "nullable": true,
-            "description": "True total of proven holders on the backed side (may exceed the holders array length)."
+            "description": "True pre-cap total for the frozen holders cohort on the backed side (may exceed the holders array length). Newly captured backing snapshots count the complete provider-confirmed S/A-only cohort."
           },
           "editorial_note": {
             "type": "string",
@@ -10342,7 +10649,7 @@
           },
           "thesis": {
             "type": "string",
-            "description": "The reasoning behind the pick."
+            "description": "Required truthful thesis. With at least one proven holder: Proven sharp money holds {pick_outcome_label}[, led by a grade-{top_grade} trader]. Without proven holder backing: 0xInsider's Pick of the Day is {pick_outcome_label}. Wallet counts are not appended."
           },
           "market_url": {
             "type": "string",
@@ -10484,7 +10791,7 @@
         "properties": {
           "picks": {
             "type": "array",
-            "description": "Every published Pick of the Day, most recent last.",
+            "description": "Every published Pick of the Day, newest first by pick_date.",
             "items": {
               "$ref": "#/components/schemas/PickOfTheDayArchiveEntry"
             }
@@ -10514,7 +10821,11 @@
           },
           "category": {
             "type": "string",
-            "description": "Market category (e.g. \"Soccer\")."
+            "description": "Frozen canonical calibration/report bucket (e.g. \"Basketball\", \"MMA\", or \"Soccer\"). Existing semantics are unchanged; presentation consumers should prefer display_category when present."
+          },
+          "display_category": {
+            "type": "string",
+            "description": "Frozen public presentation category. For supported Polymarket sports this is the exact verified official event league (e.g. \"WNBA\" or \"UFC\"); otherwise it equals category. Additive and optional for mixed-version client compatibility."
           },
           "image_url": {
             "type": "string",
@@ -10523,12 +10834,12 @@
           "pick_outcome_label": {
             "type": "string",
             "nullable": true,
-            "description": "The backed side's outcome label. Omitted for a still-pending pick when the request is not from an authenticated Insider key."
+            "description": "The backed side's outcome label. Omitted for a still-pending pick when the request is not from an authenticated Pro key."
           },
           "top_grade": {
             "type": "string",
             "nullable": true,
-            "description": "Best grade among the proven smart-money holders on the backed side (S, A, B, C, D, F)."
+            "description": "Best (highest) grade among the PROVEN smart-money (S/A-graded) wallets on the backed side. Scoped to S and A only: a backing whose graded holders are all sub-S/A (B) reports null, so a grade is never shown next to a zero proven-wallet count. null when no S/A wallet backs the pick, when a pending legacy proof has not yet upgraded, or when the stored holder policy is unknown-future or structurally invalid. Resolved legacy history remains supported."
           },
           "outcome": {
             "type": "string",
@@ -11470,9 +11781,46 @@
           }
         }
       },
+      "SportsEdgeSignalCategorySkill": {
+        "type": "object",
+        "description": "Shadow-only category evidence over the full uncapped piled-side S/A/B holder allocation. It never changes signal membership, ordering, routing, or sizing.",
+        "required": [
+          "status", "model_version", "taxonomy_version", "platform", "scope",
+          "source_coverage", "observation_started_at", "as_of", "canonical_category",
+          "eligible_holders", "covered_holders", "backed_sharp_usd", "covered_backed_usd",
+          "coverage_pct", "weighted_edge_mean", "weighted_holder_lower_mean",
+          "specialist_backed_usd", "specialist_backed_usd_pct",
+          "largest_holder_backed_usd_pct", "minimum_holder_event_count"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["live", "insufficient", "stale", "unknown", "degraded"]
+          },
+          "model_version": { "type": "string" },
+          "taxonomy_version": { "type": "string", "nullable": true },
+          "platform": { "type": "string", "const": "polymarket" },
+          "scope": { "type": "string", "const": "observed_goldsky_primary_taker_fill" },
+          "source_coverage": { "type": "string", "const": "partial_whale_threshold_fills" },
+          "observation_started_at": { "type": "string", "format": "date-time" },
+          "as_of": { "type": "string", "format": "date-time" },
+          "canonical_category": { "type": "string", "nullable": true },
+          "eligible_holders": { "type": "integer", "minimum": 0 },
+          "covered_holders": { "type": "integer", "minimum": 0 },
+          "backed_sharp_usd": { "type": "number", "nullable": true, "minimum": 0 },
+          "covered_backed_usd": { "type": "number", "nullable": true, "minimum": 0 },
+          "coverage_pct": { "type": "number", "nullable": true, "minimum": 0, "maximum": 1 },
+          "weighted_edge_mean": { "type": "number", "nullable": true, "minimum": -1, "maximum": 1 },
+          "weighted_holder_lower_mean": { "type": "number", "nullable": true },
+          "specialist_backed_usd": { "type": "number", "nullable": true, "minimum": 0 },
+          "specialist_backed_usd_pct": { "type": "number", "nullable": true, "minimum": 0, "maximum": 1 },
+          "largest_holder_backed_usd_pct": { "type": "number", "nullable": true, "minimum": 0, "maximum": 1 },
+          "minimum_holder_event_count": { "type": "integer", "nullable": true, "minimum": 0 }
+        }
+      },
       "SportsEdgeSignal": {
         "type": "object",
-        "description": "One ranked pre-game sports market where graded smart money is piled on one side, with the grade distribution, kickoff, and piled-side CLOB token id.",
+        "description": "One ranked pre-game sports market where graded smart money is piled on one side, with required-status shadow category evidence from partial forward-observed Polymarket fills.",
         "required": [
           "condition_id",
           "piled_outcome_index",
@@ -11483,6 +11831,7 @@
           "graded_holders",
           "conviction_score",
           "directional_rank_score",
+          "category_skill",
           "rank"
         ],
         "properties": {
@@ -11522,11 +11871,11 @@
           "piled_side": {
             "type": "string",
             "nullable": true,
-            "description": "Human piled-side label (never a bare Yes/Over); null when the provider outcome label is missing."
+            "description": "Nullable provider-backed piled-outcome display label. When provider group context is unavailable, it may remain a bare Yes/No/Over/Under; do not use it alone as participant identity."
           },
           "piled_outcome_index": {
             "type": "integer",
-            "description": "Provider binary-column selector: 0 selects outcome_yes/token_id_yes; 1 selects outcome_no/token_id_no. It does not identify home/away or a participant; use piled_side for participant identity."
+            "description": "Provider binary-column selector: 0 selects outcome_yes/token_id_yes; 1 selects outcome_no/token_id_no. It does not identify home/away or a participant. Use piled_side together with title/event context for display."
           },
           "sharp_pct": {
             "type": "number",
@@ -11610,6 +11959,9 @@
             "type": "number",
             "description": "The ranking key, descending: conviction_score * (1 + 0.25 * directional_confidence). Equals conviction_score when the directional read is null/zero, so signals without the read rank exactly as before."
           },
+          "category_skill": {
+            "$ref": "#/components/schemas/SportsEdgeSignalCategorySkill"
+          },
           "rank": {
             "type": "integer",
             "description": "1-based rank within the (min_grade-filtered) ranked result."
@@ -11618,7 +11970,7 @@
       },
       "SportsEdgeObservationTerminalReason": {
         "type": "string",
-        "description": "Closed 25-value terminal-reason vocabulary for the accountable sports-edge observation funnel. capacity_limited is intentional bounded provider-work admission and does not itself set the snapshot degraded. board_source_unavailable is a completed board-source failure; board_deadline_unavailable is fair-wave deadline exhaustion; provider_unavailable is reserved for an attempted holder-provider failure; holder_deadline_unavailable is holder cache/provider absolute-deadline exhaustion.",
+        "description": "Closed 25-value terminal-reason vocabulary for the accountable sports-edge observation funnel. capacity_limited is intentional bounded provider-work admission and does not itself set the snapshot degraded. board_source_unavailable is a completed board-source failure; board_deadline_unavailable means live-board work missed either an internal configured-scope deadline or the outer fair-wave deadline; both classify only already-started rows, so for the upcoming source read funnel.sports[].board_upcoming_status instead; provider_unavailable is reserved for an attempted holder-provider failure; holder_deadline_unavailable is holder cache/provider absolute-deadline exhaustion.",
         "enum": [
           "outside_horizon",
           "resolved",
@@ -11764,7 +12116,7 @@
           "piled_side": {
             "type": "string",
             "nullable": true,
-            "description": "Human provider-backed label for the piled outcome."
+            "description": "Nullable provider-backed piled-outcome display label. When provider group context is unavailable, it may remain a bare Yes/No/Over/Under; do not use it alone as participant identity."
           },
           "piled_outcome_index": {
             "type": "integer",
@@ -11772,7 +12124,7 @@
               0,
               1
             ],
-            "description": "Provider binary-column selector: 0 selects outcome_yes/token_id_yes; 1 selects outcome_no/token_id_no. It does not identify home/away or a participant; use piled_side for participant identity."
+            "description": "Provider binary-column selector: 0 selects outcome_yes/token_id_yes; 1 selects outcome_no/token_id_no. It does not identify home/away or a participant. Use piled_side together with title/event context for display."
           },
           "backed_price": {
             "type": "number",
@@ -11917,6 +12269,7 @@
           "board_live_available",
           "board_upcoming_configured",
           "board_upcoming_available",
+          "board_upcoming_status",
           "input",
           "terminals",
           "terminal_total",
@@ -11949,7 +12302,7 @@
           },
           "board_live_available": {
             "type": "boolean",
-            "description": "Whether the always-applicable live-board source completed as available. False can mean a completed source failure (board_source_unavailable) or fair-wave deadline exhaustion (board_deadline_unavailable); inspect terminals to distinguish them."
+            "description": "Whether the always-applicable live-board source completed as available. False can mean a completed source failure (board_source_unavailable) or live-board work missing an internal configured-scope deadline or the outer fair-wave deadline (board_deadline_unavailable); inspect terminals to distinguish them."
           },
           "board_upcoming_configured": {
             "type": "boolean",
@@ -11957,7 +12310,38 @@
           },
           "board_upcoming_available": {
             "type": "boolean",
-            "description": "Whether the configured upcoming-board source completed as available. False with board_upcoming_configured=false means not applicable; false with it true can mean a completed source failure or fair-wave deadline exhaustion, distinguished by board_source_unavailable versus board_deadline_unavailable terminals."
+            "description": "Whether every configured upcoming-board scope completed as available. False with board_upcoming_configured=false means not applicable. When board_upcoming_configured is true and this flag is false, read board_upcoming_status for the cause (it reads unknown, i.e. no recorded cause, only on a snapshot cached before that field existed, which self-clears within one TTL): the board_source_unavailable and board_deadline_unavailable terminals are assigned only to already-started rows (the live half) and are structurally 0 for the upcoming source, so they never explain this flag."
+          },
+          "board_upcoming_status": {
+            "type": "string",
+            "enum": [
+              "unknown",
+              "not_configured",
+              "available",
+              "source_unavailable",
+              "cold_unavailable",
+              "deadline_unavailable"
+            ],
+            "description": "Why the upcoming-board source is (un)available. Board supply is one canonical-sport union: the bare category owns live truth and every routable league scope contributes upcoming rows; folded leagues without a configured board (currently NCAAB, NCAAF, and CFL) are not in the upcoming union. available: every configured scope completed truthfully (a successful empty schedule still counts). source_unavailable: composition failed before a truthful union; resolved scope readers turn half failures into cold_unavailable, so fresh producers are whole-union identity reconciliation or a registry contract failure and carry zero rows. cold_unavailable: every scope completed but at least one reported its upcoming half unavailable because no servable entry was inside the stale-serve bound and the background warm did not land in time; it is not by itself proof of a provider outage. deadline_unavailable: an internal configured-scope deadline or the outer bounded fair wave expired. An internal deadline may retain healthy bare-category or sibling-scope rows; the outer wave records zero rows. These upcoming fields do not describe league live-membership availability. If the bare-category live scope fails, all live rows are dropped even when a league scope completed, because the bare category is the sole live-truth owner. not_configured: no upcoming scope applies to the sport. unknown: exactly one cause -- a snapshot cached before this field existed whose legacy flags recorded an unavailable-but-configured half without saying why. Every freshly computed snapshot reports a concrete status, and a legacy available or not-configured row is reconstructed exactly, so unknown self-clears within one TTL. board_upcoming_available is exactly board_upcoming_status == available."
+          },
+          "board_upcoming_unavailable_scopes": {
+            "type": "array",
+            "description": "Configured upcoming scopes that did not complete as available. Values are category, a provider league tag slug (nfl, nba, wnba, nhl, or mls), registry when the compiled scope/projection contract drifted, union when cross-scope identity reconciliation failed, or wave when the outer fair-wave deadline expired before scope-level evidence returned. Empty means no unavailable upcoming scope was identified; this includes healthy/not-configured rows and a legacy cached row. Observation league scopes are upcoming-only and perform no live-membership read.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "category",
+                "nfl",
+                "nba",
+                "wnba",
+                "nhl",
+                "mls",
+                "registry",
+                "union",
+                "wave"
+              ]
+            },
+            "uniqueItems": true
           },
           "input": {
             "type": "integer",
@@ -11966,7 +12350,7 @@
           },
           "terminals": {
             "type": "object",
-            "description": "Sparse counts over the closed 25-value terminal vocabulary: outside_horizon, resolved, provider_closed, provider_excluded, invalid_market, missing_token, missing_stored_market, not_provider_live, board_source_unavailable, board_deadline_unavailable, primary_slate_candidate, zero_indexed_holder_research, capacity_limited, provider_unavailable, holder_deadline_unavailable, holder_computation_unavailable, holder_scan_incomplete, no_current_graded_holder, split_holder_pile, price_unavailable, wider_holder_emitted, in_play_emitted, in_play_stale_observed, in_play_directional_unavailable, or internal_unclassified. primary_slate_candidate means exact admission by the funded route's raw shared slate query before provider/holder enrichment; recent-flow rows rejected by its event, bucket, or total caps remain eligible for wider_holder measurement. capacity_limited is intentional bounded provider-work admission, is fully accounted here, and does not itself set degraded=true. board_source_unavailable means a completed board source was unavailable; board_deadline_unavailable means its fair wave missed the bounded deadline inside the shared pre-holder stage; provider_unavailable means an attempted holder-provider read failed; holder_deadline_unavailable means holder cache/provider work missed the absolute request deadline; holder_computation_unavailable means post-holder provider or DB-backed price/metadata evaluation was unavailable.",
+            "description": "Sparse counts over the closed 25-value terminal vocabulary: outside_horizon, resolved, provider_closed, provider_excluded, invalid_market, missing_token, missing_stored_market, not_provider_live, board_source_unavailable, board_deadline_unavailable, primary_slate_candidate, zero_indexed_holder_research, capacity_limited, provider_unavailable, holder_deadline_unavailable, holder_computation_unavailable, holder_scan_incomplete, no_current_graded_holder, split_holder_pile, price_unavailable, wider_holder_emitted, in_play_emitted, in_play_stale_observed, in_play_directional_unavailable, or internal_unclassified. primary_slate_candidate means exact admission by the funded route's raw shared slate query before provider/holder enrichment; recent-flow rows rejected by its event, bucket, or total caps remain eligible for wider_holder measurement. capacity_limited is intentional bounded provider-work admission, is fully accounted here, and does not itself set degraded=true. board_source_unavailable means a completed board source was unavailable; board_deadline_unavailable means live-board work missed either an internal configured-scope deadline or the outer fair-wave deadline; provider_unavailable means an attempted holder-provider read failed; holder_deadline_unavailable means holder cache/provider work missed the absolute request deadline; holder_computation_unavailable means post-holder provider or DB-backed price/metadata evaluation was unavailable.",
             "propertyNames": {
               "$ref": "#/components/schemas/SportsEdgeObservationTerminalReason"
             },
@@ -12430,7 +12814,7 @@
             "type": "string",
             "format": "date-time",
             "nullable": true,
-            "description": "The recommended next retry instant (RFC3339). Present on every retryable error (reason=pick_not_released, code=rate_limited, code=rate_limit_unavailable, reason=read_model_warming) and omitted otherwise. Always in the future. For pick_not_released it has two regimes: before the 11:00 UTC operating-window start, before a selected pick's stored release, or after a terminal skipped day, it is an exact floor and nothing can publish first. When a publish is overdue or the selector is still hunting inside the operating window, it is a bounded cadence (~60s), not a lower-bound promise; a pick may publish before it. Schedule one request and do not poll. Prefer Retry-After for the duration because it is immune to client clock skew."
+            "description": "The recommended next retry instant (RFC3339). Present on every retryable error (reason=pick_not_released, code=rate_limited, code=rate_limit_unavailable, reason=read_model_warming) and omitted otherwise. Always in the future. For pick_not_released: before the 11:00 UTC operating-window start, before a selected pick's stored release, or after a skipped day, it names the automatic system's next boundary. While no candidate exists in the live window it normally names the persisted next automatic selector attempt (~15m). Every value is advisory under supported operator actions: manual publication, release-time override, or admin generation can make a pick available first. When the automatic schedule is absent/due or a pick is overdue it degrades to ~60s. Schedule one request and do not poll. Prefer Retry-After for the duration because it is immune to client clock skew."
           },
           "reason": {
             "type": "string",
@@ -12439,10 +12823,12 @@
               "unknown_endpoint",
               "pick_not_released",
               "trader_not_tracked",
-              "read_model_warming"
+              "read_model_warming",
+              "idempotency_in_progress",
+              "webhook_delivery_in_progress"
             ],
             "nullable": true,
-            "description": "ADDITIVE (#7209). The specific, actionable cause behind `code`, when there is one more specific than the code itself. `code` keeps its published values, so existing clients are unaffected; new clients branch on `reason`. Omitted when the code already says everything we know. pick_not_released: no Pick of the Day is published for the current product day; schedule one request against retry_at instead of polling. unknown_endpoint: the PATH is not a route on this API -- read GET /api/v1, do not retry. trader_not_tracked: the wallet is real and the URL is right, but the trader is outside the HOT/WARM sync tiers -- stop asking for this wallet. cursor_expired: pagination went stale mid-walk -- re-request the first page and continue. read_model_warming: the requested endpoint cannot serve its read model yet; exact causes are endpoint-specific and can include a cold or contended refresh or a dependency that prevented refresh. Consult that endpoint's contract, retry only this route after the interval, and do not infer dependency health from this reason."
+            "description": "ADDITIVE (#7209). The specific, actionable cause behind `code`, when there is one more specific than the code itself. `code` keeps its published values, so existing clients are unaffected; new clients branch on `reason`. Omitted when the code already says everything we know. pick_not_released: no Pick of the Day is published for the current product day; schedule one request against retry_at instead of polling. unknown_endpoint: the PATH is not a route on this API -- read GET /api/v1, do not retry. trader_not_tracked: the wallet is real and the URL is right, but the trader is outside the HOT/WARM sync tiers -- stop asking for this wallet. cursor_expired: pagination went stale mid-walk -- re-request the first page and continue. read_model_warming: the requested endpoint cannot serve its read model yet; exact causes are endpoint-specific and can include a cold or contended refresh or a dependency that prevented refresh. idempotency_in_progress: retain the exact Idempotency-Key and request body, then retry shortly. webhook_delivery_in_progress: retry the URL or signing-secret configuration change after the destination's active request completes."
           }
         }
       },
@@ -12615,7 +13001,7 @@
                 "type": "string",
                 "format": "date-time",
                 "nullable": true,
-                "description": "The recommended next retry instant (RFC3339). Present on every retryable error (reason=pick_not_released, code=rate_limited, code=rate_limit_unavailable, reason=read_model_warming) and omitted otherwise. Always in the future. For pick_not_released it has two regimes: before the 11:00 UTC operating-window start, before a selected pick's stored release, or after a terminal skipped day, it is an exact floor and nothing can publish first. When a publish is overdue or the selector is still hunting inside the operating window, it is a bounded cadence (~60s), not a lower-bound promise; a pick may publish before it. Schedule one request and do not poll. Prefer Retry-After for the duration because it is immune to client clock skew."
+                "description": "The recommended next retry instant (RFC3339). Present on every retryable error (reason=pick_not_released, code=rate_limited, code=rate_limit_unavailable, reason=read_model_warming) and omitted otherwise. Always in the future. For pick_not_released: before the 11:00 UTC operating-window start, before a selected pick's stored release, or after a skipped day, it names the automatic system's next boundary. While no candidate exists in the live window it normally names the persisted next automatic selector attempt (~15m). Every value is advisory under supported operator actions: manual publication, release-time override, or admin generation can make a pick available first. When the automatic schedule is absent/due or a pick is overdue it degrades to ~60s. Schedule one request and do not poll. Prefer Retry-After for the duration because it is immune to client clock skew."
               },
               "reason": {
                 "type": "string",
@@ -12624,10 +13010,12 @@
                   "unknown_endpoint",
                   "pick_not_released",
                   "trader_not_tracked",
-                  "read_model_warming"
+                  "read_model_warming",
+                  "idempotency_in_progress",
+                  "webhook_delivery_in_progress"
                 ],
                 "nullable": true,
-                "description": "ADDITIVE (#7209). The specific, actionable cause behind `code`, when there is one more specific than the code itself. `code` keeps its published values, so existing clients are unaffected; new clients branch on `reason`. Omitted when the code already says everything we know. pick_not_released: no Pick of the Day is published for the current product day; schedule one request against retry_at instead of polling. unknown_endpoint: the PATH is not a route on this API -- read GET /api/v1, do not retry. trader_not_tracked: the wallet is real and the URL is right, but the trader is outside the HOT/WARM sync tiers -- stop asking for this wallet. cursor_expired: pagination went stale mid-walk -- re-request the first page and continue. read_model_warming: the requested endpoint cannot serve its read model yet; exact causes are endpoint-specific and can include a cold or contended refresh or a dependency that prevented refresh. Consult that endpoint's contract, retry only this route after the interval, and do not infer dependency health from this reason."
+                "description": "ADDITIVE (#7209). The specific, actionable cause behind `code`, when there is one more specific than the code itself. `code` keeps its published values, so existing clients are unaffected; new clients branch on `reason`. Omitted when the code already says everything we know. pick_not_released: no Pick of the Day is published for the current product day; schedule one request against retry_at instead of polling. unknown_endpoint: the PATH is not a route on this API -- read GET /api/v1, do not retry. trader_not_tracked: the wallet is real and the URL is right, but the trader is outside the HOT/WARM sync tiers -- stop asking for this wallet. cursor_expired: pagination went stale mid-walk -- re-request the first page and continue. read_model_warming: the requested endpoint cannot serve its read model yet; exact causes are endpoint-specific and can include a cold or contended refresh or a dependency that prevented refresh. idempotency_in_progress: retain the exact Idempotency-Key and request body, then retry shortly. webhook_delivery_in_progress: retry the URL or signing-secret configuration change after the destination's active request completes."
               }
             }
           },
@@ -13974,7 +14362,7 @@
         }
       },
       "SubscriptionRequired": {
-        "description": "Active Insider subscription required",
+        "description": "Active Pro subscription required",
         "content": {
           "application/json": {
             "schema": {
@@ -14017,7 +14405,7 @@
         "description": "Request exceeded the server's 30-second transport timeout. The timeout response has an empty body because it is generated before handler-level JSON error shaping."
       },
       "RateLimited": {
-        "description": "Rate limit exceeded. Two independent budgets. (1) 100 requests/minute per user (sliding window), on every authenticated route. (2) On the BATCH routes only: 2500 batch item units/minute per user, reserved before any item is executed. A batch with N requested items costs N item units, including duplicate and invalid items. 2500 = 100 requests x 25 items per batch, which is the most item work a key can buy through the request limiter at all: a caller may spend their entire 100-request minute on full 25-item batches without the item budget being what stops them. The REQUEST budget is the effective ceiling, and batching is never the more expensive choice. The item budget still denies at a sliding-window boundary (both counters carry the previous window forward with a floor, and the item counter runs 25x the request counter), so honor a 429 from either. Over-quota batches return 429 with Retry-After before any item work is done.",
+        "description": "Rate limit exceeded. Two independent budgets. (1) 100 requests/minute per user (sliding window), on every authenticated route. (2) On the BATCH routes only: 2500 batch item units/minute per user, reserved before any item is executed. A batch with N requested items costs N item units, including duplicate and invalid items. 2500 = 100 requests x 25 items per batch, which is the most item work a key can buy through the request limiter at all: a caller may spend their entire 100-request minute on full 25-item batches without the item budget being what stops them. The REQUEST budget is the effective ceiling, and batching is never the more expensive choice. The item budget can still deny at a sliding-window boundary (both counters carry the previous window forward with a floor, and the item counter runs 25x the request counter), so honor a 429 from either. Over-quota batches return 429 with Retry-After before any item work is done.",
         "headers": {
           "Retry-After": {
             "description": "Seconds until rate limit resets.",
@@ -14101,8 +14489,9 @@
                   "object": "error",
                   "error": {
                     "code": "bad_request",
-                    "message": "Idempotency-Key request is still in progress; retry shortly",
-                    "param": "Idempotency-Key"
+                    "message": "Your previous request is still processing. Retry in a moment.",
+                    "param": "Idempotency-Key",
+                    "reason": "idempotency_in_progress"
                   },
                   "meta": {
                     "request_id": "req_example",
@@ -14144,10 +14533,10 @@
         }
       },
       "PickNotReleased": {
-        "description": "No Pick of the Day is published for the current product day. This is expected before the selected pick's kickoff-relative release; each selected pick normally releases one hour before kickoff within the 11:00-19:00 UTC operating window, and on a skipped day no pick is published at all. The body carries error.code=\"not_found\" with error.reason=\"pick_not_released\" (branch on the reason -- the code stays \"not_found\" because error.code is a frozen contract) plus error.retry_at (RFC3339, always in the future), and the response sets Retry-After. Schedule against those instead of polling -- polling this window is what makes a schedule look like an outage.",
+        "description": "No Pick of the Day is published for the current product day. This is expected before the selected pick's kickoff-relative release; each selected pick normally releases one hour before kickoff within the 11:00-23:00 UTC operating window, and on a skipped day no pick is published at all. The body carries error.code=\"not_found\" with error.reason=\"pick_not_released\" (branch on the reason -- the code stays \"not_found\" because error.code is a frozen contract) plus error.retry_at (RFC3339, always in the future), and the response sets Retry-After. Schedule against those instead of polling -- polling this window is what makes a schedule look like an outage.",
         "headers": {
           "Retry-After": {
-            "description": "Seconds until the recommended next retry. It is an exact floor before the operating-window start, before a selected pick's stored release, or after a terminal skipped day. While a publish is overdue or the selector is hunting, it is a bounded cadence and a pick may publish before it. Always >= 1. Schedule one request (error.retry_at is its absolute RFC3339 twin); do not poll or block a worker thread.",
+            "description": "Seconds until the recommended next retry. Before the operating-window start, before a selected pick's stored release, or after a skipped day it names the automatic system's next boundary. While no candidate exists it normally names the persisted next automatic selector attempt (~15m). Supported operator actions can make a pick available before any recommendation. An absent/due schedule or overdue pick degrades to ~60s. Always >= 1. Schedule one request (error.retry_at is its absolute RFC3339 twin); do not poll or block a worker thread.",
             "schema": {
               "type": "integer"
             }

--- a/authentication.mdx
+++ b/authentication.mdx
@@ -78,7 +78,7 @@ These manage *your own* keys from the dashboard. They use the session cookie (JW
   "object": "error",
   "error": {
     "code": "subscription_required",
-    "message": "Active Insider subscription required.",
+    "message": "Active Pro subscription required.",
     "doc_url": "https://docs.0xinsider.com/authentication"
   }
 }

--- a/errors.mdx
+++ b/errors.mdx
@@ -61,7 +61,7 @@ async function call(path, opts = {}) {
       return call(path, opts);
     }
     if (code === "subscription_required") {
-      throw new Error("Insider subscription required");
+      throw new Error("Pro subscription required");
     }
     throw new Error(`${code}: ${message}${param ? ` (param=${param})` : ""}`);
   }
@@ -89,7 +89,7 @@ def call(path, **params):
         time.sleep(int(r.headers.get("Retry-After", "1")))
         return call(path, **params)
     if code == "subscription_required":
-        raise RuntimeError("Insider subscription required")
+        raise RuntimeError("Pro subscription required")
     raise RuntimeError(f"{code}: {body['error']['message']}")
 ```
 </CodeGroup>

--- a/integrations/typescript-client.mdx
+++ b/integrations/typescript-client.mdx
@@ -91,7 +91,7 @@ try {
     if (code === "not_found") {
       // expected: unknown trader
     } else if (code === "subscription_required") {
-      throw new Error("Insider subscription required");
+      throw new Error("Pro subscription required");
     } else {
       throw err;
     }

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -13,7 +13,7 @@ API access is bundled with the [Insider subscription](https://0xinsider.com/pric
   <Step title="Sign up or log in">
     [0xinsider.com/sign-up](https://0xinsider.com/sign-up)
   </Step>
-  <Step title="Subscribe to Insider">
+  <Step title="Subscribe to Pro">
     Pick the Insider plan on [Pricing](https://0xinsider.com/pricing).
   </Step>
   <Step title="Generate your key">


### PR DESCRIPTION
Closes the docs-site half of 0xinsider/0xinsider#7867, the follow-through PR #7846 deferred.

## Why this mattered

`ApiError::SubscriptionRequired` sets `doc_url` to this site. Every 402 an API consumer received linked them to a page publishing a response body the API no longer emits, and selling a plan that no longer exists.

Verified against the live backend rather than assumed:

```
$ rg -n 'subscription required' backend/crates --type rust
backend/crates/api-core/src/api_error.rs:547:  Self::SubscriptionRequired => "Active Pro subscription required.".to_string(),

$ (this site, before) authentication.mdx:81
    "message": "Active Insider subscription required.",
```

## What changed

**`api-reference/openapi.json` is synced from the product's `web/public/api/v1/openapi.json`.** That copy was a stale snapshot, not just a rename gap: 13 stale plan references plus 28KB of accumulated drift, across the same 49 paths.

Checked before copying that the sync loses nothing. Only 4 leaf keys existed solely here, and all four sit inside older shapes the product spec has since made strictly richer — the two webhook `409` responses gain inline bodies with two worked examples each, replacing a bare `$ref` to `IdempotencyInProgress`.

**Plan name fixed in the hand-written pages the spec does not own:** `authentication.mdx`, `errors.mdx` (both code samples), `quickstart.mdx`, `integrations/typescript-client.mdx`, `api-reference/objects.mdx`, `api-reference/endpoint/list-webhook-events.mdx`, and both pick-of-the-day endpoint pages.

## Deliberately not changed

- **`changelog.mdx`.** Its entries are dated historical records of what shipped when, and the plan was called Insider at the time. Rewriting them would make the record wrong.
- **`SubscriberScope::InsiderOnly`** in the webhook description. That is a Rust type name carried verbatim from the product spec, not a plan name.
- **"Insider Radar"** and the insider-scanner recipe. Those are product feature names, unaffected by the plan rename.
- **No API changelog entry.** `AGENTS.md` requires one for externally visible API changes; this is a docs-copy sync of a rename that already shipped.

## Verification

- `mint broken-links` — `success no broken links found`
- `api-reference/openapi.json` parses, and is byte-identical to the product spec
- A final sweep for plan-name references leaves only the two historical `changelog.mdx` lines