### PR TITLE
docs: rewrite API copy in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
 # 0xinsider API Documentation
 
-Documentation for the [0xinsider API](https://docs.0xinsider.com) — prediction market intelligence for AI agents, trading bots, and research tools.
+Docs for the [0xinsider API](https://docs.0xinsider.com): prediction-market data for agents, bots, and research tools.
 
 ## What is 0xinsider?
 
-0xinsider provides trader grades, whale trade signals, smart money flow analysis, and insider detection across Polymarket and Kalshi.
-
-The API gives you programmatic access to the same intelligence powering the [0xinsider terminal](https://0xinsider.com).
+0xinsider provides trader grades, whale trades, smart-money flow, positions, and insider signals across Polymarket and Kalshi.
 
 ## API endpoints
 
-- **Trader** — grades (S through F), P&L, win rate, strategy detection
-- **Leaderboard** — top traders ranked by score with cursor pagination
-- **Whale Trades** — large trades with signal scoring, filterable by grade and category
-- **Explore Markets** — browse whale-active titled markets by category, platform, status, and sort order
-- **Market Intel** — smart money flow direction, buy/sell volumes, top positions
-- **Search Markets** — find markets by keyword with category and status filters
-- **Insider Radar** — suspicious trading patterns and pre-resolution accumulation
+- **Trader** — grades, P&L, win rate, and strategy
+- **Leaderboard** — traders ranked by score
+- **Whale Trades** — large trades with grade and category filters
+- **Explore Markets** — whale-active markets by category, platform, and status
+- **Market Intel** — smart-money flow and top positions
+- **Search Markets** — markets by keyword and filters
+- **Insider Radar** — unusual timing and accumulation patterns
 
 ## MCP Server
 

--- a/api-reference/endpoint/batch-get-market-intel.mdx
+++ b/api-reference/endpoint/batch-get-market-intel.mdx
@@ -3,7 +3,11 @@ title: "Batch Get Market Intel"
 openapi: "POST /api/v1/markets/intel/batch"
 ---
 
-Fetch market intel for up to 25 markets in one call. Each item has the same shape as [Get Market Intel](/api-reference/endpoint/get-market-intel), plus a per-item `error` field when a condition ID fails.
+Get market intel for up to 25 markets in one request. Each item matches [Get Market Intel](/api-reference/endpoint/get-market-intel).
+
+## Use this endpoint when
+
+Use this endpoint when a dashboard already has several market IDs. It cuts one request per market to one batch request.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -12,4 +16,10 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/markets/intel/batch"
 ```
 
-Each item costs one unit against the batch budget: a 25-market batch reserves 25 units. The top-level status stays `200` even when some items fail, so check `data[i].error` per item. See [Rate Limits](/rate-limits).
+Read `data[i].error` for every item. The top-level status stays `200` when one market fails.
+
+Each item costs one batch unit. A 25-market request costs 25 units. See [Rate Limits](/rate-limits).
+
+## Example: refresh a market board
+
+Send the `condition_id` values from your board. Render successful items and show an error for each failed item.

--- a/api-reference/endpoint/batch-get-traders.mdx
+++ b/api-reference/endpoint/batch-get-traders.mdx
@@ -3,7 +3,11 @@ title: "Batch Get Traders"
 openapi: "POST /api/v1/traders/batch"
 ---
 
-Fetch up to 25 trader profiles in one call. Each item has the same shape as [Get Trader](/api-reference/endpoint/get-trader), plus a per-item `error` field when an address fails.
+Get up to 25 trader profiles in one request. Each item matches [Get Trader](/api-reference/endpoint/get-trader).
+
+## Use this endpoint when
+
+Use this endpoint when a leaderboard, alert, or follow list contains several wallets. It avoids one request per trader.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -12,4 +16,10 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/traders/batch"
 ```
 
-Each item costs one unit against the batch budget: a 25-address batch reserves 25 units. The top-level status stays `200` even when some items fail, so check `data[i].error` per item. See [Rate Limits](/rate-limits).
+Read `data[i].error` for every item. The top-level status stays `200` when one trader fails.
+
+Each item costs one batch unit. A 25-trader request costs 25 units. See [Rate Limits](/rate-limits).
+
+## Example: enrich a follow list
+
+Send the wallet addresses from your leaderboard result. Keep successful profiles and record item errors for later retry.

--- a/api-reference/endpoint/create-webhook.mdx
+++ b/api-reference/endpoint/create-webhook.mdx
@@ -3,7 +3,11 @@ title: "Create Webhook"
 openapi: "POST /api/v1/webhooks"
 ---
 
-Register an HTTPS endpoint to receive [webhook events](/guides/webhooks#event-types) as they happen. The endpoint starts in `pending_verification` and must be verified before deliveries begin.
+Register an HTTPS endpoint for [webhook events](/guides/webhooks#event-types). The endpoint starts as `pending_verification`.
+
+## Use this endpoint when
+
+Use this endpoint when a worker needs push alerts for new whale trades. Verify the endpoint before you expect deliveries.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -17,6 +21,12 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/webhooks"
 ```
 
-The response includes a one-time `signing_secret` and a `verification.token`. **Copy the secret now**. You can't retrieve it later. Use it to verify the `x-0xinsider-signature` header on every delivery; see the [Webhooks guide](/guides/webhooks). Then send the verification token to [Verify Webhook](/api-reference/endpoint/verify-webhook) to activate the endpoint. If the secret leaks, [rotate it](/api-reference/endpoint/rotate-webhook-secret).
+The response includes `signing_secret` and `verification.token` once. **Copy the secret now.** You cannot retrieve it later. Use the secret to check each `x-0xinsider-signature` header. Then call [Verify Webhook](/api-reference/endpoint/verify-webhook).
 
-Send `Idempotency-Key` when retrying after a timeout. The same key with the same body returns the original webhook; the same key with a different body returns `422`.
+See the [Webhooks guide](/guides/webhooks) for signature code.
+
+Send `Idempotency-Key` when you retry after a timeout. The same key and body return the original webhook. A different body with that key returns `422`.
+
+## Example: start a whale-trade alert
+
+Register `whale_trades_inserted`, save the secret in your server secret store, then verify the returned token.

--- a/api-reference/endpoint/delete-webhook.mdx
+++ b/api-reference/endpoint/delete-webhook.mdx
@@ -3,7 +3,11 @@ title: "Delete Webhook"
 openapi: "DELETE /api/v1/webhooks/{id}"
 ---
 
-Permanently remove a webhook. No further events are delivered to that URL, and the signing secret is invalidated.
+Remove a webhook and invalidate its signing secret. The API sends no more events to that URL.
+
+## Use this endpoint when
+
+Use this endpoint when you no longer need a destination. Use `enabled: false` for a temporary pause.
 
 ```bash
 curl -X DELETE \
@@ -12,6 +16,10 @@ curl -X DELETE \
   "https://api.0xinsider.com/api/v1/webhooks/42"
 ```
 
-To pause deliveries without losing the webhook, [update](/api-reference/endpoint/update-webhook) it to `enabled: false` instead.
+To pause delivery without deleting the registration, [update](/api-reference/endpoint/update-webhook) it with `enabled: false`.
 
-Send `Idempotency-Key` when retrying a delete. A matching retry returns the original response instead of deleting again.
+Send `Idempotency-Key` when you retry a delete. A matching retry returns the original response.
+
+## Example: remove a retired staging hook
+
+Delete the webhook ID after you remove its URL from your deployment configuration.

--- a/api-reference/endpoint/download-trader-export.mdx
+++ b/api-reference/endpoint/download-trader-export.mdx
@@ -3,7 +3,11 @@ title: "Download Trader Export"
 openapi: "GET /api/v1/trader/{address}/export/download"
 ---
 
-Redirects to a short-lived presigned URL for a completed trader export. The file is gzip-compressed and uses the selected format's content type.
+Download a completed trader export. The API redirects to a short-lived presigned URL and returns gzip data in the selected format.
+
+## Use this endpoint when
+
+Use this endpoint after [Trader Export Status](/api-reference/endpoint/get-trader-export-status) returns `ready`.
 
 ```bash
 curl -L --compressed -o trader-export.ndjson \
@@ -11,4 +15,8 @@ curl -L --compressed -o trader-export.ndjson \
   "https://api.0xinsider.com/api/v1/trader/0xabc.../export/download?job_id=123"
 ```
 
-The endpoint returns `400` until the job is `ready`. Check [Trader Export Status](/api-reference/endpoint/get-trader-export-status) before downloading.
+The endpoint returns `400` until the job is `ready`.
+
+## Example: save an offline research file
+
+Poll the job, then follow the redirect and save the file for analysis. Do not store the presigned URL for later use.

--- a/api-reference/endpoint/explore-markets.mdx
+++ b/api-reference/endpoint/explore-markets.mdx
@@ -3,9 +3,13 @@ title: "Explore Markets"
 openapi: "GET /api/v1/markets/explore"
 ---
 
-Browse whale-active markets. This is the "what's going on right now" feed, already filtered to titled, user-facing markets with real activity. Omit `q` for the full feed, or pass it to narrow by keyword.
+Find titled markets with current whale activity. Omit `q` for the full feed or add a keyword.
 
-Grouped events (e.g. "Next US president by candidate") return one row per event with a primary market injected, so you always have something to link to.
+## Use this endpoint when
+
+Use this endpoint when a user wants to browse active markets before you know a `condition_id`.
+
+Grouped events return one row per event with a primary market when one exists.
 
 Common filters:
 
@@ -20,4 +24,8 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/markets/explore?category=crypto&status=active&limit=20"
 ```
 
-Cursor-paginated. See [Pagination](/concepts/pagination).
+The response uses cursor pagination. See [Pagination](/concepts/pagination).
+
+## Example: build an active-market screen
+
+Request `category=crypto&status=active`, render the returned titles, and pass each returned market ID to [Get Market Snapshot](/api-reference/endpoint/get-market-snapshot).

--- a/api-reference/endpoint/get-api-discovery.mdx
+++ b/api-reference/endpoint/get-api-discovery.mdx
@@ -3,12 +3,20 @@ title: "Get API Discovery"
 openapi: "GET /api/v1"
 ---
 
-Discover the public V1 API surface without a key.
+Discover the public V1 API without a key.
 
-`GET /api/v1` returns the API base URL, docs URL, OpenAPI URL, unauthenticated health URL, and representative authenticated data routes.
+## Use this endpoint when
+
+Use this endpoint as the first request in an SDK, agent, or health probe.
+
+The response lists the API base URL, docs URL, OpenAPI URL, health URL, and sample data routes.
 
 ```bash
 curl "https://api.0xinsider.com/api/v1"
 ```
 
-Use it as the first probe for agents, SDK setup, and uptime checks that need the docs and health endpoints before authenticating.
+Use the returned URLs to configure the client. Use the health URL before you send an authenticated request.
+
+## Example: configure a new client
+
+Fetch this document once at startup. Read its API and OpenAPI URLs instead of hard-coding them in the client.

--- a/api-reference/endpoint/get-daily-report-snapshot.mdx
+++ b/api-reference/endpoint/get-daily-report-snapshot.mdx
@@ -3,11 +3,19 @@ title: "Get Daily Report Snapshot"
 openapi: "GET /api/v1/reports/daily"
 ---
 
-The daily recap for a given date: top traders, biggest whale trades, smart-money rotations, pre-baked. Power morning-email digests, Slack briefs, or "what happened yesterday?" panels without rerunning every query.
+Get one daily recap for a date. It includes top traders, large whale trades, and smart-money rotations.
+
+## Use this endpoint when
+
+Use this endpoint for a daily email, Slack brief, or “what happened yesterday?” panel.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/reports/daily?date=2026-05-08"
 ```
 
-For longer windows, use [Weekly](/api-reference/endpoint/get-weekly-report-snapshot) or [Monthly](/api-reference/endpoint/get-monthly-report-snapshot). Snapshots carry trust metadata, so partial or unavailable sections are explicit.
+Use [Weekly](/api-reference/endpoint/get-weekly-report-snapshot) or [Monthly](/api-reference/endpoint/get-monthly-report-snapshot) for longer windows. Read trust metadata before you show a partial or unavailable section.
+
+## Example: send a morning brief
+
+Request the previous UTC date at a fixed time. Cache the snapshot and include its `generated_at` value in the brief.

--- a/api-reference/endpoint/get-event-replay-since.mdx
+++ b/api-reference/endpoint/get-event-replay-since.mdx
@@ -7,11 +7,11 @@ Replay feed events after the last event that your worker processed.
 
 ## Use this endpoint when
 
-Use this endpoint after a worker restart or stream disconnect. Omit `cursor` on the first request.
+Use this endpoint after a worker restart or stream disconnect. Load the saved cursor and pass it on the first recovery request. Omit `cursor` only for initial bootstrap.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
-  "https://api.0xinsider.com/api/v1/events/feed/since?limit=100"
+  "https://api.0xinsider.com/api/v1/events/feed/since?cursor=$REPLAY_CURSOR&limit=100"
 ```
 
 Save `next_cursor` after each page. Pass it as `cursor` on the next request. Process events idempotently. Use [Webhooks](/api-reference/endpoint/list-webhooks) for push delivery.

--- a/api-reference/endpoint/get-event-replay-since.mdx
+++ b/api-reference/endpoint/get-event-replay-since.mdx
@@ -7,14 +7,14 @@ Replay feed events after the last event that your worker processed.
 
 ## Use this endpoint when
 
-Use this endpoint after a worker restart or a stream disconnect. Pass the saved timestamp or event ID.
+Use this endpoint after a worker restart or stream disconnect. Omit `cursor` on the first request.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
-  "https://api.0xinsider.com/api/v1/events/feed/since?since=2026-05-08T12:34:56Z&limit=100"
+  "https://api.0xinsider.com/api/v1/events/feed/since?limit=100"
 ```
 
-The response uses cursor pagination. Save the last processed event before you request the next page. Use [Webhooks](/api-reference/endpoint/list-webhooks) for push delivery.
+Save `next_cursor` after each page. Pass it as `cursor` on the next request. Process events idempotently. Use [Webhooks](/api-reference/endpoint/list-webhooks) for push delivery.
 
 ## Example: recover after a deploy
 

--- a/api-reference/endpoint/get-event-replay-since.mdx
+++ b/api-reference/endpoint/get-event-replay-since.mdx
@@ -3,11 +3,19 @@ title: "Get Event Replay Since"
 openapi: "GET /api/v1/events/feed/since"
 ---
 
-Replay feed events you missed during a disconnection. Pass the timestamp (or event ID) of the last event you processed, and the response is everything after it.
+Replay feed events after the last event that your worker processed.
+
+## Use this endpoint when
+
+Use this endpoint after a worker restart or a stream disconnect. Pass the saved timestamp or event ID.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/events/feed/since?since=2026-05-08T12:34:56Z&limit=100"
 ```
 
-Cursor-paginated. Catch a worker back up after a crash or deploy without back-filling from the live feed. Pair with [Webhooks](/api-reference/endpoint/list-webhooks) if you'd rather not poll at all.
+The response uses cursor pagination. Save the last processed event before you request the next page. Use [Webhooks](/api-reference/endpoint/list-webhooks) for push delivery.
+
+## Example: recover after a deploy
+
+Read the last event checkpoint from durable storage, request events after it, process them idempotently, and save the new checkpoint.

--- a/api-reference/endpoint/get-insider-radar-flag.mdx
+++ b/api-reference/endpoint/get-insider-radar-flag.mdx
@@ -3,11 +3,19 @@ title: "Get Insider Radar Flag"
 openapi: "GET /api/v1/insider-radar/{id}"
 ---
 
-Fetch one radar flag by ID. Use either the raw `radar_flags.id` or the `rf_...` ID returned by insider-radar list responses.
+Get one Insider Radar flag by ID. Use the raw ID or the `rf_...` ID from a list response.
+
+## Use this endpoint when
+
+Use this endpoint when a user opens one radar result from an alert or review queue.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/insider-radar/rf_123"
 ```
 
-The response is a single `radar_flag` envelope with the same item shape as [Get Insider Radar](/api-reference/endpoint/get-insider-radar).
+The response is one `radar_flag` envelope. Its item shape matches [Get Insider Radar](/api-reference/endpoint/get-insider-radar).
+
+## Example: open a radar detail view
+
+Store the `rf_...` ID from the list result. Request this page when the user selects the flag.

--- a/api-reference/endpoint/get-insider-radar.mdx
+++ b/api-reference/endpoint/get-insider-radar.mdx
@@ -3,13 +3,21 @@ title: "Get Insider Radar"
 openapi: "GET /api/v1/insider-radar"
 ---
 
-Flags wallets that look like they know something the market doesn't: pre-resolution accumulation, well-timed entries, or one-sided conviction with no hedges.
+Find wallets with unusual pre-resolution activity, timing, or one-sided positions.
 
-Each flag carries a `suspicion_score` and a reason. A high score is worth a closer look, not proof of wrongdoing.
+## Use this endpoint when
+
+Use this endpoint to build a review queue for possible insider-like patterns.
+
+Each flag has a `suspicion_score` and a reason. A high score marks a review target. It does not prove wrongdoing.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/insider-radar?limit=20"
 ```
 
-Cursor-paginated by score. See [Pagination](/concepts/pagination). To fetch one returned `rf_...` item again, use [Get Insider Radar Flag](/api-reference/endpoint/get-insider-radar-flag).
+The response uses score-ordered cursor pagination. See [Pagination](/concepts/pagination). Use [Get Insider Radar Flag](/api-reference/endpoint/get-insider-radar-flag) for one result.
+
+## Example: triage new flags
+
+Poll this endpoint on a schedule, sort by `suspicion_score`, and request the highest-priority `rf_...` flags for review.

--- a/api-reference/endpoint/get-leaderboard.mdx
+++ b/api-reference/endpoint/get-leaderboard.mdx
@@ -3,13 +3,21 @@ title: "Get Leaderboard"
 openapi: "GET /api/v1/leaderboard"
 ---
 
-Top traders by composite score. Only S, A, and B grades appear; see [Trader Grades](/concepts/grades).
+List top traders by composite score. The response includes S, A, and B grades. See [Trader Grades](/concepts/grades).
 
-Filter by category (`crypto`, `politics`, `sports`) or strategy (`swing_trader`, and others). Some traders rank with no detected strategy, so `strategy_type` is nullable.
+## Use this endpoint when
+
+Use this endpoint to build a follow list or compare traders before you request full profiles.
+
+Filter by category or strategy. Treat `strategy_type` as nullable.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/leaderboard?limit=20&category=crypto"
 ```
 
-Cursor-paginated. Pass `next_cursor` from one response as `cursor` on the next. See [Pagination](/concepts/pagination).
+The response uses cursor pagination. Pass `next_cursor` as `cursor` on the next request. See [Pagination](/concepts/pagination).
+
+## Example: choose five crypto traders
+
+Request `category=crypto&limit=5`. Pass the returned trader IDs to [Batch Get Traders](/api-reference/endpoint/batch-get-traders) for more fields.

--- a/api-reference/endpoint/get-market-candles.mdx
+++ b/api-reference/endpoint/get-market-candles.mdx
@@ -3,13 +3,21 @@ title: "Get Market Candles"
 openapi: "GET /api/v1/market/{condition_id}/candles"
 ---
 
-Returns provider-first OHLC candles for each outcome token from 0xinsider's stored daily price snapshots. Open and resolved markets are supported.
+Get provider-first OHLC candles for each outcome token. The series uses stored daily price snapshots.
 
-Use `resolution=1d` for daily points or `resolution=1w` for weekly OHLC across the observed daily closes. Daily storage does not provide intraday fidelity, so a one-day candle commonly has equal open, high, low, and close values.
+## Use this endpoint when
+
+Use this endpoint to chart a market over days or weeks. Open and resolved markets are supported.
+
+Use `resolution=1d` for daily points or `resolution=1w` for weekly points. Daily storage does not provide intraday data.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/market/0xabc.../candles?resolution=1w"
 ```
 
-A market with no stored series returns empty outcome arrays. The API does not fabricate candles.
+A market with no stored series returns empty outcome arrays. The API does not create candles from missing data.
+
+## Example: draw a weekly price chart
+
+Request `resolution=1w`, group the returned candles by outcome token, and leave an empty series empty.

--- a/api-reference/endpoint/get-market-intel.mdx
+++ b/api-reference/endpoint/get-market-intel.mdx
@@ -20,4 +20,4 @@ Use [Batch Get Market Intel](/api-reference/endpoint/batch-get-market-intel) whe
 
 ## Example: explain a market card
 
-Read `smart_money.direction`, `net_flow_usd`, and `top_positions`. Show the trust metadata when a value is partial or unavailable.
+Read `sharp_money.direction`, `net_flow_usd`, and `top_positions`. If a value is unavailable, label it unavailable. Do not replace it with `0`.

--- a/api-reference/endpoint/get-market-intel.mdx
+++ b/api-reference/endpoint/get-market-intel.mdx
@@ -3,13 +3,21 @@ title: "Get Market Intel"
 openapi: "GET /api/v1/market/{condition_id}/intel"
 ---
 
-Smart-money breakdown for one market: buy vs sell volume from graded traders, top positions, and which side has conviction.
+Get the smart-money breakdown for one market. The response includes graded buy and sell volume, top positions, and direction.
 
-Pass either the raw provider-backed `condition_id` or the `mkt_...` market ID emitted by V1 responses. The API returns `400 bad_request` for known non-market prefixes such as `trd_`, `wt_`, or `rf_`.
+## Use this endpoint when
+
+Use this endpoint after search or discovery returns a market ID. It answers which side graded traders favor.
+
+Pass the raw provider-backed `condition_id` or a `mkt_...` market ID from a V1 response. Known non-market prefixes return `400 bad_request`.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/market/0xabc.../intel"
 ```
 
-For multiple markets in one call, use [Batch Get Market Intel](/api-reference/endpoint/batch-get-market-intel).
+Use [Batch Get Market Intel](/api-reference/endpoint/batch-get-market-intel) when you need more than one market.
+
+## Example: explain a market card
+
+Read `smart_money.direction`, `net_flow_usd`, and `top_positions`. Show the trust metadata when a value is partial or unavailable.

--- a/api-reference/endpoint/get-market-snapshot.mdx
+++ b/api-reference/endpoint/get-market-snapshot.mdx
@@ -3,7 +3,7 @@ title: "Get Market Snapshot"
 openapi: "GET /api/v1/market/{condition_id}/snapshot"
 ---
 
-Get the current state of one market: price, volume, status, and recent activity. Trust metadata describes each provider-owned value.
+Get the current state of one market: price, volume, status, and recent activity. Request `expand=trust` to receive trust metadata for `current_price` and `spread_bps`.
 
 ## Use this endpoint when
 
@@ -11,9 +11,11 @@ Use this endpoint to render one market page or refresh one market card.
 
 Pass the raw provider-backed `condition_id` or a `mkt_...` market ID from a V1 response.
 
+Add `expand=trust` when your UI must gate `current_price` or `spread_bps` on trust metadata.
+
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
-  "https://api.0xinsider.com/api/v1/market/0xabc.../snapshot"
+  "https://api.0xinsider.com/api/v1/market/0xabc.../snapshot?expand=trust"
 ```
 
 If a field is `unavailable`, treat it as missing. Do not change it to `0`. See [Trust metadata](/api-reference/introduction#trust-metadata).

--- a/api-reference/endpoint/get-market-snapshot.mdx
+++ b/api-reference/endpoint/get-market-snapshot.mdx
@@ -3,13 +3,21 @@ title: "Get Market Snapshot"
 openapi: "GET /api/v1/market/{condition_id}/snapshot"
 ---
 
-One-shot view of a single market: price, volume, status, recent activity. Trust-metadata fields tell you which values are live and provider-backed and which are cached, partial, or unavailable.
+Get the current state of one market: price, volume, status, and recent activity. Trust metadata describes each provider-owned value.
 
-Pass either the raw provider-backed `condition_id` or the `mkt_...` market ID emitted by V1 responses.
+## Use this endpoint when
+
+Use this endpoint to render one market page or refresh one market card.
+
+Pass the raw provider-backed `condition_id` or a `mkt_...` market ID from a V1 response.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/market/0xabc.../snapshot"
 ```
 
-If a field comes back `unavailable`, treat it as missing. Don't flatten it to `0`. See [Trust metadata](/api-reference/introduction#trust-metadata).
+If a field is `unavailable`, treat it as missing. Do not change it to `0`. See [Trust metadata](/api-reference/introduction#trust-metadata).
+
+## Example: refresh one market card
+
+Read the snapshot, show the current price only when its trust metadata supports it, and label unavailable values as unavailable.

--- a/api-reference/endpoint/get-monthly-report-snapshot.mdx
+++ b/api-reference/endpoint/get-monthly-report-snapshot.mdx
@@ -3,9 +3,19 @@ title: "Get Monthly Report Snapshot"
 openapi: "GET /api/v1/reports/monthly"
 ---
 
-The monthly recap: rolling-30-day leaderboard, category-rotation summary, and biggest realized P&L by trader and by market. Use it for end-of-month digests and longer newsletters.
+Get a monthly recap with leaderboard, category rotation, and large realized P&L changes.
+
+## Use this endpoint when
+
+Use this endpoint for an end-of-month digest or a monthly research report.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/reports/monthly?month=2026-05"
 ```
+
+Read trust metadata before you publish a section as complete.
+
+## Example: publish a monthly review
+
+Request one `YYYY-MM` period, store the snapshot, and use its period fields as the report label.

--- a/api-reference/endpoint/get-pick-of-the-day-archive.mdx
+++ b/api-reference/endpoint/get-pick-of-the-day-archive.mdx
@@ -3,20 +3,28 @@ title: "Get Pick of the Day track record"
 openapi: "GET /api/v1/pick-of-the-day/archive"
 ---
 
-The full Pick of the Day track record: every published pick with its real outcome, plus the rolling hit rate.
+Get the full Pick of the Day record and its rolling hit rate.
 
-- `picks` lists every published pick, most recent last, each with its `outcome` and (for resolved, priced picks) the `return_per_100` on a $100 stake.
-- `hit_rate` is the headline record: `wins`, `losses`, `decided` (wins + losses), and `pct` (wins / decided). `void` and `pending` picks are excluded from the rate.
-- `hit_rate.net_profit_usd`, `staked_usd`, and `roi_pct` model a flat $100-per-pick strategy over resolved, priced picks.
-- `hit_rate.series` is the cumulative curve, one point per decided pick in ascending date order, ready to chart. Its last point equals the headline `net_profit_usd` and `pct` by construction.
+## Use this endpoint when
 
-Resolved picks are the public record. A still-pending pick's backed side (`pick_outcome_label`) is included because the API key already proves Pro tier.
+Use this endpoint to build a results page or chart the record over time.
+
+- `picks` contains published picks and their outcomes.
+- `hit_rate` contains wins, losses, decided picks, and `pct`. `void` and `pending` picks do not count.
+- `hit_rate.net_profit_usd`, `staked_usd`, and `roi_pct` model a flat $100 stake.
+- `hit_rate.series` contains one point per decided pick in date order.
+
+Resolved picks form the record. A pending pick can still include `pick_outcome_label`.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/pick-of-the-day/archive"
 ```
 
-Side-effect-free and ETag-cacheable. Send the previous `ETag` back via `If-None-Match` for a `304 Not Modified` when the archive is unchanged.
+The response is side-effect-free and ETag-cacheable. Send `If-None-Match` for `304 Not Modified` when the archive is unchanged.
 
-For today's single pick, see [Get Pick of the Day](/api-reference/endpoint/get-pick-of-the-day).
+For the current single pick, see [Get Pick of the Day](/api-reference/endpoint/get-pick-of-the-day).
+
+## Example: chart the record
+
+Plot `hit_rate.series`. Use `hit_rate` for the headline value and do not count `pending` or `void` picks.

--- a/api-reference/endpoint/get-pick-of-the-day.mdx
+++ b/api-reference/endpoint/get-pick-of-the-day.mdx
@@ -3,21 +3,29 @@ title: "Get Pick of the Day"
 openapi: "GET /api/v1/pick-of-the-day"
 ---
 
-One sourced sharp-money call a day, promoted to the API. This is a Pro-tier endpoint. Your API key already proves the subscription, so the response is always the full pick. The web teaser is a product-UI concept, not an API one.
+Get the current Pick of the Day. The endpoint returns the full pick for a key with the required subscription.
 
-The pick returns the backed side, the pre-game odds, and the return on a $100 stake. It also returns the proven smart-money holders on that side, the grade and category edge, and the thesis behind it.
+## Use this endpoint when
 
-- `backed_price` and `return_per_100` are a snapshot frozen before kickoff, so the value does not drift between calls.
-- `sharp_pct`, `market_pct`, and `consensus_edge_pct` are the WHY breakdown: sharp-money conviction versus the market-implied price. These are conviction signals, not expected-value or guaranteed-edge claims.
-- `outcome` is `pending` until the market resolves, then `win`, `loss`, or `void`.
-- `sports_context` carries provider-owned team crests, league branding, and live score for team-sports picks; it is omitted otherwise.
-- Returns `404` when no pick is published right now.
+Use this endpoint to show the current pick in a daily brief or research workflow.
+
+The response includes the backed side, pre-game price, $100 return, smart-money holders, grade edge, and thesis.
+
+- `backed_price` and `return_per_100` are fixed before kickoff.
+- `sharp_pct`, `market_pct`, and `consensus_edge_pct` show conviction. They do not guarantee profit.
+- `outcome` is `pending`, `win`, `loss`, or `void`.
+- `sports_context` appears only for team-sports picks.
+- The endpoint returns `404` when no pick is published.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/pick-of-the-day"
 ```
 
-The response is side-effect-free and ETag-cacheable. Send the previous `ETag` back via `If-None-Match` to get a `304 Not Modified` when the pick is unchanged.
+The response is side-effect-free and ETag-cacheable. Send `If-None-Match` for `304 Not Modified` when the pick is unchanged.
 
 For the full track record and rolling hit rate, see [Get Pick of the Day track record](/api-reference/endpoint/get-pick-of-the-day-archive).
+
+## Example: show one daily pick
+
+Request the endpoint once per report window. If it returns `404`, show that no pick is published instead of using an older pick.

--- a/api-reference/endpoint/get-pick-of-the-day.mdx
+++ b/api-reference/endpoint/get-pick-of-the-day.mdx
@@ -15,7 +15,7 @@ The response includes the backed side, pre-game price, $100 return, smart-money 
 - `sharp_pct`, `market_pct`, and `consensus_edge_pct` show conviction. They do not guarantee profit.
 - `outcome` is `pending`, `win`, `loss`, or `void`.
 - `sports_context` appears only for team-sports picks.
-- The endpoint returns `404` when no pick is published.
+- The endpoint returns `404` with `error.reason="pick_not_released"` when no pick is published.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -23,6 +23,7 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
 ```
 
 The response is side-effect-free and ETag-cacheable. Send `If-None-Match` for `304 Not Modified` when the pick is unchanged.
+For `404`, schedule one request from `Retry-After` or `error.retry_at`. Do not poll.
 
 For the full track record and rolling hit rate, see [Get Pick of the Day track record](/api-reference/endpoint/get-pick-of-the-day-archive).
 

--- a/api-reference/endpoint/get-platforms.mdx
+++ b/api-reference/endpoint/get-platforms.mdx
@@ -3,12 +3,20 @@ title: "Get Platforms"
 openapi: "GET /api/v1/platforms"
 ---
 
-The platform capability matrix: which V1 intelligence surfaces are supported, partial, or unsupported per provider platform. Read it once at integration time so you know which endpoints return data for Polymarket versus Kalshi before you call them.
+List the V1 data surfaces for each provider platform. Each surface is marked supported, partial, or unsupported.
 
-This is an unauthenticated discovery endpoint, so you can fetch it without an API key.
+## Use this endpoint when
+
+Use this endpoint during client setup. It tells your app whether a surface supports Polymarket, Kalshi, or both.
+
+This endpoint needs no API key.
 
 ```bash
 curl "https://api.0xinsider.com/api/v1/platforms"
 ```
 
-Use it to gate features client-side instead of hardcoding per-platform assumptions that drift as coverage expands.
+Use the response to hide unsupported features. Do not hard-code platform coverage.
+
+## Example: choose a market source
+
+Load the matrix at startup. Enable a feature only when its returned status supports the feature.

--- a/api-reference/endpoint/get-position-timeline.mdx
+++ b/api-reference/endpoint/get-position-timeline.mdx
@@ -4,11 +4,19 @@ sidebarTitle: "Position timeline"
 openapi: "GET /api/v1/trader/{address}/position-timeline"
 ---
 
-Per-market fill history for one trader. Each fill carries a server-computed running amount and average entry price. You can see how a position was built or unwound without recomputing it client-side.
+Get the fill history for one trader and market. Each fill includes server-computed amount and average entry price.
+
+## Use this endpoint when
+
+Use this endpoint to explain how a trader built or closed a position. Do not recompute the running values in your client.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53/position-timeline?condition_id=0xabc..."
 ```
 
-You may hold a username, a `trd_`-prefixed trader id, or the integer internal trader id instead of the wallet address. Use [Get Trader Position Timeline](/api-reference/endpoint/get-trader-position-timeline) for those. It resolves all four identity shapes and returns a byte-identical body.
+This path accepts a wallet address. If you have a username, `trd_` ID, or integer trader ID, use [Get Trader Position Timeline](/api-reference/endpoint/get-trader-position-timeline).
+
+## Example: explain a position
+
+Pass the market `condition_id`, then render each fill in response order with its running amount and average price.

--- a/api-reference/endpoint/get-position-timeline.mdx
+++ b/api-reference/endpoint/get-position-timeline.mdx
@@ -15,7 +15,14 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53/position-timeline?condition_id=0xabc..."
 ```
 
-This path accepts a wallet address. If you have a username, `trd_` ID, or integer trader ID, use [Get Trader Position Timeline](/api-reference/endpoint/get-trader-position-timeline).
+The `address` path segment accepts these trader identities:
+
+- wallet address, such as `0x863...`
+- known username
+- `trd_`-prefixed trader ID
+- bare integer `traders.id`
+
+The server checks wallet, `trd_` ID, integer ID, then username. Use [Get Trader Position Timeline](/api-reference/endpoint/get-trader-position-timeline) when you need its plural alias path.
 
 ## Example: explain a position
 

--- a/api-reference/endpoint/get-positions.mdx
+++ b/api-reference/endpoint/get-positions.mdx
@@ -8,15 +8,15 @@ List current positions for traders or markets. Each row includes the trader, mar
 
 ## Use this endpoint when
 
-Use this endpoint for a positions board or a filtered market view.
+Use this endpoint for a global positions board. Filter by size, category, grade, or side.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
-  "https://api.0xinsider.com/api/v1/positions?trader=0x863134d00841b2e200492805a01e1e2f5defaa53&limit=50"
+  "https://api.0xinsider.com/api/v1/positions?min_size=25000&min_grade=A&side=yes&limit=50"
 ```
 
 Use [Position Timeline](/api-reference/endpoint/get-position-timeline) for fill history. Treat an `unavailable` value as missing. Do not change it to `0`. See [Trust metadata](/api-reference/introduction#trust-metadata).
 
 ## Example: show large positions
 
-Filter by trader or market, read the trust fields, and label partial data before you show it as current.
+Request large A-grade YES positions. Read the trust fields and label partial data before you show it as current.

--- a/api-reference/endpoint/get-positions.mdx
+++ b/api-reference/endpoint/get-positions.mdx
@@ -4,11 +4,19 @@ sidebarTitle: "Positions"
 openapi: "GET /api/v1/positions"
 ---
 
-Current positions across traders or markets. Each row carries the trader, market, current value, and side. It also carries trust-metadata fields for source, freshness, and completeness. You can tell a live provider-backed value from a cached or partial one.
+List current positions for traders or markets. Each row includes the trader, market, value, side, and trust metadata.
+
+## Use this endpoint when
+
+Use this endpoint for a positions board or a filtered market view.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/positions?trader=0x863134d00841b2e200492805a01e1e2f5defaa53&limit=50"
 ```
 
-For per-fill history (running amount and average entry price), use [Position Timeline](/api-reference/endpoint/get-position-timeline). When a value is unavailable from the provider, don't flatten it to `0`. See [Trust metadata](/api-reference/introduction#trust-metadata).
+Use [Position Timeline](/api-reference/endpoint/get-position-timeline) for fill history. Treat an `unavailable` value as missing. Do not change it to `0`. See [Trust metadata](/api-reference/introduction#trust-metadata).
+
+## Example: show large positions
+
+Filter by trader or market, read the trust fields, and label partial data before you show it as current.

--- a/api-reference/endpoint/get-reports.mdx
+++ b/api-reference/endpoint/get-reports.mdx
@@ -3,9 +3,13 @@ title: "Get Reports"
 openapi: "GET /api/v1/reports"
 ---
 
-One route for every report granularity. Pass `granularity` (`daily`, `weekly`, or `monthly`) and the matching `period` token, and the response is byte-identical to the legacy `/api/v1/reports/{daily,weekly,monthly}` route for the same window.
+Get a daily, weekly, or monthly report from one route. The response matches the legacy route for the same period.
 
-The `period` token shape depends on the granularity:
+## Use this endpoint when
+
+Use this endpoint when a report picker lets a user change the time range.
+
+Use one period form for the selected granularity:
 
 - `daily`: a UTC date, `YYYY-MM-DD`.
 - `weekly`: an ISO week `YYYY-WW`, or a `from,to` pair of `YYYY-MM-DD` dates.
@@ -16,4 +20,8 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/reports?granularity=daily&period=2026-05-08"
 ```
 
-The per-granularity caps match the legacy routes (daily 50, weekly 100, monthly 200), and the three legacy routes stay live. Snapshots carry trust metadata, so partial or unavailable sections are explicit. The singular [Daily](/api-reference/endpoint/get-daily-report-snapshot), [Weekly](/api-reference/endpoint/get-weekly-report-snapshot), and [Monthly](/api-reference/endpoint/get-monthly-report-snapshot) routes return the same bodies.
+The caps are daily 50, weekly 100, and monthly 200. The legacy routes stay live. Read trust metadata before you publish a partial or unavailable section.
+
+## Example: serve a report picker
+
+Map `daily`, `weekly`, or `monthly` to its period form. Send the selected pair to this endpoint.

--- a/api-reference/endpoint/get-sports-edge-observations.mdx
+++ b/api-reference/endpoint/get-sports-edge-observations.mdx
@@ -3,50 +3,44 @@ title: "Get Sports Edge Observations"
 openapi: "GET /api/v1/sports-edge-observations"
 ---
 
-Measures sports opportunities that are deliberately excluded from the funded Sports Edge slate. Use this endpoint to collect point-in-time evidence for wider-holder pre-game markets or provider-confirmed in-play markets without changing the funded algorithm.
+Collect sports observations that stay outside the funded Sports Edge slate. Use them for research, not order execution.
+
+## Use this endpoint when
+
+Use this endpoint to study wider-holder pre-game markets or provider-confirmed in-play markets.
 
 Pass one required `cohort`:
 
-- `wider_holder` measures current graded-holder consensus without requiring recent graded whale flow.
-- `in_play` measures only provider-confirmed live games. Stale or unavailable live-board, holder, or directional evidence fails closed and emits no observation.
+- `wider_holder` measures graded-holder consensus without a recent whale-flow requirement.
+- `in_play` measures provider-confirmed live games. Missing live, holder, or direction data emits no row.
 
-Every returned row has `observation_only: true`. Never route these rows to an order executor. This endpoint does not feed [Sports Edge Signals](/api-reference/endpoint/get-sports-edge-signals) or Pick of the Day.
+Every row has `observation_only: true`. This endpoint does not feed [Sports Edge Signals](/api-reference/endpoint/get-sports-edge-signals) or Pick of the Day.
 
-Omit `category` to evaluate all 14 observation sports. The observation registry includes Table Tennis and Pickleball, but both remain outside the 12-sport funded projection. `category=table-tennis`, `category=table tennis`, and `category=pickleball` resolve through the same canonical taxonomy as their title-cased bucket names; a non-sport category returns an empty list.
-
-For an all-sports request, board reads run in bounded fair waves so one slow source cannot block every later sport. Cold holder admission gives each represented canonical sport a first-candidate attempt before any sport repeats. This preserves evaluation breadth; it does not guarantee an emitted row when that sport's candidates fail a terminal gate.
-
-All category and all-sports cache scopes share one global observation provider-work admission. Independent scope keys cannot multiply concurrent holder and price fan-out against funded provider traffic.
-
-For `in_play`, provider `event_status` is authoritative when present: `Live` and `Paused` count as in progress, while `Ended` does not. The legacy score overlay is consulted only when `event_status` is absent.
+## Example: collect tennis observations
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/sports-edge-observations?cohort=wider_holder&category=Tennis&limit=20"
 ```
 
-Every `200` response includes a required top-level `degraded` boolean. It is `true` when an operational failure or unknown completeness state made the snapshot partial. Treat it as the snapshot-wide verdict. It can remain `true` even when the per-sport funnel cannot show the same failure, because each input receives exactly one terminal reason.
+Omit `category` to evaluate all 14 observation sports. The observation registry includes Table Tennis and Pickleball. These sports stay outside the funded 12-sport projection.
 
-The response also includes that per-sport `funnel`. For each evaluated sport, `input` must equal `terminal_total`; sparse terminal reason counts explain why candidates were emitted or excluded. `capacity_limited` is intentional bounded admission: it remains fully accounted in the funnel and does not by itself set `degraded: true`. `board_upcoming_configured` distinguishes a sport with no applicable upcoming-board source from a configured source that is unavailable.
+For `in_play`, provider `event_status` is authoritative when present. `Live` and `Paused` count as active. `Ended` does not.
 
-A healthy `wider_holder` request can reuse a snapshot for about 180 seconds. An `in_play` request never serves a cached observation snapshot older than about 30 seconds. Degraded snapshots use the shorter, about-30-second lifetime for both cohorts.
+## Read the result
 
-Directional degradation is cohort-specific. A `wider_holder` candidate can remain emitted with `directional_status: "unavailable"` and terminal reason `wider_holder_emitted`. An `in_play` candidate fails closed instead and is counted under `in_play_directional_unavailable`.
+Read the top-level `degraded` boolean. `true` means the snapshot is partial or its completeness is unknown.
 
-The route reserves about 25 seconds for one compute attempt.
+Read the per-sport `funnel`. For each sport, `input` equals `terminal_total`. The terminal counts explain emitted and excluded candidates.
 
-These states return JSON `503 rate_limit_unavailable` with `error.reason: "read_model_warming"`:
+`capacity_limited` means bounded admission. It does not set `degraded: true` by itself.
 
-- Single-flight refresh contention.
-- Global provider-work admission contention.
-- The deadline elapsing before a usable cache, universe, or exact raw funded-slate membership result exists.
+An emitted `wider_holder` row can have `directional_status: "unavailable"`. An `in_play` row fails closed when direction is unavailable.
 
-Category-resolution SQL errors, Redis coordination failures, observation-universe SQL errors, and primary-slate membership SQL errors return JSON `500 internal_error`. Once a usable universe exists, later unfinished board, holder, price, or metadata work does not become a route-wide error. It is represented in a degraded `200` funnel instead.
+The API can return `503 rate_limit_unavailable` with `error.reason: "read_model_warming"` during refresh contention. Retry after `Retry-After`.
 
-Pagination uses the endpoint-specific `seo_` cursor. Cursors are pinned to `snapshot_as_of` and the selected cohort, so you cannot reuse one across cohorts or after its snapshot refreshes.
+The API returns `500 internal_error` for category, coordination, observation-universe, or primary-slate SQL failures. Later incomplete board, holder, price, or metadata work stays in a degraded `200` response.
 
-Successful responses return a weak semantic `ETag`. It covers the stable page payload, including `next_cursor`, but excludes request-specific `meta`. Send it back as `If-None-Match` with the same query to receive `304 Not Modified` with an empty body when that stable payload is unchanged.
+The route uses an `seo_` cursor tied to `snapshot_as_of` and `cohort`. Do not reuse it after the snapshot changes or across cohorts.
 
-Malformed typed query values, such as `limit=abc`, return the standard JSON `400 bad_request` envelope. Read `error.param` when it is present; otherwise use `error.message`.
-
-Like other public API routes, this endpoint is also subject to the 30-second transport timeout. If that outer timeout is reached, it returns `408 Request Timeout` with an empty body. Check the status before parsing JSON.
+Send the same query with `If-None-Match` to receive `304 Not Modified` when the stable payload is unchanged. A transport timeout returns `408 Request Timeout` with an empty body.

--- a/api-reference/endpoint/get-sports-edge-signals.mdx
+++ b/api-reference/endpoint/get-sports-edge-signals.mdx
@@ -3,6 +3,19 @@ title: "Get Sports Edge Signals"
 openapi: "GET /api/v1/sports-edge-signals"
 ---
 
-Returns the ranked list of upcoming pre-game sports markets (moneyline and props) where graded smart money is piled on one side. Each signal carries the piled side and its CLOB token, the grade distribution of the pile (S/A/B holder counts), and dollar concentration. It also carries the market's kickoff time and a grade-weighted conviction score. Everything needed to act on the signal arrives in one call, computed server-side.
+List upcoming pre-game sports markets where graded smart money favors one side. Each signal includes the side, CLOB token, grade counts, dollar concentration, kickoff time, and conviction score.
 
-Ranking is grade-distribution driven: `conviction_score = (5·s_count + 4·a_count + 3·b_count) · sharp_pct`, so a market with more top-grade (S/A) traders concentrated on the piled side ranks higher. All raw fields are returned so callers can re-rank. Markets with no clear pile (roughly 50/50) are excluded.
+## Use this endpoint when
+
+Use this endpoint to rank sports markets before a game starts. The response gives you the signal data in one call.
+
+The ranking uses the grade distribution and `sharp_pct`. Markets without a clear side are excluded. The raw fields let you rank the list again.
+
+## Example: build a pre-game list
+
+```bash
+curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
+  "https://api.0xinsider.com/api/v1/sports-edge-signals"
+```
+
+Show the returned kickoff time and side. Treat the signal as research data, not a guaranteed result.

--- a/api-reference/endpoint/get-stream.mdx
+++ b/api-reference/endpoint/get-stream.mdx
@@ -3,13 +3,23 @@ title: "Get Stream"
 openapi: "GET /api/v1/stream"
 ---
 
-A resumable Server-Sent Events stream of the live feed envelopes the platform broadcasts: whale-trade pulses and other public and insider feed events. This is a long-lived `text/event-stream` response. Keep the connection open and read frames as they arrive. It forwards the same backend-owned envelope shape as the internal feed, with no provider data recomputed.
+Open a resumable Server-Sent Events stream for live feed envelopes. The response stays open as `text/event-stream`.
 
-Authenticate with your `oxi_sk` Bearer key like every other `/api/v1` endpoint. Connection counts are limited per API key and across the cluster. When either cap is exceeded you get `429` with a `Retry-After`. You get `503` with a `Retry-After` if the admission backend is briefly unavailable.
+## Use this endpoint when
+
+Use this endpoint when a service needs whale-trade and feed events with low delay. Keep a durable last-event checkpoint.
+
+Authenticate with an `oxi_sk` Bearer key. Connection limits apply per key and across the cluster. A limit returns `429` with `Retry-After`. Admission failure returns `503` with `Retry-After`.
 
 ```bash
 curl -N -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/stream"
 ```
 
-Every frame carries an SSE `id` equal to the envelope sequence. To resume after a disconnect, reconnect with the `Last-Event-ID` header. Use the `last_event_id` or `seq` query fallback when you cannot set the header. The stream replays the strictly-newer window before resuming live. If your resume point predates the retained window, the stream emits one `event: resync` marker instead of silently skipping frames. Idle connections receive periodic `: keep-alive` comment lines.
+Every frame has an SSE `id` equal to the envelope sequence. Reconnect with `Last-Event-ID` after a disconnect. Use `last_event_id` or `seq` when you cannot set that header.
+
+The stream replays newer events before it sends live events. An old checkpoint emits one `event: resync` marker. Idle connections send `: keep-alive` comments.
+
+## Example: recover a feed worker
+
+Save the last processed SSE ID after each event. Send it on the next connection and process duplicate events safely.

--- a/api-reference/endpoint/get-trader-context-markdown.mdx
+++ b/api-reference/endpoint/get-trader-context-markdown.mdx
@@ -3,13 +3,21 @@ title: "Get Trader Context as Markdown"
 openapi: "GET /api/v1/trader/{address}/context.md"
 ---
 
-Returns the trader context as a human- and LLM-readable Markdown briefing with identity, grade, P&L, position coverage, and freshness.
+Return one trader briefing as Markdown. It includes identity, grade, P&L, position coverage, and freshness.
 
-The path accepts a wallet address, known username, or `trd_...` trader ID. Unknown traders still return a degraded `200` document instead of `404`.
+## Use this endpoint when
+
+Use this endpoint when a human or an LLM needs a readable trader brief instead of a JSON object.
+
+The path accepts a wallet address, username, or `trd_...` trader ID. An unknown trader returns a degraded `200` document.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/swisstony/context.md"
 ```
 
-This Markdown variant does not emit an `ETag` and ignores `If-None-Match`. Use the [JSON context endpoint](/api-reference/endpoint/get-trader-context) for conditional reads.
+This variant does not emit an `ETag` and ignores `If-None-Match`. Use [Get Trader Context](/api-reference/endpoint/get-trader-context) for conditional reads.
+
+## Example: give an agent trader context
+
+Fetch the Markdown after a user selects a trader. Pass the response to the agent as context and keep the freshness fields visible.

--- a/api-reference/endpoint/get-trader-context.mdx
+++ b/api-reference/endpoint/get-trader-context.mdx
@@ -3,13 +3,21 @@ title: "Get Trader Context"
 openapi: "GET /api/v1/trader/{address}/context"
 ---
 
-Returns one structured, AI-ready trader briefing: the full trader profile, position and sync coverage, realized and unrealized P&L rollups, and point-in-time freshness metadata.
+Return one structured trader briefing. It includes the profile, position and sync coverage, P&L rollups, and freshness metadata.
 
-The path accepts a wallet address, known username, or `trd_...` trader ID. An unknown trader returns `200` with `sync_status: "unknown"`; `position_summary` is omitted when no local row exists.
+## Use this endpoint when
+
+Use this endpoint when an agent or dashboard needs one current trader summary in JSON.
+
+The path accepts a wallet address, username, or `trd_...` trader ID. An unknown trader returns `200` with `sync_status: "unknown"`. The API omits `position_summary` when no local row exists.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/swisstony/context"
 ```
 
-The JSON route returns an `ETag`. Send it with `If-None-Match` for a conditional read. Use the [Markdown variant](/api-reference/endpoint/get-trader-context-markdown) when you need a directly readable briefing instead.
+The JSON route returns an `ETag`. Send it with `If-None-Match` for a conditional read. Use the [Markdown variant](/api-reference/endpoint/get-trader-context-markdown) for readable output.
+
+## Example: refresh a trader panel
+
+Request the JSON brief, show its freshness fields, and refresh only when the `ETag` changes.

--- a/api-reference/endpoint/get-trader-export-snapshot.mdx
+++ b/api-reference/endpoint/get-trader-export-snapshot.mdx
@@ -3,11 +3,19 @@ title: "Get Trader Export Snapshot"
 openapi: "GET /api/v1/trader/{address}/export"
 ---
 
-One-shot export of everything 0xinsider knows about a trader: profile, positions, recent trades, category breakdown. Built for offline analysis or feeding into an LLM prompt.
+Get one export snapshot for a trader. It includes the profile, positions, recent trades, and category breakdown.
+
+## Use this endpoint when
+
+Use this endpoint for offline analysis or one agent request that needs several trader datasets.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53/export"
 ```
 
-Each section carries trust metadata, so you can tell which fields are live provider-backed and which are cached or partial.
+Each section carries trust metadata. Read it before you label a value live or complete.
+
+## Example: prepare an offline brief
+
+Save the response with its freshness metadata. Give the snapshot date to the analyst or agent with the data.

--- a/api-reference/endpoint/get-trader-export-status.mdx
+++ b/api-reference/endpoint/get-trader-export-status.mdx
@@ -3,11 +3,19 @@ title: "Get Trader Export Status"
 openapi: "GET /api/v1/trader/{address}/export/status"
 ---
 
-Returns the state of an asynchronous trader export owned by the authenticated API key: `queued`, `running`, `ready`, or `failed`.
+Get the state of one trader export: `queued`, `running`, `ready`, or `failed`.
+
+## Use this endpoint when
+
+Use this endpoint after [Submit Trader Export](/api-reference/endpoint/submit-trader-export) and before you download the file.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/0xabc.../export/status?job_id=123"
 ```
 
-When the state is `ready`, request the file through [Download Trader Export](/api-reference/endpoint/download-trader-export).
+When the state is `ready`, call [Download Trader Export](/api-reference/endpoint/download-trader-export).
+
+## Example: poll an export job
+
+Poll with a delay between requests. Stop on `ready` or `failed`; do not download while the state is `queued` or `running`.

--- a/api-reference/endpoint/get-trader-pnl.mdx
+++ b/api-reference/endpoint/get-trader-pnl.mdx
@@ -3,7 +3,11 @@ title: "Get Trader P&L"
 openapi: "GET /api/v1/trader/{address}/pnl"
 ---
 
-A trader's daily P&L time series plus pre-derived stats, read from the precomputed `daily_pnl` read model rather than a per-request equity replay. The response carries daily cumulative P&L entries, period stats (all-time, 90d, 30d, 7d), monthly aggregation, per-year totals, and the drawdown series.
+A trader's daily P&L series and period statistics come from the `daily_pnl` read model. The response includes daily, monthly, yearly, and drawdown data.
+
+## Use this endpoint when
+
+Use this endpoint to draw a trader performance chart or compare fixed periods.
 
 `{address}` accepts a `0x...` wallet address, a username, or a `trd_`-prefixed trader id.
 
@@ -12,4 +16,8 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53/pnl"
 ```
 
-A resolved trader with no daily P&L returns an empty structured object with `200`; an unknown address returns `404`. The series spans both providers wherever the read model has it.
+A resolved trader with no daily P&L returns an empty structured object with `200`. An unknown address returns `404`. The series covers both providers when the read model has data.
+
+## Example: draw a performance chart
+
+Plot the daily cumulative series. Use the period statistics for summary cards and the drawdown series for risk context.

--- a/api-reference/endpoint/get-trader-position-timeline.mdx
+++ b/api-reference/endpoint/get-trader-position-timeline.mdx
@@ -26,7 +26,7 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
 
 Only HOT and WARM tier traders are tracked. Other traders return `404`. The body matches [Get Position Timeline](/api-reference/endpoint/get-position-timeline) for the same pair.
 
-The response uses cursor pagination. Send `If-None-Match` for `304 Not Modified` when the timeline is unchanged.
+The response uses cursor pagination. When `has_more` is `true`, pass `next_cursor` as `cursor` on the next request. Send `If-None-Match` for `304 Not Modified` when the timeline is unchanged.
 
 ## Example: inspect a trader entry
 

--- a/api-reference/endpoint/get-trader-position-timeline.mdx
+++ b/api-reference/endpoint/get-trader-position-timeline.mdx
@@ -4,7 +4,11 @@ sidebarTitle: "Trader position timeline"
 openapi: "GET /api/v1/traders/{trader}/position-timeline"
 ---
 
-Per-market fill history for one trader, newest first. Each fill carries a server-computed `running_amount` and `running_avg_price`. You can see how a position was built or unwound without recomputing it client-side. Polymarket fills only.
+Get one trader's market fills, newest first. Each fill includes server-computed `running_amount` and `running_avg_price`. The data covers Polymarket fills.
+
+## Use this endpoint when
+
+Use this endpoint when you already have a trader identity and a market `condition_id`.
 
 `{trader}` accepts all four identity shapes, resolved by a single shared trader-identity resolver:
 
@@ -13,11 +17,17 @@ Per-market fill history for one trader, newest first. Each fill carries a server
 - a `trd_`-prefixed trader id
 - a bare integer `traders.id` (use this when you are paging other API responses and already hold the numeric id)
 
-`condition_id` is required: one timeline per `(trader, market)`.
+`condition_id` is required. Each response covers one `(trader, market)` pair.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/traders/0x863134d00841b2e200492805a01e1e2f5defaa53/position-timeline?condition_id=0xabc..."
 ```
 
-Only HOT and WARM tier traders are tracked; other traders return `404`. The body is byte-identical to the wallet-keyed [Get Position Timeline](/api-reference/endpoint/get-position-timeline) for the same `(trader, market)`. Cursor-paginated: pass `next_cursor` as `cursor`. Send `If-None-Match` with a prior `ETag` to get `304 Not Modified` when nothing changed.
+Only HOT and WARM tier traders are tracked. Other traders return `404`. The body matches [Get Position Timeline](/api-reference/endpoint/get-position-timeline) for the same pair.
+
+The response uses cursor pagination. Send `If-None-Match` for `304 Not Modified` when the timeline is unchanged.
+
+## Example: inspect a trader entry
+
+Request the timeline after a whale trade alert. Use the fill order and running fields to show the position path.

--- a/api-reference/endpoint/get-trader.mdx
+++ b/api-reference/endpoint/get-trader.mdx
@@ -3,13 +3,21 @@ title: "Get Trader"
 openapi: "GET /api/v1/trader/{address}"
 ---
 
-Full profile for a single wallet: grade, realized P&L, win rate, strategy classification, category strengths, and current open positions.
+Get one trader profile with grade, realized P&L, win rate, strategy, category strengths, and open positions.
 
-The path takes a raw wallet address (strip the `trd_` prefix) or a known trader username. Opt into heavy fields with repeated `expand` query params (`expand=strategy&expand=categories`). The legacy `expand[]` form still works.
+## Use this endpoint when
+
+Use this endpoint after the leaderboard or whale-trade feed gives you a wallet, username, or trader ID.
+
+The path accepts a raw wallet address or known username. Add repeated `expand` values for heavier fields.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53?expand=strategy&expand=categories"
 ```
 
-Use this when you have an address (from the leaderboard or a whale trade) and want the full story. For multiple traders in one call, see [Batch Get Traders](/api-reference/endpoint/batch-get-traders).
+For several traders, use [Batch Get Traders](/api-reference/endpoint/batch-get-traders).
+
+## Example: enrich a whale alert
+
+Read the trader address from the alert. Request `expand=strategy&expand=categories` when the alert needs those fields.

--- a/api-reference/endpoint/get-trader.mdx
+++ b/api-reference/endpoint/get-trader.mdx
@@ -9,7 +9,7 @@ Get one trader profile with grade, realized P&L, win rate, strategy, category st
 
 Use this endpoint after the leaderboard or whale-trade feed gives you a wallet, username, or trader ID.
 
-The path accepts a raw wallet address or known username. Add repeated `expand` values for heavier fields.
+The path accepts a raw wallet address, known username, or `trd_`-prefixed trader ID. Add repeated `expand` values for heavier fields.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \

--- a/api-reference/endpoint/get-usage.mdx
+++ b/api-reference/endpoint/get-usage.mdx
@@ -3,9 +3,13 @@ title: "Get Usage"
 openapi: "GET /api/v1/usage"
 ---
 
-Read your current request budget without spending primary quota.
+Read the current request budget without spending primary quota.
 
-Returns the live per-minute primary limiter window plus UTC-day usage. It does not increment the primary request counter and does not log itself into daily usage. The endpoint has its own 100 reads/minute per-user guard; a 429 here is a backoff signal, not proof you spent primary quota.
+## Use this endpoint when
+
+Use this endpoint before a polling loop or batch job. It shows the current limiter window.
+
+The response includes the per-minute limiter window and UTC-day usage. This read does not increment primary quota or daily usage. It has its own 100-reads-per-minute guard.
 
 The daily `limit` and `remaining` fields are `null` because V1 has no daily hard cap.
 
@@ -14,4 +18,8 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/usage"
 ```
 
-Check quota here instead of polling a data endpoint to guess your remaining budget.
+Check quota here instead of using a data endpoint as a quota probe.
+
+## Example: protect a polling loop
+
+Pause the loop when the remaining request count is low. Respect `Retry-After` if this endpoint returns `429`.

--- a/api-reference/endpoint/get-webhook.mdx
+++ b/api-reference/endpoint/get-webhook.mdx
@@ -3,7 +3,7 @@ title: "Get Webhook"
 openapi: "GET /api/v1/webhooks/{id}"
 ---
 
-Get one registered webhook. The response includes its URL, events, enabled state, and delivery status.
+Get one registered webhook. The response includes its URL, events, `status`, and delivery details.
 
 ## Use this endpoint when
 

--- a/api-reference/endpoint/get-webhook.mdx
+++ b/api-reference/endpoint/get-webhook.mdx
@@ -3,9 +3,19 @@ title: "Get Webhook"
 openapi: "GET /api/v1/webhooks/{id}"
 ---
 
-Inspect a single registered webhook: its URL, subscribed events, active flag, and recent delivery status. The signing secret is not returned; it is shown once at create time.
+Get one registered webhook. The response includes its URL, events, enabled state, and delivery status.
+
+## Use this endpoint when
+
+Use this endpoint to show webhook status in an account page or to check a destination before an update.
+
+The signing secret is never returned. Save it when you create or rotate the webhook.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/webhooks/42"
 ```
+
+## Example: check delivery readiness
+
+Read the webhook state before you enable a worker. Use [List Webhook Deliveries](/api-reference/endpoint/list-webhook-deliveries) for delivery attempts.

--- a/api-reference/endpoint/get-weekly-report-snapshot.mdx
+++ b/api-reference/endpoint/get-weekly-report-snapshot.mdx
@@ -3,11 +3,19 @@ title: "Get Weekly Report Snapshot"
 openapi: "GET /api/v1/reports/weekly"
 ---
 
-The weekly recap snapshot: top movers, sustained-flow markets, leaderboard shifts, pre-baked for the requested week. Same shape as the [daily report](/api-reference/endpoint/get-daily-report-snapshot), rolled up over seven days.
+Get a weekly recap with top movers, sustained flows, and leaderboard changes.
+
+## Use this endpoint when
+
+Use this endpoint for a weekly email, dashboard, or research review.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/reports/weekly?week_of=2026-05-04"
 ```
 
-`week_of` accepts any date inside the target week.
+`week_of` accepts any date inside the target week. The response matches the [daily report](/api-reference/endpoint/get-daily-report-snapshot) shape.
+
+## Example: build a weekly digest
+
+Choose one date from the target week. Read the trust fields before you mark a section complete.

--- a/api-reference/endpoint/get-whale-trade.mdx
+++ b/api-reference/endpoint/get-whale-trade.mdx
@@ -3,11 +3,19 @@ title: "Get Whale Trade"
 openapi: "GET /api/v1/whale-trades/{id}"
 ---
 
-Fetch one whale trade by ID. Use either the raw `whale_alerts.id` or the `wt_...` ID returned by whale-trade list and history responses.
+Get one whale trade by ID. Use the raw ID or the `wt_...` ID from a list or history response.
+
+## Use this endpoint when
+
+Use this endpoint when a user opens one trade from a feed, alert, or report.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/whale-trades/wt_123"
 ```
 
-The response is a single `whale_trade` envelope with the same item shape as [Get Whale Trades](/api-reference/endpoint/get-whale-trades).
+The response is one `whale_trade` envelope with the same item shape as [Get Whale Trades](/api-reference/endpoint/get-whale-trades).
+
+## Example: open an alert detail
+
+Store the `wt_...` ID from the feed. Request this endpoint when the user selects the alert.

--- a/api-reference/endpoint/get-whale-trades-history.mdx
+++ b/api-reference/endpoint/get-whale-trades-history.mdx
@@ -3,11 +3,19 @@ title: "Get Whale Trades History"
 openapi: "GET /api/v1/whale-trades/history"
 ---
 
-Bounded historical whale-trade ranges. Built for backtests, recap reports, and warming a cache after a deploy. For the live feed, use [Get Whale Trades](/api-reference/endpoint/get-whale-trades).
+Get whale trades for a fixed time range. Use it for backtests, reports, or cache recovery.
+
+## Use this endpoint when
+
+Use [Get Whale Trades](/api-reference/endpoint/get-whale-trades) for new activity. Use this endpoint when the start and end times matter.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/whale-trades/history?from=2026-04-01T00:00:00Z&to=2026-04-30T23:59:59Z&min_grade=A&limit=100"
 ```
 
-Responses carry trust metadata, so you can tell provider-backed from reconciled or partial ranges. See [Trust metadata](/api-reference/introduction#trust-metadata).
+Read trust metadata to distinguish provider-backed, reconciled, and partial ranges. See [Trust metadata](/api-reference/introduction#trust-metadata).
+
+## Example: replay one month
+
+Store the `from` and `to` values with the result. Use the same filters when you repeat the backtest.

--- a/api-reference/endpoint/get-whale-trades.mdx
+++ b/api-reference/endpoint/get-whale-trades.mdx
@@ -3,19 +3,27 @@ title: "Get Whale Trades"
 openapi: "GET /api/v1/whale-trades"
 ---
 
-Recent large trades, newest first, each with the trader's grade and a signal score.
+List recent large trades, newest first. Each item includes the trader grade and a trade signal score.
 
-Useful filters:
+## Use this endpoint when
+
+Use this endpoint to power an alert feed or find current whale activity.
+
+Common filters:
 
 - `min_grade=A`: only trades from S/A-grade traders (set `B` to widen).
 - `category=crypto`: restrict to a market category.
 - `min_size=10000`: floor on trade notional in USD.
 
-Each item carries the trade's `side` (`buy`/`sell`) in the response; there is no `side` request filter.
+The response carries `side` (`buy` or `sell`). The request has no `side` filter.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&category=crypto&min_size=10000&limit=50"
 ```
 
-Cursor-paginated by timestamp. For a fixed time range (backtests, recap reports), use [Whale Trades History](/api-reference/endpoint/get-whale-trades-history). To fetch one returned `wt_...` item again, use [Get Whale Trade](/api-reference/endpoint/get-whale-trade).
+The response uses timestamp cursor pagination. Use [Whale Trades History](/api-reference/endpoint/get-whale-trades-history) for fixed ranges and [Get Whale Trade](/api-reference/endpoint/get-whale-trade) for one item.
+
+## Example: alert on large crypto trades
+
+Request `min_grade=A`, `category=crypto`, and `min_size=10000`. Keep the returned `wt_...` ID for a detail request.

--- a/api-reference/endpoint/health.mdx
+++ b/api-reference/endpoint/health.mdx
@@ -3,7 +3,11 @@ title: "Health Check"
 openapi: "GET /api/v1/health"
 ---
 
-A liveness probe. Returns `200` with database and cache status when the API is up. No auth required, so it works as a smoke test from CI or a status dashboard.
+Check API liveness and database and cache status. The endpoint needs no auth.
+
+## Use this endpoint when
+
+Use this endpoint for a status page or a startup check before you use an API key.
 
 ```bash
 curl https://api.0xinsider.com/api/v1/health
@@ -16,3 +20,7 @@ curl https://api.0xinsider.com/api/v1/health
   "meta": { "request_id": "req_abc123", "cached": false }
 }
 ```
+
+## Example: gate a worker start
+
+Start the worker only when the response is `200` and `data.status` is `ok`. Log `meta.request_id` when the check fails.

--- a/api-reference/endpoint/list-large-positions.mdx
+++ b/api-reference/endpoint/list-large-positions.mdx
@@ -3,7 +3,11 @@ title: "List Large Positions"
 openapi: "GET /api/v1/large-positions"
 ---
 
-The largest current open positions held by graded traders, value-descending, with opaque cursor pagination. Polymarket-only by design: the scanner filters on `platform = 'polymarket'`, so a Kalshi or unknown `condition_id` filter returns an empty list rather than fabricated rows.
+List the largest current positions held by graded traders. Results sort by value and use cursor pagination. This scanner covers Polymarket only.
+
+## Use this endpoint when
+
+Use this endpoint to find large positions for a market board or risk review.
 
 Useful filters:
 
@@ -17,4 +21,8 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/large-positions?min_grade=A&min_size=25000&limit=50"
 ```
 
-The API key already proves an active subscription, so authed callers get full access with no teaser cap. Cursor-paginated: pass `next_cursor` from one response as `cursor` on the next. See [Pagination](/concepts/pagination).
+An authenticated key gets the full list. Pass `next_cursor` as `cursor` on the next request. See [Pagination](/concepts/pagination).
+
+## Example: find large A-grade crypto positions
+
+Request `min_grade=A`, `min_size=25000`, and `category=crypto`. Use `condition_id` to narrow the result to one market.

--- a/api-reference/endpoint/list-trending-wallets.mdx
+++ b/api-reference/endpoint/list-trending-wallets.mdx
@@ -3,13 +3,21 @@ title: "List Trending Wallets"
 openapi: "GET /api/v1/leaderboard/trending"
 ---
 
-Wallets ranked by trailing-window realized P&L, with opaque page-cursor pagination. Each row carries window P&L, volume, distinct markets traded, grade, hot-streak tier, and a zero-filled daily P&L series. Polymarket-only discovery.
+Rank wallets by realized P&L over a trailing window. Each row includes P&L, volume, markets traded, grade, streak tier, and a daily P&L series. This discovery route covers Polymarket.
 
-Set the lookback with `window`. Pick a wider window for durable performers, a tighter one for who is hot right now.
+## Use this endpoint when
+
+Use this endpoint to find wallets that are hot in a chosen period.
+
+Set the lookback with `window`. Use a wider window for durable results and a shorter window for recent form.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/leaderboard/trending?window=7d&limit=20"
 ```
 
-The ranking is served from a warmed read model. A cold read returns `503` with a `Retry-After`, never a fabricated ranking, so retry after the hint and the warmed result follows. Cursor-paginated: pass `next_cursor` as `cursor`. See [Pagination](/concepts/pagination).
+The route can return `503` with `Retry-After` while the read model warms. Retry after the hint. Pass `next_cursor` as `cursor`. See [Pagination](/concepts/pagination).
+
+## Example: find seven-day leaders
+
+Request `window=7d`. Add the returned wallets to a follow list, then enrich them with [Batch Get Traders](/api-reference/endpoint/batch-get-traders).

--- a/api-reference/endpoint/list-webhook-deliveries.mdx
+++ b/api-reference/endpoint/list-webhook-deliveries.mdx
@@ -3,11 +3,19 @@ title: "List Webhook Deliveries"
 openapi: "GET /api/v1/webhooks/{id}/deliveries"
 ---
 
-Lists recent delivery attempts for one webhook destination owned by the authenticated API-key user, newest first.
+List recent delivery attempts for one webhook, newest first.
+
+## Use this endpoint when
+
+Use this endpoint when a webhook alert did not reach your worker and you need its delivery status.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/webhooks/123/deliveries?limit=50"
 ```
 
-The endpoint uses opaque cursor pagination. A webhook not owned by the caller returns the same `404` as an unknown ID. Delivery rows omit the request body and signing secret.
+The response uses cursor pagination. A webhook that you do not own returns `404`, like an unknown ID. Rows omit the request body and signing secret.
+
+## Example: investigate a missed alert
+
+Read the newest attempts, compare their status and response fields with your server logs, and retry only after you fix the receiver.

--- a/api-reference/endpoint/list-webhook-events.mdx
+++ b/api-reference/endpoint/list-webhook-events.mdx
@@ -3,11 +3,19 @@ title: "List Webhook Events"
 openapi: "GET /api/v1/webhooks/events"
 ---
 
-Returns the catalog of webhook event types, including each event's description, data shape, and whether its producer is active or dormant.
+List webhook event types, their data shapes, and producer status.
+
+## Use this endpoint when
+
+Use this endpoint before you create or update a webhook subscription.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/webhooks/events"
 ```
 
-Pro-only event types appear in the catalog for every authenticated key, but they deliver only to an API key with an active Pro subscription. A dormant event is subscribable but does not currently fire.
+Pro event types appear for every authenticated key. They deliver only for an active Pro subscription. A dormant event can be subscribed to but does not fire now.
+
+## Example: build an event picker
+
+Load the catalog, hide dormant events, and show the subscription requirement before a user saves the webhook.

--- a/api-reference/endpoint/list-webhooks.mdx
+++ b/api-reference/endpoint/list-webhooks.mdx
@@ -27,4 +27,4 @@ For event types, the signature scheme, and verification code, see the [Webhooks 
 
 ## Example: audit webhook state
 
-List the webhooks after a deployment. Flag returned endpoints that are pending verification. For a known webhook ID, call [Get Webhook](/api-reference/endpoint/get-webhook) to inspect its `enabled` state; this list does not prove that a disabled endpoint is absent.
+List webhooks after a deployment. Flag returned endpoints with `status=pending_verification`. The list omits disabled endpoints. [Get Webhook](/api-reference/endpoint/get-webhook) also returns `404` for a disabled ID, so do not treat an omitted endpoint as deleted.

--- a/api-reference/endpoint/list-webhooks.mdx
+++ b/api-reference/endpoint/list-webhooks.mdx
@@ -27,4 +27,4 @@ For event types, the signature scheme, and verification code, see the [Webhooks 
 
 ## Example: audit webhook state
 
-List webhooks after a deployment. Flag returned endpoints with `status=pending_verification`. The list omits disabled endpoints. [Get Webhook](/api-reference/endpoint/get-webhook) also returns `404` for a disabled ID, so do not treat an omitted endpoint as deleted.
+List webhooks after a deployment. Flag returned endpoints with `status=pending_verification` or `status=disabled`. Delivery failures can set `status=disabled` while the endpoint remains readable. After deletion, the endpoint is omitted from this list and [Get Webhook](/api-reference/endpoint/get-webhook) returns `404` for its ID.

--- a/api-reference/endpoint/list-webhooks.mdx
+++ b/api-reference/endpoint/list-webhooks.mdx
@@ -3,20 +3,28 @@ title: "List Webhooks"
 openapi: "GET /api/v1/webhooks"
 ---
 
-List every webhook registered on your account. Each entry has the destination URL, subscribed events, delivery status, and signature-verification metadata.
+List the webhooks registered on your account. Each item includes its URL, events, delivery status, and signature state.
+
+## Use this endpoint when
+
+Use this endpoint for a webhook settings page or a startup audit.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/webhooks"
 ```
 
-## The webhook lifecycle
+## Change a webhook
 
-- [Create](/api-reference/endpoint/create-webhook) a webhook with the URL and event types you care about.
-- [Get](/api-reference/endpoint/get-webhook) one to inspect its current state.
-- [Update](/api-reference/endpoint/update-webhook) to change URL, events, or active flag.
-- [Delete](/api-reference/endpoint/delete-webhook) when you no longer need it.
-- [Verify](/api-reference/endpoint/verify-webhook) the endpoint with its token to activate deliveries.
-- [Rotate secret](/api-reference/endpoint/rotate-webhook-secret) if a signing secret leaks.
+- [Create](/api-reference/endpoint/create-webhook) a webhook.
+- [Get](/api-reference/endpoint/get-webhook) its current state.
+- [Update](/api-reference/endpoint/update-webhook) its URL, events, or enabled state.
+- [Delete](/api-reference/endpoint/delete-webhook) it when you no longer need it.
+- [Verify](/api-reference/endpoint/verify-webhook) it before delivery.
+- [Rotate the secret](/api-reference/endpoint/rotate-webhook-secret) after a leak.
 
 For event types, the signature scheme, and verification code, see the [Webhooks guide](/guides/webhooks).
+
+## Example: audit webhook state
+
+List the webhooks after a deployment. Flag any endpoint that is pending verification or disabled.

--- a/api-reference/endpoint/list-webhooks.mdx
+++ b/api-reference/endpoint/list-webhooks.mdx
@@ -27,4 +27,4 @@ For event types, the signature scheme, and verification code, see the [Webhooks 
 
 ## Example: audit webhook state
 
-List webhooks after a deployment. Flag returned endpoints with `status=pending_verification` or `status=disabled`. Delivery failures can set `status=disabled` while the endpoint remains readable. After deletion, the endpoint is omitted from this list and [Get Webhook](/api-reference/endpoint/get-webhook) returns `404` for its ID.
+List webhooks after a deployment. Flag returned endpoints with `status=pending_verification`. If delivery failures stop an endpoint, use its saved ID with [Get Webhook](/api-reference/endpoint/get-webhook) to inspect `status`. After deletion, the endpoint is omitted from this list and Get Webhook returns `404` for its ID.

--- a/api-reference/endpoint/list-webhooks.mdx
+++ b/api-reference/endpoint/list-webhooks.mdx
@@ -27,4 +27,4 @@ For event types, the signature scheme, and verification code, see the [Webhooks 
 
 ## Example: audit webhook state
 
-List the webhooks after a deployment. Flag any endpoint that is pending verification or disabled.
+List the webhooks after a deployment. Flag returned endpoints that are pending verification. For a known webhook ID, call [Get Webhook](/api-reference/endpoint/get-webhook) to inspect its `enabled` state; this list does not prove that a disabled endpoint is absent.

--- a/api-reference/endpoint/redirect-api-openapi-spec.mdx
+++ b/api-reference/endpoint/redirect-api-openapi-spec.mdx
@@ -5,10 +5,18 @@ openapi: "GET /api/v1/openapi.json"
 
 Resolve the canonical OpenAPI document from the API origin.
 
-Returns a temporary redirect to the web-origin spec at `https://0xinsider.com/api/v1/openapi.json`. One spec, one owner, still discoverable from the API origin.
+## Use this endpoint when
+
+Use this endpoint in code generation or docs tooling that starts from the API origin.
+
+The API redirects to `https://0xinsider.com/api/v1/openapi.json`. The web origin owns the document.
 
 ```bash
 curl -I "https://api.0xinsider.com/api/v1/openapi.json"
 ```
 
-Use the `Location` header as the canonical OpenAPI URL for code generation and docs tooling.
+Use the `Location` header as the OpenAPI URL for code generation and docs tooling.
+
+## Example: refresh a generated client
+
+Follow the redirect, fetch the returned document, and pin the document version in your build.

--- a/api-reference/endpoint/remote-mcp-stream.mdx
+++ b/api-reference/endpoint/remote-mcp-stream.mdx
@@ -4,7 +4,11 @@ sidebarTitle: "Remote MCP stream"
 openapi: "GET /api/v1/mcp"
 ---
 
-Open the server-to-client streaming channel for [Remote MCP](/api-reference/endpoint/remote-mcp). Pass the `Mcp-Session-Id` from the `initialize` call to attach to your session, plus `Authorization: Bearer ...` if your client supports headers.
+Open the server-to-client stream for [Remote MCP](/api-reference/endpoint/remote-mcp). Pass the `Mcp-Session-Id` from `initialize`.
+
+## Use this endpoint when
+
+Use this endpoint after you start a Remote MCP session and need streamed tool responses.
 
 ```bash
 curl -N \
@@ -13,4 +17,8 @@ curl -N \
   https://api.0xinsider.com/api/v1/mcp
 ```
 
-This is the stdio analog over HTTP. Hold the connection open to receive streamed tool responses, progress events, and resource updates.
+Keep the connection open for streamed tool responses and progress events.
+
+## Example: receive a tool response
+
+Send the session ID from the initialize response. Read the stream until the tool call completes.

--- a/api-reference/endpoint/remote-mcp-stream.mdx
+++ b/api-reference/endpoint/remote-mcp-stream.mdx
@@ -8,7 +8,7 @@ Open the server-to-client stream for [Remote MCP](/api-reference/endpoint/remote
 
 ## Use this endpoint when
 
-Use this endpoint after you start a Remote MCP session and need streamed tool responses.
+Use this endpoint after you start a Remote MCP session and need a server-to-client stream.
 
 ```bash
 curl -N \
@@ -17,8 +17,8 @@ curl -N \
   https://api.0xinsider.com/api/v1/mcp
 ```
 
-Keep the connection open for streamed tool responses and progress events.
+Keep the connection open for server-to-client notifications. The current GET stream sends only a keep-alive. Send `tools/call` to the POST endpoint to receive a tool response.
 
-## Example: receive a tool response
+## Example: keep a session stream open
 
-Send the session ID from the initialize response. Read the stream until the tool call completes.
+Send the session ID from the initialize response. Do not wait for tool results on this GET stream. Use [Remote MCP](/api-reference/endpoint/remote-mcp) for POST requests and tool results.

--- a/api-reference/endpoint/remote-mcp.mdx
+++ b/api-reference/endpoint/remote-mcp.mdx
@@ -10,7 +10,7 @@ Use the hosted Streamable HTTP MCP endpoint when your agent cannot run a local `
 
 Use this endpoint from a serverless function, browser-based agent, or hosted automation service.
 
-Remote MCP exposes the 21 read-only V1 data operations below as tools. The tools use the same auth, limits, and payloads as REST. `/usage`, `/health`, and webhook mutations are not tools.
+Remote MCP exposes 30 read-only V1 data operations below as tools. The tools use the same auth, limits, and payloads as REST. `/usage`, `/health`, and webhook mutations are not tools.
 
 The endpoint supports `initialize`, `notifications/initialized`, `ping`, `tools/list`, and `tools/call`. It has no resources or prompts.
 
@@ -20,11 +20,15 @@ Current tools:
 - `get_trader`
 - `batch_get_traders`
 - `get_whale_trades`
+- `get_whale_trade`
 - `get_whale_trades_history`
 - `get_market_intel`
 - `batch_get_market_intel`
+- `get_smart_money_flows`
+- `get_sharp_money_flows`
 - `get_market_snapshot`
 - `get_insider_radar`
+- `get_insider_radar_flag`
 - `get_positions`
 - `get_position_timeline`
 - `get_position_timeline_by_id`
@@ -36,7 +40,12 @@ Current tools:
 - `get_daily_report_snapshot`
 - `get_weekly_report_snapshot`
 - `get_monthly_report_snapshot`
+- `get_report`
 - `get_trader_export_snapshot`
+- `get_platforms`
+- `get_large_positions`
+- `get_trending_wallets`
+- `get_trader_pnl`
 
 ## Authentication
 

--- a/api-reference/endpoint/remote-mcp.mdx
+++ b/api-reference/endpoint/remote-mcp.mdx
@@ -4,11 +4,15 @@ sidebarTitle: "Remote MCP"
 openapi: "POST /api/v1/mcp"
 ---
 
-Hosted, streamable HTTP MCP endpoint. Use it when your agent can't spawn a local `npx` subprocess: a serverless function, a browser-based agent, or a hosted automation runtime.
+Use the hosted Streamable HTTP MCP endpoint when your agent cannot run a local `npx` process.
 
-Remote MCP exposes the 21 read-only V1 data operations below as tools. Each tool dispatches to the matching `/api/v1/*` handler in-process, so auth, rate limits, and payload contracts match direct REST calls. Meta endpoints (`/usage`, `/health`) and webhook mutations are not exposed as tools.
+## Use this endpoint when
 
-The remote endpoint is tools-only. It supports `initialize`, `notifications/initialized`, `ping`, `tools/list`, and `tools/call`; it does not implement resources or prompts.
+Use this endpoint from a serverless function, browser-based agent, or hosted automation service.
+
+Remote MCP exposes the 21 read-only V1 data operations below as tools. The tools use the same auth, limits, and payloads as REST. `/usage`, `/health`, and webhook mutations are not tools.
+
+The endpoint supports `initialize`, `notifications/initialized`, `ping`, `tools/list`, and `tools/call`. It has no resources or prompts.
 
 Current tools:
 
@@ -46,6 +50,10 @@ curl -X POST \
   https://api.0xinsider.com/api/v1/mcp
 ```
 
-A `?token=...` query parameter is still available for URL-only clients but is **legacy**. URL secrets leak into shell history, browser history, proxies, and logs. Use headers wherever you can.
+A `?token=...` query parameter is **legacy**. Use the header form because URL secrets enter histories, proxies, and logs.
 
 For the streaming response, see [Remote MCP Stream](/api-reference/endpoint/remote-mcp-stream).
+
+## Example: list tools from a hosted agent
+
+Send `tools/list` with the Bearer header. Select a tool, then send its JSON-RPC arguments in `tools/call`.

--- a/api-reference/endpoint/rotate-webhook-secret.mdx
+++ b/api-reference/endpoint/rotate-webhook-secret.mdx
@@ -7,7 +7,7 @@ Create a new signing secret for a webhook. The response shows it **once**. The o
 
 ## Use this endpoint when
 
-Use this endpoint after a secret leak. Deploy the new secret to your verifier before you rotate.
+Use this endpoint after a secret leak or during scheduled rotation. Call it first, then deploy the new secret from the response to every verifier.
 
 ```bash
 curl -X POST \
@@ -16,10 +16,10 @@ curl -X POST \
   "https://api.0xinsider.com/api/v1/webhooks/42/rotate-secret"
 ```
 
-Rotate the secret after it enters git, a log, a screenshot, or another unsafe location.
+Rotate the secret after it enters git, a log, a screenshot, or another unsafe location. The response shows the new secret once. Store it immediately. The old secret stops working when the call commits.
 
 Send `Idempotency-Key` when you retry after a timeout. A matching retry returns the same one-time secret response.
 
 ## Example: replace a leaked secret
 
-Deploy the new secret to every verifier, then restart those workers. Do not log the response.
+Store the response secret in your secret manager, deploy it to every verifier, and restart those workers. Do not log the response.

--- a/api-reference/endpoint/rotate-webhook-secret.mdx
+++ b/api-reference/endpoint/rotate-webhook-secret.mdx
@@ -3,7 +3,11 @@ title: "Rotate Webhook Secret"
 openapi: "POST /api/v1/webhooks/{id}/rotate-secret"
 ---
 
-Generate a fresh signing secret for a webhook. The response includes the new secret **once**, so copy it immediately. The old secret stops working the moment this call returns. Deploy the new secret to your verification code before you rotate.
+Create a new signing secret for a webhook. The response shows it **once**. The old secret stops working when this call returns.
+
+## Use this endpoint when
+
+Use this endpoint after a secret leak. Deploy the new secret to your verifier before you rotate.
 
 ```bash
 curl -X POST \
@@ -12,6 +16,10 @@ curl -X POST \
   "https://api.0xinsider.com/api/v1/webhooks/42/rotate-secret"
 ```
 
-Rotate right away if a secret leaks (committed to git, exposed in a log, sent in a screenshot).
+Rotate the secret after it enters git, a log, a screenshot, or another unsafe location.
 
-Use `Idempotency-Key` when retrying a rotate after a timeout. A matching retry returns the same one-time secret response instead of rotating again.
+Send `Idempotency-Key` when you retry after a timeout. A matching retry returns the same one-time secret response.
+
+## Example: replace a leaked secret
+
+Deploy the new secret to every verifier, then restart those workers. Do not log the response.

--- a/api-reference/endpoint/rotate-webhook-secret.mdx
+++ b/api-reference/endpoint/rotate-webhook-secret.mdx
@@ -7,7 +7,13 @@ Create a new signing secret for a webhook. The response shows it **once**. The o
 
 ## Use this endpoint when
 
-Use this endpoint after a secret leak or during scheduled rotation. Call it first, then deploy the new secret from the response to every verifier.
+Use this endpoint after a secret leak or during scheduled rotation. Pause deliveries first when you can:
+
+1. Set `enabled` to `false` with [Update Webhook](/api-reference/endpoint/update-webhook).
+2. Wait for any active delivery to finish.
+3. Rotate the secret and capture the one-time response.
+4. Deploy the new secret to every verifier.
+5. Set `enabled` to `true`.
 
 ```bash
 curl -X POST \
@@ -16,10 +22,10 @@ curl -X POST \
   "https://api.0xinsider.com/api/v1/webhooks/42/rotate-secret"
 ```
 
-Rotate the secret after it enters git, a log, a screenshot, or another unsafe location. The response shows the new secret once. Store it immediately. The old secret stops working when the call commits.
+Rotate the secret after it enters git, a log, a screenshot, or another unsafe location. The response shows the new secret once. Store it immediately. The old secret stops working when the call commits. If you rotate an active webhook, deliveries can fail during the cutover and follow normal retries.
 
 Send `Idempotency-Key` when you retry after a timeout. A matching retry returns the same one-time secret response.
 
 ## Example: replace a leaked secret
 
-Store the response secret in your secret manager, deploy it to every verifier, and restart those workers. Do not log the response.
+Store the response secret in your secret manager, deploy it to every verifier, and restart those workers before you re-enable deliveries. Do not log the response.

--- a/api-reference/endpoint/search-markets.mdx
+++ b/api-reference/endpoint/search-markets.mdx
@@ -3,11 +3,19 @@ title: "Search Markets"
 openapi: "GET /api/v1/markets/search"
 ---
 
-Keyword search across Polymarket and Kalshi markets. Best when you know what you want and need the raw `condition_id` for other endpoints.
+Search Polymarket and Kalshi markets by keyword.
+
+## Use this endpoint when
+
+Use this endpoint when you know a market topic and need a `condition_id` for another endpoint.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/markets/search?q=trump&category=politics&status=active"
 ```
 
-Pass the returned `condition_id` or returned `mkt_...` market ID into [Market Intel](/api-reference/endpoint/get-market-intel) or [Market Snapshot](/api-reference/endpoint/get-market-snapshot). For browsing rather than searching, use [Explore Markets](/api-reference/endpoint/explore-markets).
+Pass the returned `condition_id` or `mkt_...` ID to [Market Intel](/api-reference/endpoint/get-market-intel) or [Market Snapshot](/api-reference/endpoint/get-market-snapshot). Use [Explore Markets](/api-reference/endpoint/explore-markets) when the user wants to browse.
+
+## Example: open a politics market
+
+Search with `q=trump`, `category=politics`, and `status=active`. Use the returned market ID for the next request.

--- a/api-reference/endpoint/sharp-money-flows.mdx
+++ b/api-reference/endpoint/sharp-money-flows.mdx
@@ -3,13 +3,21 @@ title: "Sharp Money Flows"
 openapi: "GET /api/v1/markets/sharp-money-flows"
 ---
 
-Canonical endpoint for discovering where S, A, and B grade whale flow is concentrated before you know a market's `condition_id`.
+Discover markets with concentrated S, A, and B grade whale flow before you know a `condition_id`.
 
-Filter by timeframe, category, platform, minimum grade, or direction. Results are ranked by absolute net flow. The opaque cursor preserves the first page's `as_of` timestamp, so new trades do not reorder later pages.
+## Use this endpoint when
+
+Use this endpoint to find markets for a research feed or alert before you open market detail.
+
+Filter by timeframe, category, platform, grade, or direction. Results rank by absolute net flow. The cursor keeps the first page's `as_of` timestamp.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/markets/sharp-money-flows?timeframe=24h&min_grade=B&limit=10"
 ```
 
-[`GET /api/v1/markets/smart-money-flows`](/api-reference/endpoint/smart-money-flows) remains available as a deprecated byte-identical alias. New integrations should use this canonical route.
+[`GET /api/v1/markets/smart-money-flows`](/api-reference/endpoint/smart-money-flows) remains as a deprecated byte-identical alias. Use this route for new integrations.
+
+## Example: find 24-hour sharp flow
+
+Request `timeframe=24h`, `min_grade=B`, and `limit=10`. Pass a returned market ID to [Get Market Intel](/api-reference/endpoint/get-market-intel).

--- a/api-reference/endpoint/smart-money-flows.mdx
+++ b/api-reference/endpoint/smart-money-flows.mdx
@@ -3,9 +3,11 @@ title: "Smart Money Flows"
 openapi: "GET /api/v1/markets/smart-money-flows"
 ---
 
-Rank markets by where graded traders are putting money. This is the "where is smart money flowing right now?" feed. It aggregates whale flow from S, A, and B grade traders. It ranks markets by absolute net flow over your chosen window.
+Rank markets by graded trader flow. The endpoint aggregates S, A, and B grade whale activity and sorts by absolute net flow.
 
-Use it for discovery, before you know a `condition_id`. Once you have a market, follow up with [Get Market Intel](/api-reference/endpoint/get-market-intel) for the single-market breakdown.
+## Use this endpoint when
+
+Use this endpoint for market discovery before you have a `condition_id`. Use [Get Market Intel](/api-reference/endpoint/get-market-intel) after you choose a market.
 
 Common filters:
 
@@ -20,4 +22,8 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/markets/smart-money-flows?timeframe=7d&min_grade=B&limit=10"
 ```
 
-Cursor-paginated. The cursor is anchored to the first page's `as_of` timestamp, so new whale trades do not reorder later pages. See [Pagination](/concepts/pagination).
+The response uses cursor pagination. The cursor stays anchored to the first page's `as_of` timestamp. See [Pagination](/concepts/pagination).
+
+## Example: find markets with 24-hour flow
+
+Request `timeframe=24h`, `min_grade=B`, and `limit=10`. Open the highest-flow result with Market Intel.

--- a/api-reference/endpoint/submit-trader-export.mdx
+++ b/api-reference/endpoint/submit-trader-export.mdx
@@ -3,11 +3,21 @@ title: "Submit Trader Export"
 openapi: "POST /api/v1/trader/{address}/export"
 ---
 
-Queues an asynchronous full-dataset export for one trader. Choose `json`, `ndjson`, or `csv`; JSON is the default.
+Queue a full trader export. Choose `json`, `ndjson`, or `csv`; JSON is the default.
+
+## Use this endpoint when
+
+Use this endpoint when an offline job needs more data than one JSON response should carry.
 
 ```bash
 curl -X POST -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/0xabc.../export?format=ndjson"
 ```
 
-The response contains the job ID. [Poll its status](/api-reference/endpoint/get-trader-export-status), then use the [download endpoint](/api-reference/endpoint/download-trader-export) after the job reaches `ready`. Quotas are enforced per API-key owner and trader address.
+The response contains a job ID. Poll [Trader Export Status](/api-reference/endpoint/get-trader-export-status), then call [Download Trader Export](/api-reference/endpoint/download-trader-export) when the job is `ready`.
+
+Quotas apply per API-key owner and trader address.
+
+## Example: queue an NDJSON export
+
+Store the job ID in a worker record. Retry status reads with a delay until the job reaches `ready` or `failed`.

--- a/api-reference/endpoint/update-webhook.mdx
+++ b/api-reference/endpoint/update-webhook.mdx
@@ -3,7 +3,11 @@ title: "Update Webhook"
 openapi: "PATCH /api/v1/webhooks/{id}"
 ---
 
-Change a webhook's destination URL, subscribed events, or active flag without recreating it. Promote a staging URL to production, or pause delivery during maintenance without losing the registration.
+Change a webhook URL, event list, or enabled state without creating a new webhook.
+
+## Use this endpoint when
+
+Use this endpoint to promote a staging receiver or pause delivery during maintenance.
 
 ```bash
 curl -X PATCH \
@@ -14,6 +18,10 @@ curl -X PATCH \
   "https://api.0xinsider.com/api/v1/webhooks/42"
 ```
 
-The signing secret is not affected by `PATCH`. To change it, use [Rotate Webhook Secret](/api-reference/endpoint/rotate-webhook-secret).
+`PATCH` does not change the signing secret. Use [Rotate Webhook Secret](/api-reference/endpoint/rotate-webhook-secret) to change it.
 
-Use `Idempotency-Key` when retrying the same update body. A matching retry replays the original response; a different body with the same key returns `422`.
+Send `Idempotency-Key` when you retry the same body. A matching retry returns the original response. A different body with that key returns `422`.
+
+## Example: pause during maintenance
+
+Set `enabled` to `false`, run the maintenance, then set it to `true`. Keep the same webhook ID.

--- a/api-reference/endpoint/verify-webhook.mdx
+++ b/api-reference/endpoint/verify-webhook.mdx
@@ -3,7 +3,11 @@ title: "Verify Webhook"
 openapi: "POST /api/v1/webhooks/{id}/verify"
 ---
 
-Activate a webhook by returning the `verification_token` you received when you created it. A new endpoint stays in `pending_verification` and receives no deliveries until it is verified. The token expires 24 hours after create.
+Activate a webhook with its `verification_token`. A new endpoint stays in `pending_verification` until this call succeeds. The token expires 24 hours after creation.
+
+## Use this endpoint when
+
+Use this endpoint after [Create Webhook](/api-reference/endpoint/create-webhook) and before you wait for events.
 
 ```bash
 curl -X POST \
@@ -13,6 +17,10 @@ curl -X POST \
   "https://api.0xinsider.com/api/v1/webhooks/42/verify"
 ```
 
-On success the endpoint flips to `active` and deliveries begin. This call does not send a test delivery; it activates the endpoint by matching the token. The webhook `id` is the integer returned at create.
+On success, the endpoint becomes `active` and delivery starts. This call does not send a test delivery. The webhook `id` is the integer from create.
 
 For the signature scheme and copy-pasteable verification code, see the [Webhooks guide](/guides/webhooks).
+
+## Example: activate a new receiver
+
+Read the token from the create response, send it from your setup job, and then wait for a real event delivery.

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -12,8 +12,8 @@ https://api.0xinsider.com/api/v1/
 
 ## Authentication
 
-Most data endpoints need a Bearer token. Discovery, OpenAPI, health, platforms,
-and remote MCP are public:
+Most data endpoints need a Bearer token. Discovery, OpenAPI, health, and
+platforms are public. Remote MCP also needs a Bearer token:
 
 ```bash
 Authorization: Bearer oxi_sk_live_...

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: "API Reference"
 sidebarTitle: "Overview"
-description: "What every 0xinsider endpoint shares: base URL, auth, envelope, IDs, rate limits, and trust metadata."
+description: "Shared API rules for URLs, auth, responses, IDs, limits, and trust metadata."
 ---
 
 ## Base URL
@@ -18,11 +18,11 @@ Every endpoint except `/health` needs a Bearer token:
 Authorization: Bearer oxi_sk_live_...
 ```
 
-Generate yours at [0xinsider.com/developers](https://0xinsider.com/developers). Full details in [Authentication](/authentication).
+Create a key at [0xinsider.com/developers](https://0xinsider.com/developers). See [Authentication](/authentication).
 
 ## Response envelope
 
-Single-resource endpoints return:
+Single-resource endpoints return one object:
 
 ```json
 {
@@ -32,7 +32,7 @@ Single-resource endpoints return:
 }
 ```
 
-List endpoints add pagination fields:
+List endpoints add cursor fields:
 
 ```json
 {
@@ -52,11 +52,11 @@ List endpoints add pagination fields:
 | `meta.cached` | `true` when the response came from cache. |
 | `has_more` / `next_cursor` | Present on list responses. See [Pagination](/concepts/pagination). |
 
-Errors share the same envelope, with `"object": "error"`. See [Errors](/errors).
+Errors use the same envelope with `"object": "error"`. See [Errors](/errors).
 
 ## Prefixed IDs
 
-Every ID is prefixed with its type, so it's self-describing in logs and chat transcripts.
+IDs carry a type prefix. Keep the prefix in logs and agent context.
 
 | Entity | Prefix | Example |
 |---|---|---|
@@ -66,11 +66,11 @@ Every ID is prefixed with its type, so it's self-describing in logs and chat tra
 | Radar flag | `rf_` | `rf_67890` |
 | Request | `req_` | `req_550e8400` |
 
-Trader path endpoints accept raw addresses and valid `trd_...` wallet IDs. Market path endpoints such as `/market/{condition_id}/intel` and `/market/{condition_id}/snapshot` accept either raw provider-backed condition IDs or the `mkt_...` IDs emitted by V1 responses. Single-record whale trade and radar endpoints accept raw integer IDs or their `wt_...` / `rf_...` forms.
+Trader paths accept raw addresses and `trd_...` IDs. Market paths such as `/market/{condition_id}/intel` and `/market/{condition_id}/snapshot` accept raw condition IDs and `mkt_...` IDs. Single whale-trade and radar paths accept raw integer IDs and `wt_...` or `rf_...` IDs.
 
 ## Rate limits
 
-100 requests per minute per user, sliding window. Batch endpoints have an additional 100-item-unit-per-minute budget. `GET /api/v1/usage` does not spend primary quota, but it has its own 100 reads/minute guard.
+The limit is 100 requests per minute per user in a sliding window. Batch endpoints add a 100-item-unit budget. `GET /api/v1/usage` has its own 100 reads/minute guard.
 
 | Header | Meaning |
 |---|---|
@@ -83,17 +83,16 @@ Trader path endpoints accept raw addresses and valid `trd_...` wallet IDs. Marke
 | `X-Batch-RateLimit-Reset` | Unix timestamp when the batch window resets. |
 | `Retry-After` | Seconds to wait. Only on `429`. |
 
-See [Rate Limits](/rate-limits) for backoff patterns.
+See [Rate Limits](/rate-limits) for retry code.
 
 ## Browser CORS
 
-Public REST `/api/v1/*` endpoints, excluding remote MCP (`/api/v1/mcp`), are
-callable from third-party browser origins with `Authorization: Bearer ...`. Do
-not send cookies or `credentials: "include"` on public API calls.
+Public REST `/api/v1/*` endpoints, except remote MCP (`/api/v1/mcp`), accept
+requests from third-party browser origins with `Authorization: Bearer ...`.
+Do not send cookies or `credentials: "include"`.
 
-Remote MCP at `/api/v1/mcp` is also non-credentialed, but still validates
-`Origin` against the 0xinsider/localhost allowlist per the MCP Streamable HTTP
-DNS-rebinding guidance.
+Remote MCP at `/api/v1/mcp` is also non-credentialed. It validates `Origin`
+against the 0xinsider/localhost allowlist.
 
 Allowed public request headers:
 
@@ -122,7 +121,7 @@ endpoints remain restricted to configured 0xinsider origins.
 
 ## Trust metadata
 
-Newer builder endpoints attach metadata to provider-owned values. Those endpoints are snapshots, history ranges, batch reads, and reports. The metadata lets you tell provider-backed, cached, partial, stale, and unavailable data apart.
+Builder endpoints attach metadata to provider-owned values. Use it to separate provider-backed, cached, partial, stale, and unavailable data.
 
 Per value, four dimensions:
 
@@ -131,6 +130,6 @@ Per value, four dimensions:
 - `reconciliation`: whether it was cross-checked against the source of truth (`provider_backed`, `db_mirror`, `computed`, `partial`, `not_applicable`, `unavailable`).
 - `completeness`: whether it reflects the full picture (`complete`, `partial`, `not_computed`, `not_applicable`, `unavailable`).
 
-See [Trust metadata](/concepts/trust-metadata) for what each value means and how to request field-level trust with `expand=trust`.
+See [Trust metadata](/concepts/trust-metadata) for the values and `expand=trust`.
 
-Rule of thumb: **don't flatten unavailable values into `0`, `[]`, or `{}`.** Read the metadata. Surface "unavailable" to your consumer instead of inventing a zero. Provider data that quietly becomes `0` causes silent bugs downstream.
+Do not convert unavailable values to `0`, `[]`, or `{}`. Read the metadata and pass `unavailable` to your consumer.

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -12,7 +12,8 @@ https://api.0xinsider.com/api/v1/
 
 ## Authentication
 
-Every endpoint except `/health` needs a Bearer token:
+Most data endpoints need a Bearer token. Discovery, OpenAPI, health, platforms,
+and remote MCP are public:
 
 ```bash
 Authorization: Bearer oxi_sk_live_...

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -71,7 +71,7 @@ Trader paths accept raw addresses and `trd_...` IDs. Market paths such as `/mark
 
 ## Rate limits
 
-The limit is 100 requests per minute per user in a sliding window. Batch endpoints add a 100-item-unit budget. `GET /api/v1/usage` has its own 100 reads/minute guard.
+The limit is 100 requests per minute per user in a sliding window. Batch endpoints add a 2500-item-unit budget. `GET /api/v1/usage` has its own 100 reads/minute guard.
 
 | Header | Meaning |
 |---|---|

--- a/authentication.mdx
+++ b/authentication.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Authentication"
-description: "API keys, headers, and what to do if a key leaks."
+description: "Create, send, and rotate 0xinsider API keys."
 ---
 
-Every request except `/health` uses a Bearer token:
+All requests except `/health` need a Bearer token:
 
 ```bash
 Authorization: Bearer oxi_sk_live_...
@@ -18,9 +18,9 @@ Authorization: Bearer oxi_sk_live_...
 | Active keys per account | 1. Regenerating revokes the old key. |
 | Where to generate | [0xinsider.com/developers](https://0xinsider.com/developers) |
 
-The key shows **once**, at generation. After that the dashboard shows only the prefix (`oxi_sk_live_XXXX`) so you can identify it.
+The dashboard shows the full key once. Later it shows only the prefix (`oxi_sk_live_XXXX`).
 
-## Generate a key
+## Create a key
 
 1. Log in at [0xinsider.com](https://0xinsider.com).
 2. Open [Developers](https://0xinsider.com/developers).
@@ -52,9 +52,9 @@ The key shows **once**, at generation. After that the dashboard shows only the p
   </Accordion>
 </AccordionGroup>
 
-## If a key leaks
+## If a key is exposed
 
-Treat it like any production secret:
+Rotate it at once:
 
 1. Go to [Developers](https://0xinsider.com/developers).
 2. Click **Regenerate Key**. The old key dies immediately.
@@ -62,7 +62,7 @@ Treat it like any production secret:
 
 ## Key management endpoints
 
-These manage *your own* keys from the dashboard. They use the session cookie (JWT), not an API key, so you can't call them from a script with `oxi_sk_live_...`.
+These routes manage your keys in the dashboard. They use the session cookie (JWT), not an API key.
 
 | Action | Method | Endpoint |
 |---|---|---|

--- a/authentication.mdx
+++ b/authentication.mdx
@@ -3,7 +3,8 @@ title: "Authentication"
 description: "Create, send, and rotate 0xinsider API keys."
 ---
 
-All requests except `/health` need a Bearer token:
+Most data endpoints need a Bearer token. Discovery, OpenAPI, health, platforms,
+and remote MCP are public:
 
 ```bash
 Authorization: Bearer oxi_sk_live_...

--- a/authentication.mdx
+++ b/authentication.mdx
@@ -3,8 +3,8 @@ title: "Authentication"
 description: "Create, send, and rotate 0xinsider API keys."
 ---
 
-Most data endpoints need a Bearer token. Discovery, OpenAPI, health, platforms,
-and remote MCP are public:
+Most data endpoints need a Bearer token. Discovery, OpenAPI, health, and
+platforms are public. Remote MCP also needs a Bearer token:
 
 ```bash
 Authorization: Bearer oxi_sk_live_...

--- a/concepts/expand.mdx
+++ b/concepts/expand.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Expanding Responses"
-description: "Use the expand parameter to pull heavier fields and trust metadata only when you need them."
+description: "Request strategy, quant, category, or trust fields with expand."
 ---
 
-Trader responses stay lean by default. The expensive fields, strategy classification, per-category performance, quant metrics, and trust metadata, are left out unless you ask for them. The `expand` parameter pulls them in.
+Trader responses are small by default. Use `expand` for strategy, category performance, quant metrics, or trust metadata.
 
-This keeps the common path fast. Expanded fields skip the cache and read fresh, so request them only when you need them.
+Expanded fields read fresh and make a heavier request. Ask only for fields your screen uses.
 
 ## How to pass it
 
-`expand` is repeatable. Use a comma-separated list or repeat the bracketed key:
+`expand` accepts a comma-separated list or repeated keys:
 
 ```bash
 # Comma-separated
@@ -21,11 +21,11 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/0x204f...?expand[]=strategy&expand[]=trust"
 ```
 
-Unknown values are ignored, so a forward-compatible client can safely pass options an older API build does not recognize.
+Unknown values are ignored.
 
 ## The four expand values
 
-Available on [`GET /api/v1/trader/{address}`](/api-reference/endpoint/get-trader) and [`POST /api/v1/traders/batch`](/api-reference/endpoint/batch-get-traders):
+These values work on [`GET /api/v1/trader/{address}`](/api-reference/endpoint/get-trader) and [`POST /api/v1/traders/batch`](/api-reference/endpoint/batch-get-traders):
 
 | Value | Adds field | What it contains |
 |---|---|---|
@@ -34,7 +34,7 @@ Available on [`GET /api/v1/trader/{address}`](/api-reference/endpoint/get-trader
 | `quant_metrics` | `quant_metrics` | A fixed set of nine curated risk and performance metrics, including the `smart_score` and `copy_score` headline scores. See [Quant metrics](/concepts/quant-metrics). |
 | `trust` | `trust` | Field-level [trust metadata](/concepts/trust-metadata): source, freshness, reconciliation, and completeness for each derived field. |
 
-## Example
+## Example: add strategy data
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -59,11 +59,11 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
 
 ## Market snapshots
 
-[`GET /api/v1/market/{condition_id}/snapshot`](/api-reference/endpoint/get-market-snapshot) accepts `expand=trust` only. It adds trust metadata for the snapshot's `current_price` and `spread_bps`. The trader-only values (`strategy`, `categories`, `quant_metrics`) do not apply to markets.
+[`GET /api/v1/market/{condition_id}/snapshot`](/api-reference/endpoint/get-market-snapshot) accepts only `expand=trust`. It adds trust metadata for `current_price` and `spread_bps`.
 
 ## Cost
 
-Expanded fields read live instead of from cache, so an expanded request is heavier than a plain one. Two habits keep this cheap:
+Expanded requests are heavier than plain requests. Keep them cheap:
 
-- Request only the expansions you use on a given screen.
-- For many traders at once, use [`POST /api/v1/traders/batch`](/api-reference/endpoint/batch-get-traders) with a single `expand` set rather than one expanded request per trader.
+- Request only the fields you use.
+- Use [`POST /api/v1/traders/batch`](/api-reference/endpoint/batch-get-traders) for many traders instead of one expanded request per trader.

--- a/concepts/grades.mdx
+++ b/concepts/grades.mdx
@@ -76,7 +76,7 @@ This profile shows high realized P&L, a high win rate, a strategy label, and a c
 
 This profile is available from the API but not from the leaderboard.
 
-## Using grades in the API
+## Use grades in the API
 
 ### Example: filter whale trades by grade
 

--- a/concepts/grades.mdx
+++ b/concepts/grades.mdx
@@ -1,36 +1,36 @@
 ---
 title: "Trader Grades"
-description: "What S, A, B, C, D, F mean, with real profile examples."
+description: "Use trader grades to filter profiles and whale trades."
 ---
 
-Every trader gets one letter grade. It answers one question: should you pay attention to this wallet?
+Each trader has one letter grade. It is a first-pass quality filter.
 
-Grades show up on the leaderboard, on every trader profile, and inside every whale trade object.
+The grade appears on leaderboards, trader profiles, and whale trades.
 
 ## The scale
 
 | Grade | One-line meaning | On the leaderboard? |
 |---|---|---|
-| **S** | Elite. Years of evidence, outsized P&L, high win rate, real volume. | Yes |
-| **A** | Strong. Consistently profitable, well-diversified across markets. | Yes |
-| **B** | Above average. Solid recent track record, smaller sample. | Yes |
-| **C** | Roughly breakeven. Not a clear signal. | No |
-| **D** | Net losing across the sample. | No |
-| **F** | Persistently losing. Often coin-flip or chasing resolved markets. | No |
+| **S** | Elite record with high P&L, win rate, and volume. | Yes |
+| **A** | Strong and consistent record across markets. | Yes |
+| **B** | Above average, with a smaller sample. | Yes |
+| **C** | Near breakeven. | No |
+| **D** | Net losing record. | No |
+| **F** | Persistent losses or random behavior. | No |
 
-The leaderboard ranks only S, A, and B. Those are the wallets worth following.
+The leaderboard includes S, A, and B traders.
 
 ## What goes into the grade
 
-The score is a composite (0-100) of five inputs:
+The score is a 0-100 composite of five inputs:
 
-1. **Realized P&L**: actual profit from closed positions, not unrealized markings.
-2. **Win rate**: share of markets that resolved in their favor.
-3. **Volume**: total traded size. More volume means more signal per trade.
-4. **Market count**: distinct markets they have touched (diversification).
-5. **Recency**: penalizes wallets that have not traded in a long time.
+1. **Realized P&L**: profit from closed positions.
+2. **Win rate**: share of markets resolved in their favor.
+3. **Volume**: total traded size.
+4. **Market count**: distinct markets traded.
+5. **Recency**: recent trading activity.
 
-Score thresholds assign the letter. Only B or better makes the leaderboard.
+Score thresholds assign the letter. Only B or better appears on the leaderboard.
 
 ## Two real profiles, side by side
 
@@ -53,7 +53,7 @@ Score thresholds assign the letter. Only B or better makes the leaderboard.
 }
 ```
 
-Very high realized P&L, near-perfect win rate, a classifiable strategy, a clear category strength.
+This profile shows high realized P&L, a high win rate, a strategy label, and a category strength.
 
 ### C-grade: noisy and small
 
@@ -74,13 +74,13 @@ Very high realized P&L, near-perfect win rate, a classifiable strategy, a clear 
 }
 ```
 
-P&L near breakeven, a coin-flip win rate, no detectable strategy. Visible in the API, but not on the leaderboard.
+This profile is available from the API but not from the leaderboard.
 
 ## Using grades in the API
 
-### Filter whale trades by grade
+### Example: filter whale trades by grade
 
-Only see trades from A-grade or better:
+Use `min_grade=A` to read S and A trades:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -89,9 +89,9 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
 
 `min_grade` accepts `S`, `A`, `B`. Setting `min_grade=A` returns S **and** A.
 
-### Filter the leaderboard by strategy
+### Example: filter the leaderboard by strategy
 
-Pull only S/A/B-grade swing traders:
+Use `strategy` to rank one style:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -100,9 +100,9 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
 
 Some traders make the leaderboard but lack a classifiable strategy. Their `strategy_type` is `null`, so treat the field as nullable when filtering client-side.
 
-### Combine grade + category
+### Example: combine grade and category
 
-What are A-grade or better crypto traders trading right now? (Each item carries its `side` in the response, so you can split buys from sells client-side.)
+Use both filters to inspect A-grade-or-better crypto trades. Read `side` from each item.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -111,4 +111,4 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
 
 ## A note on null strategies
 
-A leaderboard trader without a strategy classification just means we haven't detected a stable pattern yet. They are still a graded trader. Don't filter them out unless you actually need a labeled strategy.
+A missing `strategy_type` means no stable pattern is classified yet. Keep the trader unless your workflow needs a label.

--- a/concepts/number-formatting.mdx
+++ b/concepts/number-formatting.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Number Formatting"
-description: "How numeric values are formatted in API responses."
+description: "Read decimal precision, truncation, nulls, and unavailable values."
 ---
 
-Numbers come back as plain JSON numbers, not strings. Floating-point values are **truncated**, not rounded, at the API edge. The displayed value never overstates the real one.
+The API returns JSON numbers, not numeric strings. Decimal values are **truncated**, not rounded.
 
 ## Precision
 
@@ -16,13 +16,13 @@ Numbers come back as plain JSON numbers, not strings. Floating-point values are 
 
 ## Truncated, not rounded
 
-`97.9488...` becomes `97.94`, not `97.95`. `-12.345` becomes `-12.34`. Always toward zero.
+`97.9488...` becomes `97.94`. `-12.345` becomes `-12.34`. Truncation moves toward zero.
 
-Need stricter precision for accounting? Compute from the source data. The edge value is display-safe, not accounting-grade.
+For accounting precision, compute from source data. API values are display-safe.
 
 ## Integer fields
 
-These are exact integers. No decimals, no truncation:
+These fields are exact integers:
 
 - `markets_traded`
 - `rank`
@@ -30,6 +30,6 @@ These are exact integers. No decimals, no truncation:
 
 ## Nulls and `unavailable`
 
-Many fields are nullable (e.g. `strategy_type`, `best_category`). Treat them as nullable even when an endpoint usually populates them.
+Treat nullable fields such as `strategy_type` and `best_category` as nullable on every response.
 
-Newer builder endpoints also return **trust metadata**: explicit `unavailable` or `partial` markers when a provider-owned value can't be returned at request time. Don't convert these into `0`, `[]`, or `{}`. Read the metadata field and treat the value as missing.
+Builder endpoints can return trust metadata with `unavailable` or `partial`. Do not convert these values to `0`, `[]`, or `{}`. Read the metadata.

--- a/concepts/pagination.mdx
+++ b/concepts/pagination.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Pagination"
-description: "Cursor-based pagination, with a full loop in JS and Python."
+description: "Page through list endpoints with cursors in JavaScript or Python."
 ---
 
-Every list endpoint uses **cursor pagination**. No `offset`, no `page` number. Cursors stay stable as long as the sort order holds, so they beat offsets on live data.
+Every list endpoint uses a cursor. There is no `offset` or page number.
 
 ## The shape
 
@@ -19,14 +19,14 @@ A list response looks like this:
 }
 ```
 
-To get the next page, pass `next_cursor` back as the `cursor` query param:
+Pass `next_cursor` back as the `cursor` query parameter:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/leaderboard?limit=20&cursor=95.85_0x885..."
 ```
 
-Repeat until `has_more` is `false`.
+Stop when `has_more` is `false`.
 
 ## Parameters
 
@@ -35,9 +35,9 @@ Repeat until `has_more` is `false`.
 | `limit` | integer | `20` | `100` |
 | `cursor` | string | — | — |
 
-## Full loop, end to end
+## Example: read every page
 
-This pulls every page of the leaderboard.
+This loop reads every leaderboard page.
 
 <CodeGroup>
 ```javascript JavaScript
@@ -90,9 +90,9 @@ print(f"Fetched {len(leaders)} traders")
 ```
 </CodeGroup>
 
-## Cursors are opaque
+## Treat cursors as opaque
 
-Don't parse, construct, or store cursors long-term. Always use the `next_cursor` from the response you just got.
+Do not parse or construct cursors. Use the latest `next_cursor`.
 
 Different endpoints encode cursors differently:
 
@@ -100,11 +100,11 @@ Different endpoints encode cursors differently:
 - **Whale trades**: `{timestamp}_{id}` (ISO 8601)
 - **Insider radar**: `{score}_{id}`
 
-You don't need to know this. Just pass the string back.
+Pass the string back without changing it.
 
-## Gotchas
+## Common mistakes
 
-- **Don't mix cursors across filters.** A cursor from `?category=crypto` won't work on `?category=politics`. Restart pagination when filters change.
-- **Don't mix cursors across endpoints.** A leaderboard cursor won't work on whale trades.
-- **`400 Invalid cursor format`** means the cursor came from a different filter set, a different endpoint, or got mangled. Drop it and start over.
-- **Stale cursors expire.** Pause for hours and the underlying sort can shift. Expect to restart.
+- **Filters changed.** Restart when any filter changes.
+- **Endpoint changed.** A leaderboard cursor cannot page whale trades.
+- **`400 Invalid cursor format`.** Drop the cursor and start again.
+- **Cursor is old.** Restart after a long pause or a sort change.

--- a/concepts/platforms.mdx
+++ b/concepts/platforms.mdx
@@ -1,24 +1,24 @@
 ---
 title: "Platforms"
-description: "Which prediction markets 0xinsider covers, and which features are available per platform."
+description: "Check Polymarket and Kalshi feature coverage at runtime."
 ---
 
-0xinsider covers two prediction-market platforms: **Polymarket** and **Kalshi**. They are not at parity. Polymarket is fully covered. Kalshi coverage is partial, because some of the on-chain signals 0xinsider computes do not exist for Kalshi's centralized markets.
+0xinsider covers **Polymarket** and **Kalshi**. Coverage differs because some signals need on-chain data.
 
-Plan around the real coverage. A copy-trading or whale-tracking integration that assumes Kalshi grades or Kalshi whale data will come back empty.
+Check the capability response before you build a platform-specific workflow. Kalshi does not provide every grade or whale field.
 
 ## The platform enum
 
-Anywhere a `platform` field or filter appears, the values are lowercase:
+Use these lowercase `platform` values:
 
 - `polymarket`
 - `kalshi`
 
-Endpoints that accept a `platform` filter (whale-trades history, smart-money flows, explore) also accept `all`.
+Some filters also accept `all`.
 
 ## Capability matrix
 
-This mirrors the live [`GET /api/v1/platforms`](/api-reference/endpoint/get-platforms) response, which is the source of truth. Query it at runtime rather than hard-coding coverage.
+[`GET /api/v1/platforms`](/api-reference/endpoint/get-platforms) is the source of truth. Query it at runtime instead of hard-coding coverage.
 
 | Capability | Polymarket | Kalshi |
 |---|---|---|
@@ -30,11 +30,11 @@ This mirrors the live [`GET /api/v1/platforms`](/api-reference/endpoint/get-plat
 | Insider radar | Supported | Unsupported |
 | Market snapshot | Supported | Partial |
 
-`supported` means the feature is fully populated. `partial` means some fields are present but not all (Kalshi market snapshots carry last price but no order-book top-of-book, for example). `unsupported` means the feature does not apply to that platform and returns no data.
+`supported` means all fields are available. `partial` means some fields are missing. `unsupported` means the feature does not apply and returns no data.
 
 ## Polymarket-only features
 
-Two surfaces are Polymarket-only today, independent of any `platform` filter you pass:
+These surfaces are Polymarket-only:
 
 - **Whale trades** ([`/whale-trades`](/api-reference/endpoint/get-whale-trades), [`/whale-trades/history`](/api-reference/endpoint/get-whale-trades-history)). The whale-trade feed is built from Polymarket fills only. A `platform=kalshi` filter returns nothing.
 - **Large positions** ([`/large-positions`](/api-reference/endpoint/list-large-positions)). The large-position scanner runs against Polymarket markets only.
@@ -50,4 +50,4 @@ These read paths return both Polymarket and Kalshi data:
 - Market intel and smart-money flows ([`/market/{condition_id}/intel`](/api-reference/endpoint/get-market-intel), [`/markets/smart-money-flows`](/api-reference/endpoint/smart-money-flows)).
 - Market search and explore ([`/markets/search`](/api-reference/endpoint/search-markets), [`/markets/explore`](/api-reference/endpoint/explore-markets)).
 
-When a field is thin or absent for Kalshi, [trust metadata](/concepts/trust-metadata) marks it. An `unsupported` source surfaces as `unavailable`. You can detect coverage gaps in code instead of guessing.
+For thin or absent Kalshi fields, [trust metadata](/concepts/trust-metadata) marks the value. `unsupported` data appears as `unavailable`.

--- a/concepts/quant-metrics.mdx
+++ b/concepts/quant-metrics.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Quant Metrics"
-description: "The curated risk and performance metrics behind a trader's scores, what each field means, and how to read them."
+description: "Read trader skill, copyability, risk, and performance metrics."
 ---
 
-`quant_metrics` is a curated set of risk and performance metrics for a trader. It is where the two headline scores live, `smart_score` and `copy_score`, alongside the risk-adjusted return and consistency measures they are built from.
+`quant_metrics` contains curated risk and performance metrics for one trader. It includes `smart_score`, `copy_score`, and their component values.
 
-The field set is fixed and documented: exactly nine fields, each a number or `null`. It is not a raw database dump, and it does not grow silently as we add internal columns. New internal metrics stay internal until they are curated into this contract.
+The response has exactly nine fields. Each value is a number or `null`.
 
 ## How to get it
 
@@ -23,16 +23,16 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   -d '{"traders": ["0x204f...", "swisstony"], "expand": ["quant_metrics"]}'
 ```
 
-It appears on [`GET /api/v1/trader/{address}`](/api-reference/endpoint/get-trader) and [`POST /api/v1/traders/batch`](/api-reference/endpoint/batch-get-traders). The field is present only when the trader has computed metrics; when present, all nine keys are present.
+It appears on [`GET /api/v1/trader/{address}`](/api-reference/endpoint/get-trader) and [`POST /api/v1/traders/batch`](/api-reference/endpoint/batch-get-traders). If metrics are present, all nine keys are present.
 
 ## The two headline scores
 
-Both scores are 0-100 and higher is better. They answer different questions.
+Both scores range from 0 to 100. Higher is better.
 
 - `smart_score` measures **skill**: how good is this trader, on a risk-adjusted basis, relative to everyone else?
 - `copy_score` measures **copyability**: how safely could you follow this trader, after discounting traits that make a strategy hard to replicate?
 
-`smart_score` is a weighted blend of the trader's cross-sectional percentiles and a few absolute measures:
+`smart_score` combines percentiles and absolute measures:
 
 ```
 smart_score = clamp(0, 100,
@@ -44,7 +44,7 @@ smart_score = clamp(0, 100,
   + 10 * (1 - min(1, asset_concentration)))
 ```
 
-`copy_score` starts from that same base and subtracts penalties for hard-to-replicate behaviour, then clamps to 0-100:
+`copy_score` starts from the same base and subtracts penalties:
 
 | Penalty | When it applies |
 |---|---|
@@ -54,11 +54,11 @@ smart_score = clamp(0, 100,
 | -10 | Worst single-trade loss exceeds 30% |
 | -10 | Edge is inconsistent |
 
-A trader can have a high `smart_score` and a much lower `copy_score`: genuinely skilled, but running a book that is risky or impractical to mirror. When you are ranking traders to follow or copy, read `copy_score`. When you are ranking pure skill, read `smart_score`.
+A trader can have a high `smart_score` and a lower `copy_score`. Use `copy_score` to choose traders to follow. Use `smart_score` to compare skill.
 
 ## The component metrics
 
-These are the underlying measures. They are absolute values, not ranks.
+These fields are absolute values, not ranks.
 
 | Field | Meaning |
 |---|---|
@@ -69,7 +69,7 @@ These are the underlying measures. They are absolute values, not ranks.
 
 ## The percentile ranks
 
-These place the trader against the whole population, 0-100. They are the inputs the scores lean on, exposed directly so you can see where a number sits in the field.
+These fields place the trader against the population on a 0-100 scale.
 
 | Field | Meaning |
 |---|---|
@@ -79,9 +79,9 @@ These place the trader against the whole population, 0-100. They are the inputs 
 
 ## Reading the values
 
-- **`null` means insufficient trade history, not zero.** Every field is a number or `null`. A `null` field is one we cannot compute yet for this trader; treating it as `0` will rank a brand-new wallet as the worst possible trader rather than an unknown one.
-- **Values refresh periodically.** The scores and percentiles are recomputed by the cross-sectional ranking job, not on every request. A trader's percentile moves as the rest of the population moves, even if their own trades do not.
-- **Scores are 0-100; components are absolute.** `smart_score`, `copy_score`, and the three percentiles are bounded 0-100. `sharpe_30d`/`sharpe_7d` and `profit_factor` are unbounded (profit factor is capped at 1000), so compare them against the percentile fields for context.
+- **`null` means not computed.** Do not convert it to `0`.
+- **Values refresh on a schedule.** A percentile can change as the population changes.
+- **Scores and components differ.** Scores and percentiles use 0-100. Sharpe is unbounded. Profit factor is capped at 1000.
 
 ## Full response shape
 

--- a/concepts/signal-scoring.mdx
+++ b/concepts/signal-scoring.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Signal Scoring"
-description: "The smart-money and signal fields the API exposes, and what each one measures."
+description: "Choose the right trader, trade, and market signal field."
 ---
 
-0xinsider scores activity so you can sort noise from signal. There are a few distinct scores, and each answers a different question. How good is this trader? How strong is this single trade? Which way is smart money leaning on this market? This page names each field and what it measures, so you do not confuse one for another.
+Each score answers a different question. Use the field that matches your task.
 
 ## Trader quality: grade and score
 
@@ -14,20 +14,20 @@ On every trader and leaderboard entry:
 - `streak_tier`: recent form, separate from the all-time grade. One of `hot`, `rising`, `neutral`, `cooling`, `cold`.
 - `rank`: position on the leaderboard.
 
-Grade is the long-run verdict. `streak_tier` is the trailing-form overlay: an A-grade trader can be `cooling`, and a B-grade trader can be `hot`.
+`grade` is long-term quality. `streak_tier` is recent form. An A-grade trader can be `cooling`; a B-grade trader can be `hot`.
 
 ## Deeper trader metrics: quant_metrics
 
-`grade` and `score` are the headline verdict. When you want the risk and performance detail behind them, request [`quant_metrics`](/concepts/quant-metrics) on a trader (`expand=quant_metrics`). It returns nine curated fields, including two 0-100 scores that answer different questions:
+For risk and performance detail, request [`quant_metrics`](/concepts/quant-metrics) with `expand=quant_metrics`. It returns nine fields:
 
 - `smart_score`: how skilled is this trader, risk-adjusted, versus the field.
 - `copy_score`: how safely could you copy them, after penalising traits that make a strategy hard to replicate.
 
-The other seven fields (30- and 7-day Sharpe, profit factor, edge consistency, and their cross-sectional percentiles) are the inputs behind those scores. See [Quant metrics](/concepts/quant-metrics) for the full field set and how to read `null`.
+The other fields include 7-day and 30-day Sharpe, profit factor, edge consistency, and percentiles. Read `null` as not computed.
 
 ## Per-trade strength: signal_score
 
-Each [whale trade](/api-reference/endpoint/get-whale-trades) carries a `signal_score`: how strong that single fill is as a signal. Use it to rank a feed of trades, not to judge a trader overall.
+Each [whale trade](/api-reference/endpoint/get-whale-trades) carries `signal_score`. Use it to rank individual fills, not whole traders.
 
 ```json
 {
@@ -46,7 +46,7 @@ Each [whale trade](/api-reference/endpoint/get-whale-trades) carries a `signal_s
 
 ## Market direction: smart money
 
-[Market intel](/api-reference/endpoint/get-market-intel) and [smart-money flows](/api-reference/endpoint/smart-money-flows) return a `smart_money` object. This is the canonical view of where graded money is flowing on a market:
+[Market intel](/api-reference/endpoint/get-market-intel) and [smart-money flows](/api-reference/endpoint/smart-money-flows) return `smart_money`:
 
 | Field | Meaning |
 |---|---|
@@ -69,18 +69,18 @@ Each [whale trade](/api-reference/endpoint/get-whale-trades) carries a `signal_s
 }
 ```
 
-`net_flow_usd` is the field to read for "which way is smart money leaning, and how hard." A large positive `net_flow_usd` with `direction: YES` means graded traders are buying YES.
+Read `net_flow_usd` and `direction` to see the net side. A positive value with `direction: YES` means graded traders bought more YES than they sold.
 
 ## Market discovery: smart_score
 
-The [explore](/api-reference/endpoint/explore-markets) feed ranks markets with a separate set of discovery aggregates:
+The [explore](/api-reference/endpoint/explore-markets) feed uses separate discovery fields:
 
 - `smart_score`: a per-market smart-money intensity used for ranking.
 - `smart_count`: how many graded traders are active on the market.
 - `smart_label`: a short human-readable tag.
 - `discover_score`: the backend-owned score behind the default hot sort.
 
-These power discovery sorting and are distinct from the `smart_money` flow object above. When you want a number to act on for a specific market, use `smart_money.net_flow_usd`. When you want to rank a list of markets to surface, use the explore `sort` parameter, which is driven by these scores.
+These fields rank markets. They are not the `smart_money` flow object. Use `smart_money.net_flow_usd` for one market and `sort` for market discovery.
 
 ## Picking the right field
 
@@ -88,7 +88,7 @@ These power discovery sorting and are distinct from the `smart_money` flow objec
 |---|---|
 | Is this trader worth following? | `grade` (and `score`) |
 | How skilled is this trader, in detail? | `quant_metrics.smart_score` (and `copy_score` for copyability) |
-| Is this trader hot right now? | `streak_tier` |
+| Is this trader in recent form? | `streak_tier` |
 | Is this single trade a strong signal? | `signal_score` |
 | Which way is smart money leaning on this market? | `smart_money.net_flow_usd` and `direction` |
 | Which markets should I surface? | explore `sort` (driven by `discover_score`) |

--- a/concepts/strategy-types.mdx
+++ b/concepts/strategy-types.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Strategy Types"
-description: "How 0xinsider classifies a trader's style, and the ten strategy types it assigns."
+description: "Filter traders by the strategy type inferred from fill history."
 ---
 
-0xinsider classifies each trader by how they trade, not just how well. A two-sided arbitrageur and a directional swing trader can both be S-grade, but you copy them differently. The strategy type tells you the style behind the track record.
+Strategy type describes how a trader trades. It adds context to the grade.
 
-The classification is machine-derived from a trader's fill history. It is a label to filter and reason with, not a guarantee of future behavior.
+The label comes from fill history. Use it to filter and compare traders, not to predict future results.
 
 ## The ten strategy types
 
@@ -22,11 +22,11 @@ The classification is machine-derived from a trader's fill history. It is a labe
 | `directional` | Takes a clear side on an outcome and holds it. |
 | `speculator` | Opportunistic, mixed style with no single dominant pattern. |
 
-## Where it appears
+## Use it in the API
 
 The classification shows up in two places:
 
-**On a trader profile**, via [`expand=strategy`](/concepts/expand):
+Request it on a trader profile with `expand=strategy`:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -43,19 +43,19 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
 }
 ```
 
-`strategy_type` is the label. `description` is an optional human-readable note (present for some types, null for others). `confidence` is reserved and currently returns `null`.
+`strategy_type` is the label. `description` and `confidence` can be `null`.
 
-**As a leaderboard filter.** Pass `strategy` to [`GET /api/v1/leaderboard`](/api-reference/endpoint/get-leaderboard) to rank only one style:
+Pass `strategy` to [`GET /api/v1/leaderboard`](/api-reference/endpoint/get-leaderboard) to rank one style:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/leaderboard?strategy=arbitrageur&limit=20"
 ```
 
-Leaderboard entries also carry a `strategy_type` field directly, so you can read the style without an extra expand.
+Leaderboard entries include `strategy_type`, so no extra expand is needed there.
 
 ## Notes
 
-- The `strategy_type` value is the ML classifier's output. New labels can be added over time, so treat the field as a string and match against the ten values above rather than assuming a fixed closed set forever.
+- Treat `strategy_type` as a string. New labels can appear.
 - Strategy classification is Polymarket-only. See [Platforms](/concepts/platforms).
 - A trader with too little history may have no classification yet; the `strategy` object is absent until enough fills exist to classify.

--- a/concepts/trust-metadata.mdx
+++ b/concepts/trust-metadata.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Trust Metadata"
-description: "Every derived field can tell you where it came from, how fresh it is, and whether it was reconciled against the provider."
+description: "Check the source, age, reconciliation, and completeness of API values."
 ---
 
-Most APIs hand you a number and leave you to guess whether it is live, cached, or stale. 0xinsider can tell you. Ask for trust metadata and every covered field comes with its own provenance. That means the source it came from and how fresh it is. It also means whether the value was reconciled against the on-chain or provider truth, and whether it is complete.
+Trust metadata tells you where a value came from, how fresh it is, whether it matches provider data, and whether it is complete.
 
-This matters when you act on the data. A P&L figure that is `fresh` and `provider_backed` is safe to trade on. The same figure marked `stale` and `db_mirror` is a hint, not a fact.
+Use it before an automated action. `fresh` and `provider_backed` is stronger evidence than `stale` and `db_mirror`.
 
 ## How to get it
 
-Trust metadata is opt-in, because it adds weight to the response. Pass `expand=trust`:
+Trust metadata is optional. Pass `expand=trust`:
 
 ```bash
 # Field-level trust on a trader profile
@@ -21,11 +21,11 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/market/0x123.../snapshot?expand=trust"
 ```
 
-Without `expand=trust`, the `trust` block is omitted. See [Expanding responses](/concepts/expand) for the full list of expand options.
+Without `expand=trust`, the `trust` block is omitted.
 
 ## The shape
 
-Each covered field maps to a `TrustMetadata` object with four dimensions:
+Each covered field has a `TrustMetadata` object with four dimensions:
 
 ```json
 {
@@ -40,13 +40,13 @@ Each covered field maps to a `TrustMetadata` object with four dimensions:
 }
 ```
 
-On a trader profile, `trust` carries one entry per derived field (P&L, strategy, category strengths, quant metrics, last-active, and more). On a market snapshot, it covers `current_price` and `spread_bps`.
+On trader profiles, `trust` covers derived fields such as P&L, strategy, categories, and quant metrics. On market snapshots, it covers `current_price` and `spread_bps`.
 
 ## The four dimensions
 
 ### source
 
-Where the value originated.
+The value's origin.
 
 | Value | Meaning |
 |---|---|
@@ -61,7 +61,7 @@ The `owner` and `field` tell you the upstream provider and the exact provider fi
 
 ### freshness
 
-How current the value is.
+The value's age.
 
 | Value | Meaning |
 |---|---|
@@ -76,7 +76,7 @@ How current the value is.
 
 ### reconciliation
 
-Whether the value was checked against the provider's own truth.
+Whether the value was checked against provider data.
 
 | Value | Meaning |
 |---|---|
@@ -89,7 +89,7 @@ Whether the value was checked against the provider's own truth.
 
 ### completeness
 
-Whether the value reflects the full picture.
+Whether the value covers the full picture.
 
 | Value | Meaning |
 |---|---|
@@ -103,7 +103,7 @@ Whether the value reflects the full picture.
 
 ## Using it in practice
 
-One rule covers most integrations. Act on values that are `fresh` and either `provider_backed` or `db_mirror`. Treat anything `stale`, `partial`, or `unavailable` as a softer signal.
+For automated actions, prefer `fresh`, `complete`, and `provider_backed` or `db_mirror`. Treat `stale`, `partial`, and `unavailable` as weaker data.
 
 ```python
 def is_actionable(field_trust):
@@ -114,4 +114,4 @@ def is_actionable(field_trust):
     )
 ```
 
-When a trader is mid-sync, expect `partial` completeness on history-derived fields until the sync finishes. See [Platforms](/concepts/platforms) for which fields carry meaningful trust on Kalshi, where coverage is thinner than Polymarket.
+During a trader sync, history fields can be `partial`. Kalshi has thinner coverage; see [Platforms](/concepts/platforms).

--- a/concepts/trust-metadata.mdx
+++ b/concepts/trust-metadata.mdx
@@ -5,7 +5,7 @@ description: "Check the source, age, reconciliation, and completeness of API val
 
 Trust metadata tells you where a value came from, how fresh it is, whether it matches provider data, and whether it is complete.
 
-Use it before an automated action. `fresh` and `provider_backed` is stronger evidence than `stale` and `db_mirror`.
+Use it before an automated action. A `fresh`, `provider_backed` value is stronger evidence than a `stale`, `db_mirror` value.
 
 ## How to get it
 
@@ -101,7 +101,7 @@ Whether the value covers the full picture.
 
 `detail` carries a short human-readable note when the status needs one (for example, why a value is `partial`).
 
-## Using it in practice
+## Use it in practice
 
 For automated actions, prefer `fresh`, `complete`, and `provider_backed` or `db_mirror`. Treat `stale`, `partial`, and `unavailable` as weaker data.
 

--- a/errors.mdx
+++ b/errors.mdx
@@ -1,11 +1,10 @@
 ---
 title: "Errors"
-description: "How errors come back, what each code means, and how to recover."
+description: "Read API error codes and recover from failed requests."
 ---
 
-Handler and middleware errors use the JSON envelope below. The transport-level
-`408 Request Timeout` is the exception: the server's 30-second timeout returns
-an empty body, so check the HTTP status before parsing JSON.
+Most errors use the JSON envelope below. `408 Request Timeout` is different: the
+30-second transport timeout returns an empty body. Check the status before parsing JSON.
 
 ```json
 {
@@ -22,7 +21,7 @@ an empty body, so check the HTTP status before parsing JSON.
 }
 ```
 
-For JSON errors, two fields matter in production: `error.code` (machine-readable) and `meta.request_id` (the ID you give us when you contact support).
+Use `error.code` in code. Include `meta.request_id` in support requests.
 
 ## Error codes
 
@@ -39,7 +38,7 @@ For JSON errors, two fields matter in production: `error.code` (machine-readable
 | `500` | `internal_error` | Bug on our side. | Retry. Include `meta.request_id` if you contact us. |
 | `503` | `rate_limit_unavailable` | With `error.reason="read_model_warming"`, this endpoint cannot serve its read model yet. The exact cause is endpoint-specific. Without a reason, the authenticated rate limiter is unavailable and has failed closed. | Branch on `error.reason`. For read-model unavailability, retry only this route after `Retry-After` and consult its endpoint contract. Do not infer dependency health or apply a shared rate-limit backoff. |
 
-## Handling errors in code
+## Handle errors in code
 
 <CodeGroup>
 ```javascript JavaScript
@@ -94,11 +93,11 @@ def call(path, **params):
 ```
 </CodeGroup>
 
-## Per-item batch errors
+## Batch item errors
 
-Batch endpoints (e.g. `POST /api/v1/traders/batch`) return `200 OK` even when individual items fail. Each item carries its own `error` field. Read `data[i].error` per item, not just the top-level status.
+Batch endpoints can return `200 OK` with failed items. Read `data[i].status` and `data[i].error` for every item.
 
-## Quick troubleshooting
+## Fix common errors
 
 <AccordionGroup>
   <Accordion title="401 invalid_api_key">

--- a/errors.mdx
+++ b/errors.mdx
@@ -34,7 +34,7 @@ Use `error.code` in code. Include `meta.request_id` in support requests.
 | `404` | `not_found` | The trader / market / resource does not exist. | Verify the ID. |
 | `408` | - | The public API request exceeded the 30-second transport timeout. The body is empty. | Retry once. Do not attempt to parse JSON. |
 | `423` | `account_locked` | Account is suspended. | Contact support. |
-| `429` | `rate_limited` | Over 100 req/min (or 100 batch item units/min). | Sleep `Retry-After` seconds and retry. See [Rate Limits](/rate-limits). |
+| `429` | `rate_limited` | Over 100 req/min (or 2500 batch item units/min). | Sleep `Retry-After` seconds and retry. See [Rate Limits](/rate-limits). |
 | `500` | `internal_error` | Bug on our side. | Retry. Include `meta.request_id` if you contact us. |
 | `503` | `rate_limit_unavailable` | With `error.reason="read_model_warming"`, this endpoint cannot serve its read model yet. The exact cause is endpoint-specific. Without a reason, the authenticated rate limiter is unavailable and has failed closed. | Branch on `error.reason`. For read-model unavailability, retry only this route after `Retry-After` and consult its endpoint contract. Do not infer dependency health or apply a shared rate-limit backoff. |
 

--- a/guides/webhooks.mdx
+++ b/guides/webhooks.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Webhooks"
-description: "Receive whale-trade events at your own URL, verify the signature, and handle retries safely."
+description: "Receive signed whale-trade events and handle retries safely."
 ---
 
-Webhooks push events to your server as they happen, so you do not have to poll. Register an HTTPS endpoint, verify it, and 0xinsider delivers a signed POST every time a subscribed event fires.
+Webhooks send signed POST requests to your HTTPS endpoint when a subscribed event fires. They remove the need to poll.
 
-Each delivery is signed with HMAC-SHA256. Verify the signature before you trust the body. The snippets below verify a real 0xinsider signature on the first try.
+Each delivery uses HMAC-SHA256. Verify the signature before you read the body.
 
 ## Event types
 
@@ -16,7 +16,7 @@ Each delivery is signed with HMAC-SHA256. Verify the signature before you trust 
 | `whale_trader_synced` | Reserved | Accepted on subscribe, not yet emitted. |
 | `large_positions_updated` | Reserved | Accepted on subscribe, not yet emitted. |
 
-Today, `whale_trades_inserted` is the only event delivered. You can subscribe to the reserved types now; they will begin delivering when emission ships, with no change to your verification code.
+`whale_trades_inserted` is the only event delivered now. Reserved types are accepted but do not emit events yet.
 
 A `whale_trades_inserted` delivery body:
 
@@ -29,11 +29,11 @@ A `whale_trades_inserted` delivery body:
 }
 ```
 
-The event signals that new trades landed. Fetch the detail from [`GET /api/v1/whale-trades`](/api-reference/endpoint/get-whale-trades) (newest first) when you receive it.
+The event says that new trades landed. Fetch the newest trades from [`GET /api/v1/whale-trades`](/api-reference/endpoint/get-whale-trades) after you receive it.
 
 ## Set up an endpoint
 
-### 1. Create it
+### 1. Register it
 
 ```bash
 curl -X POST \
@@ -47,9 +47,9 @@ curl -X POST \
   "https://api.0xinsider.com/api/v1/webhooks"
 ```
 
-The URL must be `https` and publicly routable. Localhost and private IP literals are rejected. You can register up to 10 endpoints.
+The URL must use `https` and be public. Localhost and private IP literals are rejected. You can register up to 10 endpoints.
 
-The create response includes two values you only see once:
+The create response includes two one-time values:
 
 ```json
 {
@@ -70,11 +70,11 @@ The create response includes two values you only see once:
 }
 ```
 
-Store the `signing_secret` now. It is shown only on create and on [rotate-secret](/api-reference/endpoint/rotate-webhook-secret), never on a later read. The webhook `id` is an integer.
+Store `signing_secret` now. It appears only on create and [rotate-secret](/api-reference/endpoint/rotate-webhook-secret). The webhook `id` is an integer.
 
 ### 2. Verify it
 
-A new endpoint starts in `pending_verification` and receives nothing until you verify it. Prove you control the secret by sending the verification token back within 24 hours:
+A new endpoint starts as `pending_verification`. Send the token within 24 hours:
 
 ```bash
 curl -X POST \
@@ -84,7 +84,7 @@ curl -X POST \
   "https://api.0xinsider.com/api/v1/webhooks/42/verify"
 ```
 
-On success the endpoint flips to `active` and deliveries begin. Verification does not send a test delivery; it activates the endpoint by matching the token from create.
+Success changes the endpoint to `active`. Verification does not send a test delivery.
 
 ## Delivery format
 
@@ -101,18 +101,18 @@ Every delivery is an HTTP POST with a JSON body and these headers:
 
 ## Verify the signature
 
-The signature is computed over the timestamp and the raw request body, joined by a literal `.`:
+The signature covers the timestamp and raw request body, joined by `.`:
 
 ```
 signature = "v1=" + hex( HMAC_SHA256( signing_secret, timestamp + "." + raw_body ) )
 ```
 
-Two rules make or break verification:
+Follow these two rules:
 
 - Use the **raw request body bytes**, exactly as received. Do not parse and re-serialize the JSON first; whitespace and key order would change and the HMAC would not match.
 - Use the `signing_secret` string as the HMAC key, the full `whsec_...` value.
 
-Reject the delivery if the signature does not match. Reject it if `x-0xinsider-timestamp` is more than 5 minutes from your clock. That is a replay guard you enforce on your side.
+Reject a bad signature. Also reject a timestamp more than 5 minutes from your clock.
 
 <CodeGroup>
 ```javascript Node (Express)
@@ -213,20 +213,20 @@ def receive():
 ```
 </CodeGroup>
 
-## Retries and idempotency
+## Retry and deduplicate
 
-Respond with any `2xx` to mark a delivery successful. Anything else, or a timeout, counts as a failure.
+Return any `2xx` to mark a delivery successful. Other responses and timeouts fail the delivery.
 
-- **Timeout**: respond within 15 seconds. ACK fast, then do slow work asynchronously.
-- **Retries**: a failed delivery is retried up to 8 attempts, roughly a minute apart. After the last attempt it is moved to a dead-letter state and not retried.
-- **Idempotency**: the same logical event always carries the same `x-0xinsider-event-id`. A retried delivery reuses its `x-0xinsider-delivery-id` and increments `x-0xinsider-delivery-attempt`. Dedupe your processing on `x-0xinsider-event-id` so a redelivery does not double-handle.
+- **Timeout**: respond within 15 seconds. Acknowledge first; process later.
+- **Retries**: failed deliveries retry up to 8 times, about one minute apart. The last failure moves to dead letter.
+- **Idempotency**: deduplicate on `x-0xinsider-event-id`. A retry keeps that event ID and increments `x-0xinsider-delivery-attempt`.
 
 ## Manage and rotate
 
-- [Update](/api-reference/endpoint/update-webhook) the URL, events, or enabled flag. Changing the URL drops the endpoint back to `pending_verification` and issues a fresh verification token.
-- [Rotate the secret](/api-reference/endpoint/rotate-webhook-secret) if it leaks. The old secret stops working the moment the call returns, so deploy the new one to your verifier first.
-- [Disable](/api-reference/endpoint/delete-webhook) to stop deliveries without losing the registration, or set `enabled: false` via update.
+- [Update](/api-reference/endpoint/update-webhook) the URL, events, or enabled flag. A URL change returns the endpoint to `pending_verification`.
+- [Rotate the secret](/api-reference/endpoint/rotate-webhook-secret) if it leaks. Deploy the new secret before the call returns.
+- [Disable](/api-reference/endpoint/delete-webhook) to stop deliveries without deleting the registration, or set `enabled: false`.
 
-## Don't have a public endpoint yet?
+## No public endpoint
 
-Poll instead. [`GET /api/v1/whale-trades`](/api-reference/endpoint/get-whale-trades) is the live feed, [`GET /api/v1/events/feed/since`](/api-reference/endpoint/get-event-replay-since) is a durable cursor-based replay of the same events, and [`GET /api/v1/stream`](/api-reference/endpoint/get-stream) is a real-time SSE stream. The [alert bot recipe](/recipes/alert-bot) shows both the webhook and the polling path.
+Use [polling](/recipes/alert-bot) instead. [`GET /api/v1/whale-trades`](/api-reference/endpoint/get-whale-trades) is the live feed, [`GET /api/v1/events/feed/since`](/api-reference/endpoint/get-event-replay-since) replays events, and [`GET /api/v1/stream`](/api-reference/endpoint/get-stream) opens an SSE stream.

--- a/guides/webhooks.mdx
+++ b/guides/webhooks.mdx
@@ -223,7 +223,7 @@ Return any `2xx` to mark a delivery successful. Other responses and timeouts fai
 
 ## Manage and rotate
 
-- [Update](/api-reference/endpoint/update-webhook) the URL, events, or enabled flag. A URL change returns the endpoint to `pending_verification`.
+- [Update](/api-reference/endpoint/update-webhook) the URL, events, or enabled flag. A URL change returns a new one-time verification token and sets the endpoint to `pending_verification`. Capture that token from the response, then call [Verify Webhook](/api-reference/endpoint/verify-webhook). If a delivery is active, retry the URL change after it completes.
 - [Rotate the secret](/api-reference/endpoint/rotate-webhook-secret) if it leaks. Deploy the new secret before the call returns.
 - [Disable](/api-reference/endpoint/delete-webhook) to stop deliveries without deleting the registration, or set `enabled: false`.
 

--- a/guides/webhooks.mdx
+++ b/guides/webhooks.mdx
@@ -224,7 +224,7 @@ Return any `2xx` to mark a delivery successful. Other responses and timeouts fai
 ## Manage and rotate
 
 - [Update](/api-reference/endpoint/update-webhook) the URL, events, or enabled flag. A URL change returns a new one-time verification token and sets the endpoint to `pending_verification`. Capture that token from the response, then call [Verify Webhook](/api-reference/endpoint/verify-webhook). If a delivery is active, retry the URL change after it completes.
-- [Rotate the secret](/api-reference/endpoint/rotate-webhook-secret) if it leaks. Deploy the new secret before the call returns.
+- [Rotate the secret](/api-reference/endpoint/rotate-webhook-secret) if it leaks. Pause deliveries, wait for active work to finish, rotate, deploy the one-time response secret, then re-enable deliveries. An active rotation can cause failed deliveries during the cutover; normal retries apply.
 - [Disable](/api-reference/endpoint/delete-webhook) to stop deliveries without deleting the registration, or set `enabled: false`.
 
 ## No public endpoint

--- a/index.mdx
+++ b/index.mdx
@@ -1,46 +1,46 @@
 ---
 title: "0xinsider API"
 sidebarTitle: "Introduction"
-description: "Prediction market intelligence for AI agents, trading bots, and research tools."
+description: "Trader, market, and whale-trade data for agents, bots, and research tools."
 ---
 
-Trader grades, whale-trade signals, smart-money flow, positions, and insider detection for Polymarket and Kalshi. The same data behind the [0xinsider terminal](https://0xinsider.com), as an API.
+Use 0xinsider to read trader grades, whale trades, smart-money flow, positions, and insider signals from Polymarket and Kalshi.
 
-Three ways in:
+Choose one of three interfaces:
 
 - **REST API**: `https://api.0xinsider.com/api/v1/` for bots, dashboards, and research code.
 - **Local MCP server**: [`@0xinsider/mcp`](https://www.npmjs.com/package/@0xinsider/mcp) on stdio for Claude Code, Cursor, Codex, Gemini CLI.
-- **Remote MCP**: streamable HTTP for agents that can't run a local subprocess.
+- **Remote MCP**: Streamable HTTP for agents that cannot run a local process.
 
 One [Insider subscription](https://0xinsider.com/pricing) covers all three.
 
 <Tip>
-  Working in Claude Code, Cursor, or another AI agent? Feed it [llms-full.txt](https://docs.0xinsider.com/llms-full.txt), the whole docs site as one plain-text file. Drop it into context and ask the model to wire up calls, draft a bot, or surface ideas you can build on the data.
+  Use [llms-full.txt](https://docs.0xinsider.com/llms-full.txt) when an AI agent needs the full API reference in one file.
 </Tip>
 
 ## What it solves
 
-Polymarket and Kalshi publish raw trades. They don't publish grades, signal scores, smart-money breakdowns, position timelines, or pattern detection. 0xinsider builds that layer. The API exposes it.
+The source platforms provide raw market activity. 0xinsider adds trader grades, signal scores, smart-money flow, position timelines, and pattern detection.
 
-So you can answer:
+Use the API to answer questions such as:
 
-- Which traders consistently beat the market on crypto resolution events?
-- Did anyone buy big into this market in the last hour, and are they sharp?
-- Is someone accumulating shares in a market that hasn't resolved yet?
-- Where is smart money flowing this week?
-- What price did that S-grade trader get filled at?
+- Which traders have a strong record in a category?
+- Did a high-grade trader buy this market recently?
+- Is a trader building a position before resolution?
+- Which markets receive smart-money flow?
+- What fill price appears in a trader's timeline?
 
 ## What you can build
 
-- **Trading bots** that fire on whale buys from S-grade traders in a category.
-- **AI agents** that summarize who's winning, what they hold, and at what cost.
-- **Research tools** that pull leaderboards, trader profiles, history ranges, and category performance.
-- **Dashboards** that show where capital is rotating across prediction markets.
-- **Webhooks** that push whale-trade and radar events to your stack in real time.
+- **Trading bots** that react to high-grade whale trades.
+- **AI agents** that explain trader records and positions.
+- **Research tools** that compare traders and historical fills.
+- **Dashboards** that show market flow and open positions.
+- **Webhooks** that notify your system about new events.
 
 ## A real response
 
-The top trader by composite score, right now:
+Example: read the first leaderboard item.
 
 ```bash
 curl -H "Authorization: Bearer oxi_sk_live_..." \
@@ -67,58 +67,58 @@ curl -H "Authorization: Bearer oxi_sk_live_..." \
 }
 ```
 
-One trader. The leaderboard ranks thousands.
+The example shows the response shape. Query the endpoint again when you need current data.
 
 ## Endpoints
 
 <CardGroup cols={2}>
   <Card title="Get Trader" icon="user" href="/api-reference/endpoint/get-trader">
-    Full profile for a wallet: grade, P&L, win rate, strategy, category strengths.
+    Read a wallet's grade, P&L, win rate, strategy, and category strengths.
   </Card>
   <Card title="Batch Get Traders" icon="layer-group" href="/api-reference/endpoint/batch-get-traders">
-    Up to 25 trader profiles in one round trip.
+    Read up to 25 trader profiles in one call.
   </Card>
   <Card title="Whale Trades" icon="whale" href="/api-reference/endpoint/get-whale-trades">
-    Recent large trades with signal scoring. Filter by grade, category, side.
+    Read recent large trades. Filter by grade, category, or side.
   </Card>
   <Card title="Whale Trades History" icon="clock-rotate-left" href="/api-reference/endpoint/get-whale-trades-history">
-    Historical whale-trade ranges for backtesting and recap reports.
+    Read historical whale trades for backtests and reports.
   </Card>
   <Card title="Positions" icon="chart-line" href="/api-reference/endpoint/get-positions">
-    Current positions across traders or markets, with freshness metadata.
+    Read current positions with freshness metadata.
   </Card>
   <Card title="Position Timeline" icon="timeline" href="/api-reference/endpoint/get-position-timeline">
-    Server-computed running amount and average entry price per fill.
+    Read fill order, running amount, and average entry price.
   </Card>
   <Card title="Explore Markets" icon="compass" href="/api-reference/endpoint/explore-markets">
-    Browse whale-active titled markets by category, platform, status.
+    Browse whale-active markets by category, platform, or status.
   </Card>
   <Card title="Market Intel" icon="chart-mixed" href="/api-reference/endpoint/get-market-intel">
-    Smart-money flow direction and top positions for a single market.
+    Read smart-money flow and top positions for one market.
   </Card>
   <Card title="Market Snapshot" icon="camera" href="/api-reference/endpoint/get-market-snapshot">
-    One-shot market state with trust-metadata fields.
+    Read one market snapshot with trust metadata.
   </Card>
   <Card title="Leaderboard" icon="ranking-star" href="/api-reference/endpoint/get-leaderboard">
-    Top traders by composite score, cursor-paginated.
+    List top traders by composite score.
   </Card>
   <Card title="Search Markets" icon="magnifying-glass" href="/api-reference/endpoint/search-markets">
-    Keyword search across markets with filters.
+    Search markets by keyword and filters.
   </Card>
   <Card title="Insider Radar" icon="radar" href="/api-reference/endpoint/get-insider-radar">
-    Suspicious patterns: pre-resolution accumulation, unusual timing.
+    Find unusual timing and pre-resolution accumulation.
   </Card>
   <Card title="Event Replay" icon="rotate-right" href="/api-reference/endpoint/get-event-replay-since">
-    Replay missed feed events after a disconnection.
+    Replay feed events after a disconnect.
   </Card>
   <Card title="Webhooks" icon="webhook" href="/api-reference/endpoint/list-webhooks">
-    Push whale-trade and radar events to your endpoint.
+    Push supported events to your HTTPS endpoint.
   </Card>
   <Card title="Report Snapshots" icon="file-chart-column" href="/api-reference/endpoint/get-daily-report-snapshot">
-    Daily, weekly, monthly recap exports.
+    Read daily, weekly, or monthly reports.
   </Card>
   <Card title="Remote MCP" icon="robot" href="/api-reference/endpoint/remote-mcp">
-    Streamable HTTP MCP endpoint for hosted agents.
+    Connect hosted agents over Streamable HTTP.
   </Card>
 </CardGroup>
 
@@ -126,15 +126,15 @@ One trader. The leaderboard ranks thousands.
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/quickstart">
-    Generate a key, fire your first request, and follow the whales end to end.
+    Generate a key and make a first request.
   </Card>
   <Card title="Local MCP Server" icon="terminal" href="/integrations/mcp">
-    Plug 0xinsider into Claude Code, Cursor, Codex, or Gemini CLI in two minutes.
+    Connect a local AI client over stdio.
   </Card>
   <Card title="TypeScript Client" icon="code" href="/integrations/typescript-client">
-    Drift-tested source client with typed errors and repeated `expand` params.
+    Use typed calls, errors, and `expand` parameters.
   </Card>
   <Card title="Trader Grades" icon="medal" href="/concepts/grades">
-    What S, A, B, C, D, F actually mean, with real profile examples.
+    Learn what each trader grade means.
   </Card>
 </CardGroup>

--- a/integrations/mcp.mdx
+++ b/integrations/mcp.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Local MCP Server"
-description: "Give your AI agent direct, read-only access to 0xinsider intelligence over stdio."
+description: "Connect an AI client to read-only 0xinsider tools over stdio."
 ---
 
-[`@0xinsider/mcp`](https://www.npmjs.com/package/@0xinsider/mcp) is the official local Model Context Protocol server. It exposes the same data as the REST API (trader grades, whale trades, smart-money flow, positions, insider detection) as MCP tools your agent calls directly.
+[`@0xinsider/mcp`](https://www.npmjs.com/package/@0xinsider/mcp) is the official local Model Context Protocol server. It exposes REST data as read-only MCP tools.
 
 Works with **Claude Code, Cursor, Codex, Gemini CLI**, and any stdio MCP client.
 
@@ -17,7 +17,7 @@ Works with **Claude Code, Cursor, Codex, Gemini CLI**, and any stdio MCP client.
 npx -y @0xinsider/mcp init
 ```
 
-`init` detects your installed clients and writes the right config in the right place. It asks for your API key once.
+`init` detects installed clients, writes their config, and asks for your API key once.
 
 Prefer to edit configs by hand? The per-client paths and snippets are below.
 
@@ -114,7 +114,7 @@ Prefer to edit configs by hand? The per-client paths and snippets are below.
 | `get_market_intel` | Smart-money breakdown for a single market. |
 | `get_insider_radar` | Suspicious accumulation and timing patterns. |
 
-Every tool advertises `readOnlyHint: true`. The server can't place trades or write data.
+Every tool advertises `readOnlyHint: true`. The server cannot place trades or write data.
 
 ### Resources (auto-attached context)
 
@@ -133,17 +133,17 @@ Every tool advertises `readOnlyHint: true`. The server can't place trades or wri
 | `market_report` | You want smart-money flow on a market topic. |
 | `trading_signals` | You want a scan for high-conviction signals across markets. |
 
-## Try it
+## Example prompts
 
-After install, ask your agent:
+After install, ask a task-specific question:
 
-- "Who are the top prediction-market traders right now?"
+- "Who are the top prediction-market traders currently?"
 - "What are A-grade or better whales buying in crypto markets today?"
 - "Analyze trader `0x863134d00841b2e200492805a01e1e2f5defaa53`. Is their strategy worth following?"
 - "Are there suspicious accumulation patterns on the Trump election market?"
 - "Show me the position timeline for that whale on the Ethereum market."
 
-The agent picks the right tool and calls it for you.
+The agent selects the tool and calls it.
 
 ## Environment variables
 
@@ -153,5 +153,5 @@ The agent picks the right tool and calls it for you.
 | `OXINSIDER_API_URL` | No | Override the base URL (mostly for self-hosted dev). |
 
 <Note>
-  The MCP server uses your normal API key and shares the 100 req/min rate limit with direct API calls. One key, one budget. Get yours at [0xinsider.com/developers](https://0xinsider.com/developers).
+  The MCP server uses your API key and shares the 100 req/minute limit with REST calls.
 </Note>

--- a/integrations/typescript-client.mdx
+++ b/integrations/typescript-client.mdx
@@ -1,11 +1,11 @@
 ---
 title: "TypeScript Client"
-description: "Drift-tested source client for the 0xinsider API."
+description: "Use the typed TypeScript source client for the 0xinsider API."
 ---
 
-A typed TypeScript client lives in the app repo at `web/src/lib/api-client`. It's drift-tested against the checked-in OpenAPI spec: when the spec moves, the client moves with it or the test suite fails.
+A typed TypeScript client lives in the app repo at `web/src/lib/api-client`. It follows the checked-in OpenAPI spec.
 
-It's **not** on npm yet. Use it as source or as a reference implementation.
+It is **not** on npm. Use the source or copy its patterns.
 
 <Note>
   Want a package release? That needs decisions on package name, semver policy, changelog ownership, and npm access. Open an issue if you depend on it.
@@ -20,7 +20,7 @@ It's **not** on npm yet. Use it as source or as a reference implementation.
 - V1 error envelopes as typed exceptions with the HTTP `status`, parsed `error`, and raw response `body`.
 - Conditional reads: successful response `ETag` headers are copied to `meta.etag`, and `304` responses return a typed `not_modified` envelope instead of attempting to parse an empty body.
 
-## Example
+## Example: read a trader and search markets
 
 ```ts
 import { OxinsiderApiClient } from "./api-client";
@@ -69,11 +69,11 @@ if (!isApiNotModifiedResponse(first) && first.meta?.etag) {
 }
 ```
 
-The `304` envelope has `object: "not_modified"`, `data: null`, and metadata copied from response headers. The packaged SDK also exposes a route-specific conditional Sports Edge method; see its README for that API.
+The `304` envelope has `object: "not_modified"`, `data: null`, and response-header metadata.
 
 ## Handling errors
 
-The client throws typed exceptions instead of a generic error object. Match on the parsed `error` field:
+The client throws typed exceptions. Match on `error.code`:
 
 ```ts
 import { OxinsiderApiClient, OxinsiderApiError } from "./api-client";
@@ -103,4 +103,4 @@ try {
 
 ## Keep OpenAPI as the source of truth
 
-The client operation table regenerates from [`api-reference/openapi.json`](https://github.com/0xinsider/docs/blob/main/api-reference/openapi.json). Change the spec and the client follows. Don't hand-edit the client to add operations without updating the spec.
+The operation table follows [`api-reference/openapi.json`](https://github.com/0xinsider/docs/blob/main/api-reference/openapi.json). Update the spec before you add an operation.

--- a/integrations/typescript-client.mdx
+++ b/integrations/typescript-client.mdx
@@ -71,7 +71,7 @@ if (!isApiNotModifiedResponse(first) && first.meta?.etag) {
 
 The `304` envelope has `object: "not_modified"`, `data: null`, and response-header metadata.
 
-## Handling errors
+## Handle errors
 
 The client throws typed exceptions. Match on `error.code`:
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Quickstart"
-description: "From zero to your first whale-trade signal in two minutes."
+description: "Create a key, test the API, and follow high-grade traders."
 ---
 
-Generate a key, confirm it works, then run a real "follow the smartest traders" workflow.
+Create a key, test it, then follow high-grade traders.
 
 ## 1. Generate your API key
 
-API access is bundled with the [Insider subscription](https://0xinsider.com/pricing); current pricing is on that page.
+API access requires an [Insider subscription](https://0xinsider.com/pricing).
 
 <Steps>
   <Step title="Sign up or log in">
@@ -17,20 +17,20 @@ API access is bundled with the [Insider subscription](https://0xinsider.com/pric
     Pick the Insider plan on [Pricing](https://0xinsider.com/pricing).
   </Step>
   <Step title="Generate your key">
-    On [Developers](https://0xinsider.com/developers), click **Generate Key**. It's shown once, so copy it now. You can regenerate a lost key, but the old one stops working.
+    On [Developers](https://0xinsider.com/developers), click **Generate Key** and copy the value. You see it once. Regeneration revokes the old key.
   </Step>
 </Steps>
 
-Keys look like `oxi_sk_live_` followed by 64 hex characters.
+Keys start with `oxi_sk_live_` and contain 64 hex characters after the prefix.
 
 <Tip>
-  Export it once so the rest of this page just works:
+  Store it in an environment variable:
   ```bash
   export OXINSIDER_API_KEY="oxi_sk_live_..."
   ```
 </Tip>
 
-## 2. Confirm the key works
+## 2. Test the key
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -45,10 +45,10 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
 }
 ```
 
-`status: "ok"` means you're wired up.
+`status: "ok"` confirms the key and API path work.
 
 <Tip>
-  Browser apps can call REST endpoints under
+  Browser apps can call public REST endpoints under
   `https://api.0xinsider.com/api/v1/*` directly from any origin with
   `Authorization: Bearer ...`; do not send cookies or `credentials: "include"`.
   Remote MCP at `/api/v1/mcp` still validates `Origin` against the
@@ -59,60 +59,60 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   first-party-only and credentialed.
 </Tip>
 
-## 3. Follow the smartest traders
+## 3. Follow high-grade traders
 
-Not "who's #1," but "what are the best traders doing right now, and am I early?"
+Use four calls: leaderboard, trader profile, whale trades, and market intel.
 
-### Step A: Pull the top 5 S-grade traders
+### Step A: Get five leaderboard entries
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/leaderboard?limit=5"
 ```
 
-Each entry has the wallet address (`id`), grade, score, P&L, and strategy. Pick one to follow.
+Each item includes an ID, grade, score, P&L, and strategy. Keep the IDs you want to inspect.
 
-### Step B: Look up that trader's full profile
+### Step B: Read one trader profile
 
-The trader endpoint takes a wallet address or a known username:
+Pass a wallet address or a known username:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/trader/0x863134d00841b2e200492805a01e1e2f5defaa53"
 ```
 
-You get their realized P&L, win rate, category strengths, and current open positions.
+The response includes realized P&L, win rate, category strengths, and open positions.
 
-### Step C: See what whales are buying now
+### Step C: Find recent high-grade trades
 
-A-grade or better, last 50 trades:
+Get 50 recent trades from A-grade or better traders:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&limit=50"
 ```
 
-Layer filters. A-grade or better, crypto only, $10k+ notional:
+Add category and size filters when you need a narrower feed:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/whale-trades?min_grade=A&category=crypto&min_size=10000&limit=50"
 ```
 
-### Step D: Drill into one market
+### Step D: Read one market
 
-Grab the `condition_id` from a trade you like (raw hex, not the prefixed `mkt_...` form), then:
+Take the trade's `condition_id` and request market intel. Use the raw value or the `mkt_...` ID returned by V1:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/market/<condition_id>/intel"
 ```
 
-Market Intel returns the smart-money breakdown: buy volume vs sell volume from graded traders, top positions, and which side has conviction.
+Market Intel shows graded-trader buy and sell flow, top positions, and direction.
 
-The loop: **leaderboard -> trader profile -> whale trades -> market intel**. Wire it to a cron, a chatbot, or a dashboard.
+Use this loop in a cron job, chatbot, or dashboard: **leaderboard -> trader profile -> whale trades -> market intel**.
 
-## Same workflow, in code
+## The same workflow in code
 
 <CodeGroup>
 ```javascript JavaScript
@@ -162,7 +162,7 @@ print(top["data"][0], trader["data"]["grade"], len(whales["data"]))
 
 ## Lower the call count with a batch endpoint
 
-Already have the wallet addresses or usernames you care about? Fetch them in one call:
+If you already have wallet addresses or usernames, fetch up to 25 profiles in one call:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -171,7 +171,7 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/traders/batch"
 ```
 
-Batch reads return the same per-item shape, with per-item error fields when an address fails. They count against a separate batch-item rate-limit budget. See [Rate Limits](/rate-limits).
+Each batch item has its own status and error. One bad address does not fail the other items. Batch items use a separate budget; see [Rate Limits](/rate-limits).
 
 ## Next
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -34,18 +34,33 @@ Keys start with `oxi_sk_live_` and contain 64 hex characters after the prefix.
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
-  https://api.0xinsider.com/api/v1/health
+  https://api.0xinsider.com/api/v1/usage
 ```
 
 ```json
 {
-  "object": "health",
-  "data": { "status": "ok", "db": true, "cache": true },
-  "meta": { "request_id": "req_abc123", "cached": false }
+  "object": "usage",
+  "data": {
+    "rate_limit": {
+      "used": 7,
+      "limit": 100,
+      "remaining": 93,
+      "reset_at": 1710772860,
+      "window_seconds": 60
+    },
+    "daily_usage": {
+      "used": 42,
+      "limit": null,
+      "remaining": null,
+      "reset_at": 1710806400,
+      "window_seconds": 86400
+    }
+  },
+  "meta": { "request_id": "req_example", "cached": false, "cost": 1 }
 }
 ```
 
-`status: "ok"` confirms the key and API path work.
+The `200` response confirms that the key works. This route does not spend primary quota.
 
 <Tip>
   Browser apps can call public REST endpoints under

--- a/rate-limits.mdx
+++ b/rate-limits.mdx
@@ -5,7 +5,7 @@ description: "Read request limits and retry after a 429 response."
 
 Each user gets **100 requests per minute** in a sliding window. All keys and endpoints share this limit.
 
-Batch reads use a second budget of **100 item units per minute**. A 25-item batch uses 25 item units before it runs.
+Batch reads use a second budget of **2500 item units per minute**. A 25-item batch uses 25 item units before it runs.
 
 `GET /api/v1/usage` does not use the primary quota or daily usage count. It has its own 100 reads/minute guard.
 
@@ -13,7 +13,7 @@ Batch reads use a second budget of **100 item units per minute**. A 25-item batc
 |---|---|
 | Requests per minute | 100 |
 | Usage reads per minute | 100 |
-| Batch item units per minute | 100 |
+| Batch item units per minute | 2500 |
 | Window type | Sliding (not bucket-of-60-seconds) |
 | Scope | Per user (sum of all keys) |
 | Header on success | `X-RateLimit-*` (+ `X-Batch-RateLimit-*` on batch endpoints) |

--- a/rate-limits.mdx
+++ b/rate-limits.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Rate Limits"
-description: "How many requests you can make, and how to back off cleanly."
+description: "Read request limits and retry after a 429 response."
 ---
 
-You get **100 requests per minute** on a sliding window. The limit is **per user**, shared across every key and every endpoint.
+Each user gets **100 requests per minute** in a sliding window. All keys and endpoints share this limit.
 
-Batch read endpoints (e.g. `POST /api/v1/traders/batch`, `POST /api/v1/markets/intel/batch`) get a **separate** budget in *item units*, also 100 per minute. A 25-item batch reserves 25 item units before it runs.
+Batch reads use a second budget of **100 item units per minute**. A 25-item batch uses 25 item units before it runs.
 
-`GET /api/v1/usage` does not spend primary quota or log into daily usage. It has its own 100 reads/minute per-user guard so checking quota can't itself blow up usage-count load.
+`GET /api/v1/usage` does not use the primary quota or daily usage count. It has its own 100 reads/minute guard.
 
 | Setting | Value |
 |---|---|
@@ -19,7 +19,7 @@ Batch read endpoints (e.g. `POST /api/v1/traders/batch`, `POST /api/v1/markets/i
 | Header on success | `X-RateLimit-*` (+ `X-Batch-RateLimit-*` on batch endpoints) |
 | Header on `429` | `Retry-After` |
 
-## Headers you should read
+## Read these headers
 
 Every authenticated response carries:
 
@@ -46,14 +46,14 @@ Batch responses additionally carry:
 | `X-Batch-RateLimit-Remaining` | Item units remaining in the window. |
 | `X-Batch-RateLimit-Reset` | Unix timestamp when the batch window resets. |
 
-Browser clients can read these headers on public REST `/api/v1/*` responses
-because the public API exposes them through CORS. The public API also exposes
+Browser clients can read these headers on public REST `/api/v1/*` responses.
+The public API also exposes
 `Retry-After`, `ETag`, `X-Request-Id`, `X-Request-Cost`, `Mcp-Session-Id`, and
 `X-Mcp-Error-Code`. Remote MCP at `/api/v1/mcp` still validates `Origin`
 against the 0xinsider/localhost allowlist. Do not use credentialed CORS for
 public API calls; send only the Bearer token header.
 
-If you go over either budget, you get a `429` plus a `Retry-After` header in seconds:
+If you exceed either budget, the API returns `429` and `Retry-After` in seconds:
 
 ```
 HTTP/1.1 429 Too Many Requests
@@ -71,7 +71,7 @@ Retry-After: 12
 }
 ```
 
-## A client that respects the retry
+## Retry after `429`
 
 <CodeGroup>
 ```javascript JavaScript
@@ -112,18 +112,18 @@ body = get_with_backoff(
 ```
 </CodeGroup>
 
-## Staying well under the limit
+## Keep requests within the limit
 
-- **Cache.** Most of this data updates every 30-120 seconds. Re-fetching every second wastes budget.
-- **Paginate, don't re-list.** Use cursors instead of refetching the full leaderboard each loop.
-- **Ask for more per request.** Bump `limit` to 100 instead of making 10 calls of `limit=10`.
-- **Batch when you know your IDs.** One batch call for 25 traders costs 25 batch-item units but only one regular request.
-- **Watch `X-RateLimit-Remaining`.** Below 10, pause polling until the next reset.
-- **Use `/usage` for budget checks.** `GET /api/v1/usage` reads the current primary limiter window without incrementing it. Respect its own 100 reads/minute cap; don't probe quota with another endpoint.
-- **One process owns the polling.** Don't have every container in a fleet poll the same endpoint with the same key.
+- **Cache.** Reuse data instead of polling every second.
+- **Paginate.** Use cursors instead of fetching the same first page.
+- **Use a larger `limit`.** One request with `limit=100` costs less than ten requests with `limit=10`.
+- **Batch known IDs.** One batch call uses one regular request and one item unit per item.
+- **Watch `X-RateLimit-Remaining`.** Pause when it is low.
+- **Use `/usage`.** It reads the primary window but has its own 100 reads/minute limit.
+- **Use one poller.** Do not let every process share the same polling loop.
 
 ## Conditional GETs
 
-Deterministic read endpoints return an `ETag` header. Send it back as `If-None-Match` to get `304 Not Modified` with an empty body when nothing changed.
+Deterministic read endpoints return an `ETag`. Send it as `If-None-Match` to get `304 Not Modified` when the body did not change.
 
-Examples include trader and position reads, whale-trade and leaderboard lists, market exploration and intelligence, Sports Edge signals and observations, position timelines, and health responses. Check each endpoint's OpenAPI response table for authoritative `304` support. Report snapshots aren't conditional yet because their body includes a request-time `generated_at`.
+Examples include trader and position reads, whale-trade and leaderboard lists, market exploration and intelligence, Sports Edge signals and observations, position timelines, and health responses. Check each endpoint's OpenAPI response table for authoritative `304` support. Report snapshots are not conditional because their body includes a request-time `generated_at`.

--- a/recipes/alert-bot.mdx
+++ b/recipes/alert-bot.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Alert bot"
-description: "Get notified on large trades, by webhook push or by polling, then post to Slack or Discord."
+description: "Alert on large trades with webhooks or polling."
 ---
 
-Goal: fire an alert when a large trade lands. There are two ways to receive the events: a webhook push (no infrastructure to poll, needs a public URL) or polling (works anywhere). Pick one.
+Use this recipe to alert on large trades. Choose webhook push for a public server or polling for a script behind NAT.
 
 All requests need a Bearer key. See [Authentication](/authentication).
 
 ## Option A: webhook push
 
-Register an endpoint on `whale_trades_inserted` and verify it. Full setup, signature verification, and retry handling are in the [Webhooks guide](/guides/webhooks). The event tells you new trades landed; fetch the detail and filter:
+Subscribe to `whale_trades_inserted` and verify the endpoint. Then fetch the new trades and filter them:
 
 ```python
 # Inside your verified webhook handler, after signature check:
@@ -25,11 +25,11 @@ def handle_event(event):
         post_alert(tr)
 ```
 
-Webhook events are coarse: one event per ingest batch, no per-market or per-grade server-side filter. Apply your `min_size` and `min_grade` filter on the fetched trades.
+Webhook events identify an ingest batch. They do not filter by market, size, or grade. Apply those filters after the fetch.
 
 ## Option B: polling
 
-No public URL required. Walk the durable replay feed with a cursor so you never miss or double-count an event across restarts:
+No public URL is required. Persist the replay cursor across restarts:
 
 ```python
 import os, time, requests
@@ -55,7 +55,7 @@ while True:
         time.sleep(15)
 ```
 
-For the live feed directly, poll [`GET /api/v1/whale-trades`](/api-reference/endpoint/get-whale-trades) with your filters, or open the [SSE stream](/api-reference/endpoint/get-stream) for real-time push without a webhook.
+You can also poll [`GET /api/v1/whale-trades`](/api-reference/endpoint/get-whale-trades) with filters or open the [SSE stream](/api-reference/endpoint/get-stream).
 
 ## Post the alert
 
@@ -69,7 +69,7 @@ def post_alert(tr):
     requests.post(os.environ["SLACK_WEBHOOK_URL"], json={"text": msg})
 ```
 
-## Which to choose
+## Choose a delivery method
 
 | | Webhook push | Polling |
 |---|---|---|
@@ -78,4 +78,4 @@ def post_alert(tr):
 | Missed events on downtime | Retried up to 8 times | Caught up via cursor |
 | Filtering | After receipt | Query params (whale-trades) |
 
-Webhooks win when you have a server and want the lowest latency. Polling the cursor feed wins for a script, a notebook, or anything behind NAT.
+Use webhooks for low latency with a public server. Use the cursor feed for scripts, notebooks, and private networks.

--- a/recipes/backtest.mdx
+++ b/recipes/backtest.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Backtest a trader"
-description: "Pull a wallet's historical P&L series and fill history to evaluate it before you follow."
+description: "Compare a wallet's P&L series with its historical fills."
 ---
 
-Goal: judge a trader on history, not vibes. This recipe pulls a wallet's P&L time series and its historical fills so you can reconstruct how it actually performed.
+Use this recipe to compare a trader's historical returns with its fills.
 
 All requests need a Bearer key. See [Authentication](/authentication).
 
 ## 1. The P&L series
 
-[`GET /api/v1/trader/{address}/pnl`](/api-reference/endpoint/get-trader-pnl) returns the daily series plus rolled-up stats and drawdowns:
+[`GET /api/v1/trader/{address}/pnl`](/api-reference/endpoint/get-trader-pnl) returns a daily series, summary stats, and drawdowns:
 
 ```python
 import os, requests
@@ -27,11 +27,11 @@ for entry in pnl["entries"][-10:]:
     print(entry["date"], entry["cumulative_profit"], entry["daily_change"])
 ```
 
-`entries` is the daily series (`date`, `total_pnl`, `cumulative_profit`, `daily_change`, `markets_traded`, `total_volume`). `monthly`, `year_totals`, and `drawdown` give you the longer view. `stats` is pre-rolled for `all`, `d90`, `d30`, and `d7` windows.
+`entries` is the daily series. `monthly`, `year_totals`, and `drawdown` give longer views. `stats` includes `all`, `d90`, `d30`, and `d7` windows.
 
 ## 2. The fill history
 
-For the trades behind the curve, replay this wallet's historical whale trades over a date range with [`GET /api/v1/whale-trades/history`](/api-reference/endpoint/get-whale-trades-history). It accepts a `trader` filter and a `from`/`to` window:
+To inspect the fills behind the curve, query [`GET /api/v1/whale-trades/history`](/api-reference/endpoint/get-whale-trades-history) with `trader`, `from`, and `to`:
 
 ```python
 fills = requests.get(
@@ -49,11 +49,11 @@ for tr in fills["data"]:
     print(tr["traded_at"], tr["side"], tr["size_usd"], "@", tr["price"], tr["market"]["title"])
 ```
 
-Page through with the cursor (see [Pagination](/concepts/pagination)) to pull the full window.
+Use the cursor to read the full range. See [Pagination](/concepts/pagination).
 
 ## 3. Per-market entries and exits
 
-To reconstruct cost basis on a single market, use the [position timeline](/api-reference/endpoint/get-trader-position-timeline) with a `condition_id`. It gives ordered buys and sells with the running average price:
+For one market, use [position timeline](/api-reference/endpoint/get-trader-position-timeline) with a `condition_id`:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -62,7 +62,7 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
 
 ## Scope and limits
 
-- The whale-trade history covers fills above the whale threshold. Small trades below it are not in this feed; use the aggregated P&L series for the complete return picture.
-- There is no single "closed positions" list endpoint. Reconstruct closed lots from the per-market timelines, or rely on the `pnl` series for net performance.
-- [`/trader/{address}/export`](/api-reference/endpoint/get-trader-export-snapshot) returns export metadata (ranges, counts, completeness), not raw rows.
+- Whale-trade history includes fills above the whale threshold. Use the P&L series for the full return view.
+- There is no closed-positions list. Use per-market timelines or the P&L series.
+- [`/trader/{address}/export`](/api-reference/endpoint/get-trader-export-snapshot) returns export metadata, not raw rows.
 - Backtest history is Polymarket-only; see [Platforms](/concepts/platforms).

--- a/recipes/copy-trade.mdx
+++ b/recipes/copy-trade.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Copy-trade signals"
-description: "Build a follow list of top traders, then watch for their new activity."
+description: "Build a follow list and watch for new trades from those wallets."
 ---
 
-Goal: pick the best wallets, then get notified when they make a move. This recipe builds a follow list from the leaderboard and watches the whale-trade feed for activity from anyone on it.
+Use this recipe when you want to follow a set of high-grade wallets. It builds a list, enriches it, then watches new trades.
 
 All requests need a Bearer key. See [Authentication](/authentication).
 
 ## 1. Build the follow list
 
-Pull the leaderboard and keep the top grades. The leaderboard ranks S, A, and B already; filter to S and A in code (there is no `min_grade` param on this endpoint).
+Read the leaderboard and keep S and A traders. The endpoint has no `min_grade` filter, so filter the result in code.
 
 ```python
 import os, requests
@@ -21,7 +21,7 @@ leaders = requests.get(f"{BASE}/leaderboard", params={"limit": 100}, headers=H).
 follow = [t["address"] for t in leaders["data"] if t["grade"] in ("S", "A")]
 ```
 
-Narrow by style if you want to copy one approach. Pass `strategy` to rank a single [strategy type](/concepts/strategy-types):
+To follow one style, pass `strategy` with a [strategy type](/concepts/strategy-types):
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -30,7 +30,7 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
 
 ## 2. Enrich the list
 
-Pull full profiles for the whole set in one call with [batch](/api-reference/endpoint/batch-get-traders). Add `expand` for strategy and trust if you want to weight them:
+Read the full set with [batch](/api-reference/endpoint/batch-get-traders). Add `expand` when strategy or trust affects your choice:
 
 ```python
 batch = requests.post(
@@ -47,7 +47,7 @@ for item in batch["data"]:
 
 ## 3. Watch for new activity
 
-The whale-trade feed is the live signal. Poll it filtered to high grades, then keep only trades from wallets on your follow list:
+Poll the whale-trade feed and keep only followed wallets:
 
 ```python
 follow_set = set(a.lower() for a in follow)
@@ -67,19 +67,19 @@ for tr in new_moves():
     print(f'{tr["trader"]["username"]} {tr["side"]} ${tr["size_usd"]:,.0f} @ {tr["price"]} on {tr["market"]["title"]}')
 ```
 
-For a push instead of a poll, register a webhook on `whale_trades_inserted` and apply the same follow-list filter when each event arrives. See [Webhooks](/guides/webhooks).
+For push delivery, subscribe to `whale_trades_inserted` and apply the same filter. See [Webhooks](/guides/webhooks).
 
 ## 4. Drill into one market
 
-When a followed trader enters a market you care about, read their full entry and exit history on that market with the [position timeline](/api-reference/endpoint/get-trader-position-timeline). It takes the trader and a `condition_id`:
+When a followed trader enters a market, read its entry and exit history with [position timeline](/api-reference/endpoint/get-trader-position-timeline):
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/traders/0x204f.../position-timeline?condition_id=0x123..."
 ```
 
-Each event is a buy or sell with price, notional, and the running average price.
+Each event includes side, price, notional, and running average price.
 
 ## What this recipe does not do
 
-There is no per-trader open-positions endpoint and no per-trader push channel. "Watch" means polling the whale-trade feed (or the `whale_trades_inserted` webhook) and matching addresses, plus the per-market timeline once you know the `condition_id`. Plan your loop around the feed, not around a subscription to a single wallet.
+There is no per-trader positions endpoint or push channel. Poll the whale-trade feed, use the webhook, and match wallet addresses. Use the timeline after you know the `condition_id`.

--- a/recipes/insider-scanner.mdx
+++ b/recipes/insider-scanner.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Insider scanner"
-description: "Surface suspicious early activity, then confirm it with trader and market context."
+description: "Review unusual timing with trader and market context."
 ---
 
-Goal: catch wallets that look like they knew something, fresh wallets taking large, well-timed positions right before a move. The [insider radar](/api-reference/endpoint/get-insider-radar) does the detection; this recipe drills into each flag for context.
+Use this recipe to review unusual timing and large positions. The [insider radar](/api-reference/endpoint/get-insider-radar) finds leads; the next calls add context.
 
 All requests need a Bearer key. See [Authentication](/authentication). Insider radar is Polymarket-only; see [Platforms](/concepts/platforms).
 
 ## 1. Pull the flags
 
-Each flag has a `suspicion_score` and a `severity` of `flag` or `watch` (`watch` is the higher-conviction tier). Filter to the strong ones:
+Each flag has a `suspicion_score` and a `severity` of `flag` or `watch`. `watch` is the higher-conviction tier:
 
 ```python
 import os, requests
@@ -29,11 +29,11 @@ for f in flags["data"]:
           f'timing={s["timing"]:.0f} edge={s["edge"]:.0f} size={s["size"]:.0f} fresh={s["fresh_wallet"]:.0f}')
 ```
 
-The `scores` object breaks the suspicion down into `timing`, `edge`, `size`, and `fresh_wallet` components, so you can see why a wallet was flagged.
+The `scores` object shows the `timing`, `edge`, `size`, and `fresh_wallet` components.
 
 ## 2. Open one flag
 
-Fetch the full flag for its evidence and the linked trader and market:
+Read one flag and its linked trader and market:
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
@@ -42,7 +42,7 @@ curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
 
 ## 3. Confirm with context
 
-A flag is a lead. Confirm it with two reads:
+A flag is a lead, not proof. Confirm it with trader and market reads:
 
 ```python
 flag = flags["data"][0]
@@ -56,15 +56,15 @@ print("trader grade:", trader["grade"], "| markets traded:", trader["stats"]["ma
 print("smart money net flow:", intel["smart_money"]["net_flow_usd"], intel["smart_money"]["direction"])
 ```
 
-A fresh wallet with a high `size` score, taking the same side smart money is leaning, is the pattern worth a closer look.
+A fresh wallet with a high `size` score and the same side as smart money deserves review.
 
 ## 4. Cross-check size
 
-Confirm the position is large in absolute terms with [large positions](/api-reference/endpoint/list-large-positions), filtered to the same market:
+Check absolute size with [large positions](/api-reference/endpoint/list-large-positions):
 
 ```bash
 curl -H "Authorization: Bearer $OXINSIDER_API_KEY" \
   "https://api.0xinsider.com/api/v1/large-positions?condition_id=0x123...&min_size=25000"
 ```
 
-`Position.trader.is_new_wallet` and `wallet_age_days` are the fresh-wallet signals to confirm the radar's `fresh_wallet` score independently.
+Use `Position.trader.is_new_wallet` and `wallet_age_days` to cross-check `fresh_wallet`.

--- a/recipes/portfolio-tracker.mdx
+++ b/recipes/portfolio-tracker.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Portfolio tracker"
-description: "Track a set of wallets' P&L and current positions on one dashboard."
+description: "Track selected wallets, P&L, and current positions."
 ---
 
-Goal: keep a dashboard of the wallets you care about, their aggregate P&L and their live positions. This recipe uses the batch endpoint for the numbers and the positions board for current holdings.
+Use this recipe for a dashboard of selected wallets, their P&L, and their current positions.
 
 All requests need a Bearer key. See [Authentication](/authentication).
 
 ## 1. Aggregate P&L in one call
 
-[`POST /api/v1/traders/batch`](/api-reference/endpoint/batch-get-traders) takes up to 25 wallets (by address or `trd_` id) and returns a full profile for each. This is the clean path for portfolio totals:
+[`POST /api/v1/traders/batch`](/api-reference/endpoint/batch-get-traders) accepts up to 25 wallet addresses or `trd_` IDs:
 
 ```python
 import os, requests
@@ -42,11 +42,11 @@ for item in batch["data"]:
 print("portfolio P&L:", sum(b["total_pnl"] for b in book))
 ```
 
-Each item reports its own `status` (`ok` or `error`), so one bad wallet does not fail the batch. For more than 25 wallets, split into batches of 25.
+Each item has its own `status`. One bad wallet does not fail the batch. Split larger sets into groups of 25.
 
 ## 2. Current positions
 
-There is no per-trader open-positions endpoint. The [positions board](/api-reference/endpoint/get-positions) is global, filterable by grade, size, side, and category, but not by wallet, so scan it and intersect on your wallet set:
+There is no per-trader positions endpoint. The [positions board](/api-reference/endpoint/get-positions) is global, so scan it and keep your wallets:
 
 ```python
 wallet_set = set(w.lower() for w in wallets)
@@ -68,14 +68,14 @@ for p in positions_for_book():
           p["side"], f'${p["current_value_usd"]:,.0f}', p["freshness"])
 ```
 
-Check each position's `freshness` ([trust](/concepts/trust-metadata)) before you trust the value. `fresh` is live; `stale` means the provider read is past its window.
+Check each position's `freshness` ([trust](/concepts/trust-metadata)). `fresh` is within the freshness window; `stale` is past it.
 
 ## 3. Refresh cadence
 
-- Pull batch P&L on a slow loop (minutes). It is the heavier call.
-- Scan the positions board on whatever cadence your dashboard needs; it is cursor-paginated and cheap per page.
-- For a specific wallet-and-market pair, the [position timeline](/api-reference/endpoint/get-trader-position-timeline) gives exact entry and exit events.
+- Pull batch P&L every few minutes.
+- Scan the cursor-paginated positions board at the dashboard cadence.
+- Use [position timeline](/api-reference/endpoint/get-trader-position-timeline) for one wallet and market.
 
 ## Scope and limits
 
-Tracking N specific wallets means scanning the global positions board and filtering, because there is no "open positions for wallet X" endpoint. If your set is large, raise `min_size` so the board scan stays cheap and you only track meaningful positions. Aggregate P&L via batch is exact; the live position list is a board intersection.
+The positions list is a board intersection, not a wallet-specific query. For a large set, raise `min_size` to reduce work. Batch P&L is aggregate data for the selected wallets.


### PR DESCRIPTION
## Summary

Rewrite the reader-facing copy across `docs.0xinsider.com` in strict Simplified Technical English.

- Shorten the home, quickstart, auth, errors, limits, concepts, integrations, guides, and recipes copy.
- Add a task and a grounded example to every endpoint page.
- Rewrite page descriptions as short task summaries and remove repeated guidance.
- Keep endpoint bindings, API fields, generated references, navigation, and changelog history unchanged. Correct examples only where the existing sample did not match the live contract.

Fixes #53
Refs #17
Refs #24

Bundle: `gh issue list --repo 0xinsider/docs.0xinsider.com --state open --limit 50 --json number,title,labels,assignees,updatedAt,url` at 2026-08-11T14:10:00Z over the docs/API-copy surface; no open sibling issue existed.

## Contract boundaries

- `api-reference/openapi.json` remains the synced API contract.
- `api-reference/objects.mdx` remains generated.
- `api-reference/openapi.json`, `docs.json`, and `changelog.mdx` remain unchanged.
- This PR does not change API behavior, schemas, auth, rate-limit behavior, providers, billing, or deployment configuration.
- Examples use environment variables and placeholder IDs where no stable fixture exists.

## Verification

- `git diff --check`
- `mint validate` passed.
- `mint openapi-check api-reference/openapi.json` passed.
- `mint broken-links` passed.
- Real local Mintlify render for the home, quickstart, guide, concept, recipe, and representative endpoint routes
- Manual diff review: all 54 endpoint pages have `## Use this endpoint when` and `## Example:`. Existing endpoint code blocks remain unchanged except the intentional Sports Edge Signals curl example, authenticated Quickstart `/usage` key check, cursor-based replay recovery, and supported Positions filter example. Generated files and navigation are unchanged.
- `mint a11y` found no MDX image or accessibility issues, but exits on the pre-existing `docs.json` color contrast configuration; no color scope is included here.
- Public metadata review followed the refetched [Google AI Optimization Guide](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide) and `docs/review/ai-search-surface-checklist.md`; no robots, JSON-LD, sitemap, or date fields changed.

## Review note

Planning review ran on 2026-08-11. Claude was unavailable because its weekly quota was exhausted. Kimi was unavailable because its billing-cycle quota was exhausted. Codex Luna exact-head reviews covered the full copy baseline and each later fix delta. All actionable findings were fixed. The final P2 disposition is recorded in the PR comments with source evidence: delivery failures set `status=disabled` without `disabled_at`, while list/get filter only `disabled_at`; deletion sets `disabled_at`.

## Production

Docs-only changes deploy through the normal merged-branch workflow. Local files do not prove production deployment. After merge, read the exact merged SHA and the live docs page before closing #53.
