### PR TITLE
docs(api): document recorded whale scores

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -27,7 +27,7 @@
       "get": {
         "operationId": "getApiDiscovery",
         "summary": "API discovery",
-        "description": "Unauthenticated API-origin discovery document pointing agents to the canonical API base URL, full docs, web-origin OpenAPI spec, health check, and the COMPLETE index of authenticated data routes. data.authenticated_routes is the whole authenticated route surface, not a sample: it carries every authenticated route this spec documents, so an agent that starts here never has to guess a path. backend/src/api_v1/discovery.rs::authenticated_routes_match_the_published_spec fails if the index and this spec disagree in either direction.",
+        "description": "Unauthenticated API-origin discovery document pointing agents to the canonical API base URL, full docs, web-origin OpenAPI spec, health check, and the COMPLETE index of authenticated data routes. data.authenticated_routes is the whole authenticated route surface, not a sample: it carries every authenticated route this spec documents, so an agent that starts here never has to guess a path. The index is a hand-maintained const in backend/src/api_v1/discovery.rs kept in step with this spec by review; no automated check compares the two, so treat this spec as authoritative if they ever disagree.",
         "tags": [
           "System"
         ],
@@ -9154,7 +9154,7 @@
           },
           "authenticated_routes": {
             "type": "array",
-            "description": "The complete authenticated route index: one entry per authenticated route this spec documents, in \"<METHOD> <path>\" form, not a representative subset. GET /api/v1 is the unauthenticated entrypoint an agent hits first, so it hands back the whole authenticated surface rather than a sample the caller would have to guess around. The example on GET /api/v1 is abridged for readability -- the live response returns all of them. Kept in lockstep with this spec by backend/src/api_v1/discovery.rs::authenticated_routes_match_the_published_spec, which fails in both directions.",
+            "description": "The complete authenticated route index: one entry per authenticated route this spec documents, in \"<METHOD> <path>\" form, not a representative subset. GET /api/v1 is the unauthenticated entrypoint an agent hits first, so it hands back the whole authenticated surface rather than a sample the caller would have to guess around. The example on GET /api/v1 is abridged for readability -- the live response returns all of them. Kept in lockstep with this spec by review: it is a hand-maintained const in backend/src/api_v1/discovery.rs and no automated check compares the two, so treat this spec as authoritative if they ever disagree.",
             "items": {
               "type": "string"
             }
@@ -10312,7 +10312,7 @@
           "recorded_signal_score": {
             "type": "number",
             "nullable": true,
-            "description": "Immutable 0.0\u20131.0 signal score captured when the trade row was recorded. Available for new rows after this field launched; legacy rows return null."
+            "description": "0.0\u20131.0 signal score written once when the trade row is inserted. Available for new rows after this field launched; legacy rows return null."
           },
           "trader": {
             "type": "object",

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -10270,6 +10270,7 @@
           "side",
           "price",
           "signal_score",
+          "recorded_signal_score",
           "trader",
           "market"
         ],
@@ -10312,7 +10313,7 @@
           "recorded_signal_score": {
             "type": "number",
             "nullable": true,
-            "description": "0.0\u20131.0 signal score written once when the trade row is inserted. Available for new rows after this field launched; legacy rows return null."
+            "description": "0.0\u20131.0 signal score written once when the trade row is inserted. Available for new rows after this field launched; legacy rows return null. If a trade is added later, its time-sensitive recorded score reflects that delay."
           },
           "trader": {
             "type": "object",

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -2370,7 +2370,7 @@
           {
             "name": "strategy",
             "in": "query",
-            "description": "Filter by ML-detected strategy type. Values come from backend/src/trader_analysis/classification/decision_tree.rs and are matched exactly against trader_classifications.primary_type. Unknown values currently match zero rows; the handler does not return HTTP 400.",
+            "description": "Filter by ML-detected strategy type. Values come from backend/crates/analytics/src/trader_analysis/classification/decision_tree.rs and are matched exactly against ml_trader_category.primary_type. Unknown values currently match zero rows; the handler does not return HTTP 400.",
             "schema": {
               "type": "string",
               "enum": [

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -10307,7 +10307,12 @@
           },
           "signal_score": {
             "type": "number",
-            "description": "0.0\u20131.0 normalized signal score."
+            "description": "Current 0.0\u20131.0 normalized signal score. This value can change as scoring context changes."
+          },
+          "recorded_signal_score": {
+            "type": "number",
+            "nullable": true,
+            "description": "Immutable 0.0\u20131.0 signal score captured when the trade row was recorded. Available for new rows after this field launched; legacy rows return null."
           },
           "trader": {
             "type": "object",
@@ -12270,6 +12275,7 @@
           "board_upcoming_configured",
           "board_upcoming_available",
           "board_upcoming_status",
+          "board_upcoming_unavailable_scopes",
           "input",
           "terminals",
           "terminal_total",
@@ -12529,11 +12535,13 @@
               },
               "series_slug": {
                 "type": "string",
-                "nullable": true
+                "nullable": true,
+                "description": "Series slug from the canonical identity row. Null for Kalshi markets, which carry their series in kalshi_series_slug. For other providers, which today means Polymarket, it is populated only when the canonical row carries a provider seriesSlug, and null otherwise -- so treat null as ordinary, not as a fault. Measured 2026-08-02: non-null on 44,103 of 2,022,671 Polymarket rows lifetime, and on 37,654 of 47,832 rows refreshed in the previous 24 hours. NOTE the granularity for Polymarket: a seriesSlug is a LEAGUE, not a single series -- every same-day MLB game carries mlb -- so it is not a per-matchup grouping key, and the backend itself refuses it as one (#8124). Additive change (#8134): this field was previously null on every market, because its former source column had no working writer."
               },
               "kalshi_series_slug": {
                 "type": "string",
-                "nullable": true
+                "nullable": true,
+                "description": "Kalshi series slug, served from the markets mirror. Null is ORDINARY, not a fault: measured 2026-08-02, non-null on 10,778 of 69,866 Kalshi rows, so most Kalshi markets have none here. One legacy row on the polymarket platform also carries a value. The canonical column holds the ticker for more Kalshi rows, but this field deliberately keeps reading the mirror; changing that is a separate wire change."
               },
               "market_type": {
                 "type": "string",

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,10 +7,10 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
-<Update label="August 2, 2026" description="Large-trade scores are now stable to compare over time">
+<Update label="August 3, 2026" description="Large-trade API responses now include the score captured with each new trade">
   [`GET /api/v1/whale-trades`](/api-reference/endpoint/get-whale-trades), [`GET /api/v1/whale-trades/history`](/api-reference/endpoint/get-whale-trades-history), and [`GET /api/v1/whale-trades/{id}`](/api-reference/endpoint/get-whale-trade) now return optional `recorded_signal_score` alongside `signal_score`.
 
-  Use `signal_score` for the current score. Use `recorded_signal_score` when you need the score captured with the trade record to stay fixed for alerts, audits, or historical comparisons.
+  Use `signal_score` for the current score. Use `recorded_signal_score` for the score captured with the trade record in alerts, audits, or historical comparisons.
 
   The recorded score is available for trades recorded after this release. Older trades return `null`. This field is additive and optional, so existing clients are unaffected.
 </Update>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,6 +7,14 @@ rss: true
 
 This changelog tracks externally visible REST API changes only. Documentation-only edits are intentionally excluded.
 
+<Update label="August 2, 2026" description="Large-trade scores are now stable to compare over time">
+  [`GET /api/v1/whale-trades`](/api-reference/endpoint/get-whale-trades), [`GET /api/v1/whale-trades/history`](/api-reference/endpoint/get-whale-trades-history), and [`GET /api/v1/whale-trades/{id}`](/api-reference/endpoint/get-whale-trade) now return optional `recorded_signal_score` alongside `signal_score`.
+
+  Use `signal_score` for the current score. Use `recorded_signal_score` when you need the score captured with the trade record to stay fixed for alerts, audits, or historical comparisons.
+
+  The recorded score is available for trades recorded after this release. Older trades return `null`. This field is additive and optional, so existing clients are unaffected.
+</Update>
+
 <Update label="July 26, 2026" description="Pick of the Day reports whether its category-specialist evidence is trustworthy">
   [`GET /api/v1/pick-of-the-day`](/api-reference/endpoint/get-pick-of-the-day) adds `trust`, a full-only object carrying field-level provenance in the same vocabulary the trader endpoint uses.
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -12,6 +12,8 @@ This changelog tracks externally visible REST API changes only. Documentation-on
 
   Use `signal_score` for the current score. Use `recorded_signal_score` for the score captured with the trade record in alerts, audits, or historical comparisons.
 
+  If a trade is added later, its time-sensitive recorded score reflects that delay.
+
   The recorded score is available for trades recorded after this release. Older trades return `null`. This field is additive and optional, so existing clients are unaffected.
 </Update>
 


### PR DESCRIPTION
## Summary

- Document the optional recorded score on all whale-trade endpoints.
- Explain when to use the current score or the recorded score.
- Add the August 3, 2026 changelog entry.

## Verification

- OpenAPI operation coverage passed.
- The documentation specification matches the application specification.

Related: 0xinsider/0xinsider#8219
Depends on: 0xinsider/0xinsider#8220