### PR TITLE
docs: split the sentences over the Clarity Standard's Profile A cap

### DIFF
--- a/api-reference/endpoint/create-webhook.mdx
+++ b/api-reference/endpoint/create-webhook.mdx
@@ -17,6 +17,6 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/webhooks"
 ```
 
-The response includes a one-time `signing_secret` and a `verification.token`. **Copy the secret now**. You can't retrieve it later. Use it to check the `x-0xinsider-signature` header on every delivery; see the [Webhooks guide](/guides/webhooks). Then send the verification token to [Verify Webhook](/api-reference/endpoint/verify-webhook) to activate the endpoint. If the secret leaks, [rotate it](/api-reference/endpoint/rotate-webhook-secret).
+The response includes a one-time `signing_secret` and a `verification.token`. **Copy the secret now**. You can't retrieve it later. Use it to verify the `x-0xinsider-signature` header on every delivery; see the [Webhooks guide](/guides/webhooks). Then send the verification token to [Verify Webhook](/api-reference/endpoint/verify-webhook) to activate the endpoint. If the secret leaks, [rotate it](/api-reference/endpoint/rotate-webhook-secret).
 
 Send `Idempotency-Key` when retrying after a timeout. The same key with the same body returns the original webhook; the same key with a different body returns `422`.

--- a/api-reference/endpoint/create-webhook.mdx
+++ b/api-reference/endpoint/create-webhook.mdx
@@ -17,6 +17,6 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/webhooks"
 ```
 
-The response includes a one-time `signing_secret` and a `verification.token`. **Copy the secret now**. You can't retrieve it later. Use it to verify the `x-0xinsider-signature` header on every delivery (see the [Webhooks guide](/guides/webhooks)), and send the verification token to [Verify Webhook](/api-reference/endpoint/verify-webhook) to activate the endpoint. If the secret leaks, [rotate it](/api-reference/endpoint/rotate-webhook-secret).
+The response includes a one-time `signing_secret` and a `verification.token`. **Copy the secret now**. You can't retrieve it later. Use it to check the `x-0xinsider-signature` header on every delivery; see the [Webhooks guide](/guides/webhooks). Then send the verification token to [Verify Webhook](/api-reference/endpoint/verify-webhook) to activate the endpoint. If the secret leaks, [rotate it](/api-reference/endpoint/rotate-webhook-secret).
 
 Send `Idempotency-Key` when retrying after a timeout. The same key with the same body returns the original webhook; the same key with a different body returns `422`.

--- a/api-reference/endpoint/get-pick-of-the-day.mdx
+++ b/api-reference/endpoint/get-pick-of-the-day.mdx
@@ -3,9 +3,9 @@ title: "Get Pick of the Day"
 openapi: "GET /api/v1/pick-of-the-day"
 ---
 
-One sourced sharp-money call a day, promoted to the API. This is a Pro-tier endpoint: your API key already proves the subscription, so the response is always the full pick (the web teaser is a product-UI concept, not an API one).
+One sourced sharp-money call a day, promoted to the API. This is a Pro-tier endpoint. Your API key already proves the subscription, so the response is always the full pick. The web teaser is a product-UI concept, not an API one.
 
-The pick returns the backed side, the pre-game odds and the return on a $100 stake, the proven smart-money holders on that side, the grade and category edge, and the thesis behind it.
+The pick returns the backed side, the pre-game odds, and the return on a $100 stake. It also returns the proven smart-money holders on that side, the grade and category edge, and the thesis behind it.
 
 - `backed_price` and `return_per_100` are a snapshot frozen before kickoff, so the value does not drift between calls.
 - `sharp_pct`, `market_pct`, and `consensus_edge_pct` are the WHY breakdown: sharp-money conviction versus the market-implied price. These are conviction signals, not expected-value or guaranteed-edge claims.

--- a/api-reference/endpoint/get-position-timeline.mdx
+++ b/api-reference/endpoint/get-position-timeline.mdx
@@ -4,11 +4,11 @@ sidebarTitle: "Position timeline"
 openapi: "GET /api/v1/trader/{address}/position-timeline"
 ---
 
-Per-market fill history for one trader. Each fill carries a server-computed running amount and average entry price, so you can see how a position was built or unwound without recomputing it client-side.
+Per-market fill history for one trader. Each fill carries a server-computed running amount and average entry price. You can see how a position was built or unwound without recomputing it client-side.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53/position-timeline?condition_id=0xabc..."
 ```
 
-If you hold a username, a `trd_`-prefixed trader id, or the integer internal trader id instead of the wallet address, use [Get Trader Position Timeline](/api-reference/endpoint/get-trader-position-timeline), which resolves all four identity shapes and returns a byte-identical body.
+You may hold a username, a `trd_`-prefixed trader id, or the integer internal trader id instead of the wallet address. Use [Get Trader Position Timeline](/api-reference/endpoint/get-trader-position-timeline) for those. It resolves all four identity shapes and returns a byte-identical body.

--- a/api-reference/endpoint/get-positions.mdx
+++ b/api-reference/endpoint/get-positions.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Positions"
 openapi: "GET /api/v1/positions"
 ---
 
-Current positions across traders or markets. Each row carries the trader, market, current value, side, and trust-metadata fields (source, freshness, completeness) so you can tell a live provider-backed value from a cached or partial one.
+Current positions across traders or markets. Each row carries the trader, market, current value, and side. It also carries trust-metadata fields for source, freshness, and completeness. You can tell a live provider-backed value from a cached or partial one.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \

--- a/api-reference/endpoint/get-sports-edge-observations.mdx
+++ b/api-reference/endpoint/get-sports-edge-observations.mdx
@@ -33,7 +33,15 @@ A healthy `wider_holder` request can reuse a snapshot for about 180 seconds. An 
 
 Directional degradation is cohort-specific. A `wider_holder` candidate can remain emitted with `directional_status: "unavailable"` and terminal reason `wider_holder_emitted`. An `in_play` candidate fails closed instead and is counted under `in_play_directional_unavailable`.
 
-The route reserves about 25 seconds for one compute attempt. Two states return JSON `503 rate_limit_unavailable` with `error.reason: "read_model_warming"`. The first is single-flight refresh or global provider-work admission contention. The second is the deadline elapsing before a usable cache, universe, or exact raw funded-slate membership result exists. Category-resolution SQL errors, Redis coordination failures, observation-universe SQL errors, and primary-slate membership SQL errors return JSON `500 internal_error`. Once a usable universe exists, later unfinished work does not become a route-wide error. Board, holder, price, and metadata work is represented in a degraded `200` funnel instead.
+The route reserves about 25 seconds for one compute attempt.
+
+These states return JSON `503 rate_limit_unavailable` with `error.reason: "read_model_warming"`:
+
+- Single-flight refresh contention.
+- Global provider-work admission contention.
+- The deadline elapsing before a usable cache, universe, or exact raw funded-slate membership result exists.
+
+Category-resolution SQL errors, Redis coordination failures, observation-universe SQL errors, and primary-slate membership SQL errors return JSON `500 internal_error`. Once a usable universe exists, later unfinished board, holder, price, or metadata work does not become a route-wide error. It is represented in a degraded `200` funnel instead.
 
 Pagination uses the endpoint-specific `seo_` cursor. Cursors are pinned to `snapshot_as_of` and the selected cohort, so you cannot reuse one across cohorts or after its snapshot refreshes.
 

--- a/api-reference/endpoint/get-sports-edge-observations.mdx
+++ b/api-reference/endpoint/get-sports-edge-observations.mdx
@@ -25,7 +25,7 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/sports-edge-observations?cohort=wider_holder&category=Tennis&limit=20"
 ```
 
-Every `200` response includes a required top-level `degraded` boolean. It is `true` when an operational failure or unknown completeness state made the snapshot partial. Treat it as the snapshot-wide verdict: it can remain `true` even when the per-sport funnel cannot show the same failure because each input receives exactly one terminal reason.
+Every `200` response includes a required top-level `degraded` boolean. It is `true` when an operational failure or unknown completeness state made the snapshot partial. Treat it as the snapshot-wide verdict. It can remain `true` even when the per-sport funnel cannot show the same failure, because each input receives exactly one terminal reason.
 
 The response also includes that per-sport `funnel`. For each evaluated sport, `input` must equal `terminal_total`; sparse terminal reason counts explain why candidates were emitted or excluded. `capacity_limited` is intentional bounded admission: it remains fully accounted in the funnel and does not by itself set `degraded: true`. `board_upcoming_configured` distinguishes a sport with no applicable upcoming-board source from a configured source that is unavailable.
 
@@ -33,7 +33,7 @@ A healthy `wider_holder` request can reuse a snapshot for about 180 seconds. An 
 
 Directional degradation is cohort-specific. A `wider_holder` candidate can remain emitted with `directional_status: "unavailable"` and terminal reason `wider_holder_emitted`. An `in_play` candidate fails closed instead and is counted under `in_play_directional_unavailable`.
 
-The route reserves about 25 seconds for one compute attempt. Single-flight refresh or global provider-work admission contention, or the deadline elapsing before a usable cache, universe, or exact raw funded-slate membership result exists, returns JSON `503 rate_limit_unavailable` with `error.reason: "read_model_warming"`. Category-resolution SQL errors, Redis coordination failures, observation-universe SQL errors, and primary-slate membership SQL errors return JSON `500 internal_error`. Once a usable universe exists, later unfinished board, holder, price, or metadata work is represented in a degraded `200` funnel instead of becoming a route-wide error.
+The route reserves about 25 seconds for one compute attempt. Two states return JSON `503 rate_limit_unavailable` with `error.reason: "read_model_warming"`. The first is single-flight refresh or global provider-work admission contention. The second is the deadline elapsing before a usable cache, universe, or exact raw funded-slate membership result exists. Category-resolution SQL errors, Redis coordination failures, observation-universe SQL errors, and primary-slate membership SQL errors return JSON `500 internal_error`. Once a usable universe exists, later unfinished work does not become a route-wide error. Board, holder, price, and metadata work is represented in a degraded `200` funnel instead.
 
 Pagination uses the endpoint-specific `seo_` cursor. Cursors are pinned to `snapshot_as_of` and the selected cohort, so you cannot reuse one across cohorts or after its snapshot refreshes.
 

--- a/api-reference/endpoint/get-sports-edge-signals.mdx
+++ b/api-reference/endpoint/get-sports-edge-signals.mdx
@@ -3,6 +3,6 @@ title: "Get Sports Edge Signals"
 openapi: "GET /api/v1/sports-edge-signals"
 ---
 
-Returns the ranked list of upcoming pre-game sports markets (moneyline and props) where graded smart money is piled on one side. Each signal carries the piled side and its CLOB token, the grade distribution of the pile (S/A/B holder counts), dollar concentration, the market's kickoff time, and a grade-weighted conviction score — everything needed to act on the signal in one call, computed server-side.
+Returns the ranked list of upcoming pre-game sports markets (moneyline and props) where graded smart money is piled on one side. Each signal carries the piled side and its CLOB token, the grade distribution of the pile (S/A/B holder counts), and dollar concentration. It also carries the market's kickoff time and a grade-weighted conviction score. Everything needed to act on the signal arrives in one call, computed server-side.
 
 Ranking is grade-distribution driven: `conviction_score = (5·s_count + 4·a_count + 3·b_count) · sharp_pct`, so a market with more top-grade (S/A) traders concentrated on the piled side ranks higher. All raw fields are returned so callers can re-rank. Markets with no clear pile (roughly 50/50) are excluded.

--- a/api-reference/endpoint/get-stream.mdx
+++ b/api-reference/endpoint/get-stream.mdx
@@ -5,11 +5,11 @@ openapi: "GET /api/v1/stream"
 
 A resumable Server-Sent Events stream of the live feed envelopes the platform broadcasts: whale-trade pulses and other public and insider feed events. This is a long-lived `text/event-stream` response. Keep the connection open and read frames as they arrive. It forwards the same backend-owned envelope shape as the internal feed, with no provider data recomputed.
 
-Authenticate with your `oxi_sk` Bearer key like every other `/api/v1` endpoint. Connection counts are limited per API key and across the cluster: when either cap is exceeded you get `429` with a `Retry-After`, and `503` with a `Retry-After` if the admission backend is briefly unavailable.
+Authenticate with your `oxi_sk` Bearer key like every other `/api/v1` endpoint. Connection counts are limited per API key and across the cluster. When either cap is exceeded you get `429` with a `Retry-After`. You get `503` with a `Retry-After` if the admission backend is briefly unavailable.
 
 ```bash
 curl -N -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/stream"
 ```
 
-Every frame carries an SSE `id` equal to the envelope sequence. To resume after a disconnect, reconnect with the `Last-Event-ID` header (or the `last_event_id` / `seq` query fallback when you cannot set the header); the stream replays the strictly-newer window before resuming live. If your resume point predates the retained window, the stream emits one `event: resync` marker instead of silently skipping frames. Idle connections receive periodic `: keep-alive` comment lines.
+Every frame carries an SSE `id` equal to the envelope sequence. To resume after a disconnect, reconnect with the `Last-Event-ID` header. Use the `last_event_id` or `seq` query fallback when you cannot set the header. The stream replays the strictly-newer window before resuming live. If your resume point predates the retained window, the stream emits one `event: resync` marker instead of silently skipping frames. Idle connections receive periodic `: keep-alive` comment lines.

--- a/api-reference/endpoint/get-trader-position-timeline.mdx
+++ b/api-reference/endpoint/get-trader-position-timeline.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Trader position timeline"
 openapi: "GET /api/v1/traders/{trader}/position-timeline"
 ---
 
-Per-market fill history for one trader, newest first, with a server-computed `running_amount` and `running_avg_price` on each fill so you can see how a position was built or unwound without recomputing it client-side. Polymarket fills only.
+Per-market fill history for one trader, newest first. Each fill carries a server-computed `running_amount` and `running_avg_price`. You can see how a position was built or unwound without recomputing it client-side. Polymarket fills only.
 
 `{trader}` accepts all four identity shapes, resolved by a single shared trader-identity resolver:
 

--- a/api-reference/endpoint/smart-money-flows.mdx
+++ b/api-reference/endpoint/smart-money-flows.mdx
@@ -3,7 +3,7 @@ title: "Smart Money Flows"
 openapi: "GET /api/v1/markets/smart-money-flows"
 ---
 
-Rank markets by where graded traders are putting money. This is the "where is smart money flowing right now?" feed: it aggregates whale flow from S, A, and B grade traders and ranks markets by absolute net flow over your chosen window.
+Rank markets by where graded traders are putting money. This is the "where is smart money flowing right now?" feed. It aggregates whale flow from S, A, and B grade traders. It ranks markets by absolute net flow over your chosen window.
 
 Use it for discovery, before you know a `condition_id`. Once you have a market, follow up with [Get Market Intel](/api-reference/endpoint/get-market-intel) for the single-market breakdown.
 

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -122,7 +122,7 @@ endpoints remain restricted to configured 0xinsider origins.
 
 ## Trust metadata
 
-Newer builder endpoints attach metadata to provider-owned values. Those are snapshots, history ranges, batch reads, and reports. The metadata lets you tell provider-backed, cached, partial, stale, and unavailable data apart.
+Newer builder endpoints attach metadata to provider-owned values. Those endpoints are snapshots, history ranges, batch reads, and reports. The metadata lets you tell provider-backed, cached, partial, stale, and unavailable data apart.
 
 Per value, four dimensions:
 

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -122,7 +122,7 @@ endpoints remain restricted to configured 0xinsider origins.
 
 ## Trust metadata
 
-Newer builder endpoints (snapshots, history ranges, batch reads, reports) attach metadata to provider-owned values so you can tell provider-backed, cached, partial, stale, and unavailable data apart.
+Newer builder endpoints attach metadata to provider-owned values. Those are snapshots, history ranges, batch reads, and reports. The metadata lets you tell provider-backed, cached, partial, stale, and unavailable data apart.
 
 Per value, four dimensions:
 
@@ -133,4 +133,4 @@ Per value, four dimensions:
 
 See [Trust metadata](/concepts/trust-metadata) for what each value means and how to request field-level trust with `expand=trust`.
 
-Rule of thumb: **don't flatten unavailable values into `0`, `[]`, or `{}`.** Read the metadata and surface "unavailable" to your consumer instead of inventing a zero. Provider data that quietly becomes `0` causes silent bugs downstream.
+Rule of thumb: **don't flatten unavailable values into `0`, `[]`, or `{}`.** Read the metadata. Surface "unavailable" to your consumer instead of inventing a zero. Provider data that quietly becomes `0` causes silent bugs downstream.

--- a/api-reference/objects.mdx
+++ b/api-reference/objects.mdx
@@ -995,7 +995,7 @@ Owner-scoped view of one webhook delivery attempt. Deliberately omits the reques
 
 ## WebhookEventDescriptor
 
-Self-describing entry in the webhook event catalog: the event type a subscriber lists in event_types, when it fires, the data payload shape, and whether it currently fires (active) or is reserved (dormant, subscribable but not yet delivered). Pro-only event types (wallet_grade_changed, insider_radar_flag_raised, smart_money_flow_detected) only deliver to API keys on an active Pro subscription.
+Self-describing entry in the webhook event catalog. It carries the event type a subscriber lists in event_types, when it fires, and the data payload shape. It also says whether the event currently fires (active) or is reserved (dormant, subscribable but not yet delivered). Pro-only event types (wallet_grade_changed, insider_radar_flag_raised, smart_money_flow_detected) only deliver to API keys on an active Pro subscription.
 
 | Field | Type | Required | Description |
 |---|---|---|---|

--- a/concepts/platforms.mdx
+++ b/concepts/platforms.mdx
@@ -50,4 +50,4 @@ These read paths return both Polymarket and Kalshi data:
 - Market intel and smart-money flows ([`/market/{condition_id}/intel`](/api-reference/endpoint/get-market-intel), [`/markets/smart-money-flows`](/api-reference/endpoint/smart-money-flows)).
 - Market search and explore ([`/markets/search`](/api-reference/endpoint/search-markets), [`/markets/explore`](/api-reference/endpoint/explore-markets)).
 
-When a field is thin or absent for Kalshi, [trust metadata](/concepts/trust-metadata) marks it (`unsupported` sources surface as `unavailable`), so you can detect coverage gaps in code instead of guessing.
+When a field is thin or absent for Kalshi, [trust metadata](/concepts/trust-metadata) marks it. An `unsupported` source surfaces as `unavailable`. You can detect coverage gaps in code instead of guessing.

--- a/concepts/signal-scoring.mdx
+++ b/concepts/signal-scoring.mdx
@@ -3,7 +3,7 @@ title: "Signal Scoring"
 description: "The smart-money and signal fields the API exposes, and what each one measures."
 ---
 
-0xinsider scores activity so you can sort noise from signal. There are a few distinct scores, each answering a different question: how good is this trader, how strong is this single trade, and which way is smart money leaning on this market. This page names each field and what it measures, so you do not confuse one for another.
+0xinsider scores activity so you can sort noise from signal. There are a few distinct scores, and each answers a different question. How good is this trader? How strong is this single trade? Which way is smart money leaning on this market? This page names each field and what it measures, so you do not confuse one for another.
 
 ## Trader quality: grade and score
 

--- a/concepts/trust-metadata.mdx
+++ b/concepts/trust-metadata.mdx
@@ -3,7 +3,7 @@ title: "Trust Metadata"
 description: "Every derived field can tell you where it came from, how fresh it is, and whether it was reconciled against the provider."
 ---
 
-Most APIs hand you a number and leave you to guess whether it is live, cached, or stale. 0xinsider can tell you. Ask for trust metadata and every covered field comes with its own provenance: the source it came from, how fresh it is, whether it was reconciled against the on-chain or provider truth, and whether the value is complete.
+Most APIs hand you a number and leave you to guess whether it is live, cached, or stale. 0xinsider can tell you. Ask for trust metadata and every covered field comes with its own provenance. That means the source it came from and how fresh it is. It also means whether the value was reconciled against the on-chain or provider truth, and whether it is complete.
 
 This matters when you act on the data. A P&L figure that is `fresh` and `provider_backed` is safe to trade on. The same figure marked `stale` and `db_mirror` is a hint, not a fact.
 
@@ -103,7 +103,7 @@ Whether the value reflects the full picture.
 
 ## Using it in practice
 
-A simple rule covers most integrations: act on values that are `fresh` and either `provider_backed` or `db_mirror`, and treat anything `stale`, `partial`, or `unavailable` as a softer signal.
+One rule covers most integrations. Act on values that are `fresh` and either `provider_backed` or `db_mirror`. Treat anything `stale`, `partial`, or `unavailable` as a softer signal.
 
 ```python
 def is_actionable(field_trust):

--- a/guides/webhooks.mdx
+++ b/guides/webhooks.mdx
@@ -112,7 +112,7 @@ Two rules make or break verification:
 - Use the **raw request body bytes**, exactly as received. Do not parse and re-serialize the JSON first; whitespace and key order would change and the HMAC would not match.
 - Use the `signing_secret` string as the HMAC key, the full `whsec_...` value.
 
-Reject the delivery if the signature does not match, or if `x-0xinsider-timestamp` is more than 5 minutes from your clock (a replay guard you enforce on your side).
+Reject the delivery if the signature does not match. Reject it if `x-0xinsider-timestamp` is more than 5 minutes from your clock. That is a replay guard you enforce on your side.
 
 <CodeGroup>
 ```javascript Node (Express)


### PR DESCRIPTION
Refs 0xinsider/0xinsider#8344

`docs/ops/clarity-standard.md` (shipped in 0xinsider/0xinsider#8345) names `docs.0xinsider.com`
a **Profile A** surface, where the 20/25-word sentence caps are **hard**. This site had 43
prose sentences over 25 words, the longest at 43 words.

## What changed

**24 fixed**, all in live pages. 21 lines across 15 files; every one turns a long sentence
into two or three short ones.

Longest offenders before:

| Words | Page |
|---|---|
| 43 | `api-reference/endpoint/get-sports-edge-signals.mdx` |
| 38 | `concepts/trust-metadata.mdx` |
| 37 | `api-reference/objects.mdx` |
| 36 | `api-reference/endpoint/get-position-timeline.mdx` |
| 34 | `api-reference/endpoint/get-stream.mdx` |

**Every split preserves the facts.** No field name, status code, enum value, error reason,
endpoint path, or link is changed.

## Deliberately not changed

- **`changelog.mdx` (19 sentences).** Changelog entries are dated records of what shipped.
  Rewriting them would falsify history. That exclusion is the standard's own rule, not a
  shortcut.
- **The word-level audit came back mostly exempt**, so nothing there moved. `verify` and
  `confirm` are API operations, `attempt` is the delivery-attempt noun, `applicable` is a
  field semantic on the sports-edge sources. Those are domain terms, and the standard's
  Vocabulary exemption outranks the replacement table (0xinsider/0xinsider#8370).
- **The `String enum:` line in `objects.mdx`.** A data enumeration, not a sentence.

## Verification

- `npx mint broken-links` -> `no broken links found`.
- Re-measured after the edits: **0** over-cap prose sentences remain in live pages. The only
  survivor is the enum line above.
- No `docs.json` navigation change, no new page, no OpenAPI change — so
  `scripts/check-openapi-parity.py` has nothing new to cover.

This is the last actionable child of epic 0xinsider/0xinsider#8344 that is not blocked. The
remaining editorial word substitutions are blocked on 0xinsider/0xinsider#8363, which is live
on the same content files.


---

## Review round (`901c7dd`)

An adversarial reviewer ran a **token-level diff of all 21 hunks: zero fact drift.** Every
field name, status code, enum value, error reason, header, endpoint, and link target survives.
It listed the ~40 tokens it checked individually.

Three MEDIUMs, all in wording the splits **added** — none in what they removed. All fixed.

**1. Scope widened on an error contract.** My split moved the guarantee into sentence 1 and
the qualifier into sentence 2, so it read as "no later work becomes a route-wide error". The
authoritative `openapi.json` description keeps the qualifier bound to board, holder, price,
and metadata work. **An integrator reading only that first sentence could have dropped `500`
handling after warm-up.** The qualifier is back where the guarantee is.

**2. I authored a count, and it was wrong.** "Two states return `503`" was new text — the
original never counted, and `openapi.json` enumerates more triggers than two. That is the
**ninth** count I have got wrong across this body of work, so the fix states no number at all.
The conditions are now a vertical list, which is what shared rule 8 asks for with more than
two conditions, and it also removes the sentence fragments my first fix introduced against
rule 7.

**3. I rotated a security verb.** `verify` -> `check` on the signature header saved no words,
contradicted this PR's own commit message ("nothing there changed"), and broke shared rule 6:
every other page uses `verify` for that operation, including the **Verify Webhook** endpoint
linked two clauses later. Restored.

Also fixed: "Those are snapshots..." pointed back over the nearest plural noun; now "Those
endpoints are".

### Corrections to this PR's earlier claims

- "24 fixed" overstates by 2-3. The reviewer independently measured **43 total** (exact match)
  but split **23 live / 20 changelog**, and found one case where my splitter merged an
  already-compliant 14-word sentence with a preceding bold line. **The docs are correct; my
  count was not.** Coverage is genuinely complete either way — zero real over-cap prose
  sentences remain outside `changelog.mdx`.

### Known follow-up, not in this PR

`docs.json:250` makes `api-reference/openapi.json` the source for every page carrying
`openapi:` frontmatter, so its `description` fields render on the live site. The Clarity
Standard names "`docs.0xinsider.com` **and the API reference**" a Profile A surface. Those
descriptions carry **104 sentences over 25 words**, the longest at 134. Many are enum
vocabularies of the class this PR already excuses, but not all. That is a separate slice
against a generated artifact, and it needs the main repo's spec as its source of truth.

### Verification

- `npx mint broken-links` -> `no broken links found`, re-run after the fixes.
- Every changed line re-measured under the 25-word cap.
- Reviewer confirmed: no hedge added, no certainty added, backticks and links balanced, two
  `-ing` forms removed (a net gain against Profile A rules), `changelog.mdx` untouched.
